### PR TITLE
East Robes fix

### DIFF
--- a/code/modules/clothing/rogueclothes/armor/unique.dm
+++ b/code/modules/clothing/rogueclothes/armor/unique.dm
@@ -22,7 +22,8 @@
 	break_sound = 'sound/foley/cloth_rip.ogg'
 	drop_sound = 'sound/foley/dropsound/cloth_drop.ogg'
 	body_parts_covered = COVERAGE_ALL_BUT_HANDFEET
-	armor = ARMOR_MAILLE
+	armor = ARMOR_PADDED
+	max_integrity = ARMOR_INT_CHEST_LIGHT_MEDIUM
 	blocksound = SOFTHIT
 	sewrepair = TRUE
 	nodismemsleeves = TRUE


### PR DESCRIPTION
ARMOR_PADDED for eastrobes

## About The Pull Request

Kazengunese robes now share the same stats as a regular gambeson. You can still upgrade it into a padded gambeson.

## Testing Evidence

Nah.

## Why It's Good For The Game

These classes normally don't have maille and you should not be getting maille for being Kazengunese on top of your best-in-class sabre.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Kazengunese dobo robes were incorrectly using ARMOR_MAILLE. They now use ARMOR_PADDED.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
