### PR TITLE
[TM Only] GNOLL_SCALING_SINGLE

### DIFF
--- a/code/datums/migrants/migrant_wave.dm
+++ b/code/datums/migrants/migrant_wave.dm
@@ -126,6 +126,4 @@
 	required_roles = list(
 		/datum/migrant_role/gnoll = 1,
 	)
-	optional_roles = list(
-		/datum/migrant_role/gnoll = 3,
-	)
+	optional_roles = list()

--- a/code/datums/migrants/migrant_wave.dm
+++ b/code/datums/migrants/migrant_wave.dm
@@ -126,4 +126,6 @@
 	required_roles = list(
 		/datum/migrant_role/gnoll = 1,
 	)
-	optional_roles = list()
+	optional_roles = list(
+		/datum/migrant_role/gnoll = 3,
+	)

--- a/code/datums/storytellers/presets.dm
+++ b/code/datums/storytellers/presets.dm
@@ -88,7 +88,7 @@
 /datum/storyteller/gamemode/guaranteed_antag
 	name = "High Intensity"
 	vote_desc = "Guaranteed hard antagonist. Some soft antagonists remain."
-	desc = "Guaranteed roundstart hard antag. Wretches up to 9. Gnolls max 2. Hag present. Dreamwalker may roll."
+	desc = "Guaranteed roundstart hard antag. Wretches up to 9. Gnolls max 1. Hag present. Dreamwalker may roll."
 	welcome_text = "A cold dread settles over the town.."
 	color_theme = "#a43c3c"
 	preset_pool = GAMEMODE_POOL_GUARANTEED

--- a/code/datums/storytellers/presets.dm
+++ b/code/datums/storytellers/presets.dm
@@ -60,7 +60,7 @@
 	guaranteed_hard = FALSE
 	guarantees_roundstart_roleset = FALSE
 	roundstart_prob = 0
-	preferred_gnoll_mode = GNOLL_SCALING_SINGLE	// max 1
+	preferred_gnoll_mode = GNOLL_SCALING_SINGLE
 	wretch_slot_cap = 12
 
 	starting_point_multipliers = list(
@@ -88,7 +88,7 @@
 /datum/storyteller/gamemode/guaranteed_antag
 	name = "High Intensity"
 	vote_desc = "Guaranteed hard antagonist. Some soft antagonists remain."
-	desc = "Guaranteed roundstart hard antag. Wretches up to 9. Gnolls max 1. Hag present. Dreamwalker may roll."
+	desc = "Guaranteed roundstart hard antag. Wretches up to 9. Gnolls max 2. Hag present. Dreamwalker may roll."
 	welcome_text = "A cold dread settles over the town.."
 	color_theme = "#a43c3c"
 	preset_pool = GAMEMODE_POOL_GUARANTEED
@@ -98,7 +98,7 @@
 	block_hard = FALSE
 	block_soft = FALSE
 	allow_dreamwalker = TRUE
-	preferred_gnoll_mode = GNOLL_SCALING_SINGLE	// max 1
+	preferred_gnoll_mode = pick(GNOLL_SCALING_SINGLE, GNOLL_SCALING_FLAT)	// Let it ride
 	wretch_slot_cap = 9
 
 /datum/storyteller/gamemode/guaranteed_antag/low_wretch
@@ -118,14 +118,14 @@
 /datum/storyteller/gamemode/no_antag	// DEFAULT
 	name = "Standard Intensity"
 	vote_desc = "No hard antagonists. Soft antagonists scale reasonably."
-	desc = "No hard antags. Wretches scale normally (5 -> 12). Gnolls max 1. Hag present. Dreamwalker may roll."
+	desc = "No hard antags. Wretches scale normally (5 -> 12). Gnolls max 2. Hag present. Dreamwalker may roll."
 	welcome_text = "The warmth of daelight rouses you from your slumber.."
 	color_theme = "#2b8c87"
 	preset_pool = GAMEMODE_POOL_NOANTAG
 	block_hard = TRUE
 	block_soft = FALSE
 	allow_dreamwalker = TRUE
-	preferred_gnoll_mode = GNOLL_SCALING_SINGLE	// max 1
+	preferred_gnoll_mode = pick(GNOLL_SCALING_SINGLE, GNOLL_SCALING_FLAT)	// Let it ride
 	wretch_slot_cap = 12
 	roundstart_prob = 50
 	guarantees_roundstart_roleset = FALSE

--- a/code/datums/storytellers/presets.dm
+++ b/code/datums/storytellers/presets.dm
@@ -60,7 +60,7 @@
 	guaranteed_hard = FALSE
 	guarantees_roundstart_roleset = FALSE
 	roundstart_prob = 0
-	preferred_gnoll_mode = GNOLL_SCALING_DYNAMIC	// max 3
+	preferred_gnoll_mode = GNOLL_SCALING_SINGLE	// max 1
 	wretch_slot_cap = 12
 
 	starting_point_multipliers = list(
@@ -98,7 +98,7 @@
 	block_hard = FALSE
 	block_soft = FALSE
 	allow_dreamwalker = TRUE
-	preferred_gnoll_mode = GNOLL_SCALING_FLAT	// max 2
+	preferred_gnoll_mode = GNOLL_SCALING_SINGLE	// max 1
 	wretch_slot_cap = 9
 
 /datum/storyteller/gamemode/guaranteed_antag/low_wretch
@@ -118,14 +118,14 @@
 /datum/storyteller/gamemode/no_antag	// DEFAULT
 	name = "Standard Intensity"
 	vote_desc = "No hard antagonists. Soft antagonists scale reasonably."
-	desc = "No hard antags. Wretches scale normally (5 -> 12). Gnolls max 3. Hag present. Dreamwalker may roll."
+	desc = "No hard antags. Wretches scale normally (5 -> 12). Gnolls max 1. Hag present. Dreamwalker may roll."
 	welcome_text = "The warmth of daelight rouses you from your slumber.."
 	color_theme = "#2b8c87"
 	preset_pool = GAMEMODE_POOL_NOANTAG
 	block_hard = TRUE
 	block_soft = FALSE
 	allow_dreamwalker = TRUE
-	preferred_gnoll_mode = GNOLL_SCALING_DYNAMIC	// max 3
+	preferred_gnoll_mode = GNOLL_SCALING_SINGLE	// max 1
 	wretch_slot_cap = 12
 	roundstart_prob = 50
 	guarantees_roundstart_roleset = FALSE


### PR DESCRIPTION


## About The Pull Request

Gnolls are capped to 1 open slot on all gamemodes. A second slot may randomly be added to the high intensity vote for the round.

#7752 handles migrant waves.

This is a temporary merge while Gnoll is reconsidered by other developers.

## Testing Evidence

<img width="462" height="131" alt="image" src="https://github.com/user-attachments/assets/d7e2f545-a0a4-4d5d-9c74-719940d35b07" />

## Why It's Good For The Game

There's a lot of `something should be done about gnoll`. I think people are generally in agreement that it's not a great situation and there's some fatigue setting in over the topic.

As to not bury them in obscurity, instead gnolls will remain a mostly single slot role like Hag (and Assassin, usually).

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
config: Gnoll has been set to single scaling. If you see this in the changelog, this became a permanent solution.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
