### PR TITLE
Adds more grain to bait and feed options + craftable zigbox

### DIFF
--- a/code/modules/mob/living/simple_animal/rogue/farm/chicken.dm
+++ b/code/modules/mob/living/simple_animal/rogue/farm/chicken.dm
@@ -34,7 +34,7 @@
 		/obj/item/alch/viscera = 1
 		)
 	var/egg_type = /obj/item/reagent_containers/food/snacks/rogue/egg
-	food_type = list(/obj/item/reagent_containers/food/snacks/grown/berries/rogue,/obj/item/natural/worms,/obj/item/reagent_containers/food/snacks/grown/wheat,/obj/item/reagent_containers/food/snacks/grown/oat)
+	food_type = list(/obj/item/reagent_containers/food/snacks/grown/berries/rogue,/obj/item/natural/worms,/obj/item/reagent_containers/food/snacks/grown/wheat,/obj/item/reagent_containers/food/snacks/grown/oat,/obj/item/reagent_containers/food/snacks/grown/rice)
 	response_help_continuous = "pets"
 	response_help_simple = "pet"
 	response_disarm_continuous = "gently pushes aside"

--- a/code/modules/mob/living/simple_animal/rogue/farm/cow.dm
+++ b/code/modules/mob/living/simple_animal/rogue/farm/cow.dm
@@ -25,7 +25,7 @@
 	base_intents = list(/datum/intent/simple/headbutt)
 	health = 80
 	maxHealth = 80
-	food_type = list(/obj/item/reagent_containers/food/snacks/grown/wheat,/obj/item/reagent_containers/food/snacks/grown/oat)
+	food_type = list(/obj/item/reagent_containers/food/snacks/grown/wheat,/obj/item/reagent_containers/food/snacks/grown/oat,/obj/item/reagent_containers/food/snacks/grown/maize)
 	tame_chance = 25
 	bonus_tame_chance = 15
 	footstep_type = FOOTSTEP_MOB_SHOE

--- a/code/modules/mob/living/simple_animal/rogue/farm/fogbeast.dm
+++ b/code/modules/mob/living/simple_animal/rogue/farm/fogbeast.dm
@@ -25,7 +25,7 @@ GLOBAL_LIST_INIT(valid_fogbeast_colors, list("White" = COLOR_WHITE, "Gray" = COL
 	animal_species = /mob/living/simple_animal/hostile/retaliate/rogue/fogbeast/male
 	health = 380
 	maxHealth = 380
-	food_type = list(/obj/item/reagent_containers/food/snacks/grown/wheat, /obj/item/reagent_containers/food/snacks/grown/oat, /obj/item/reagent_containers/food/snacks/grown/apple)
+	food_type = list(/obj/item/reagent_containers/food/snacks/grown/wheat, /obj/item/reagent_containers/food/snacks/grown/oat, /obj/item/reagent_containers/food/snacks/grown/apple,/obj/item/reagent_containers/food/snacks/grown/maize)
 	tame_chance = 15
 	bonus_tame_chance = 15
 	footstep_type = FOOTSTEP_MOB_SHOE

--- a/code/modules/mob/living/simple_animal/rogue/farm/hog.dm
+++ b/code/modules/mob/living/simple_animal/rogue/farm/hog.dm
@@ -44,7 +44,7 @@
 
 	health = 140
 	maxHealth = 140
-	food_type = list(/obj/item/reagent_containers/food/snacks/grown/oat,/obj/item/reagent_containers/food/snacks/grown/potato/rogue,/obj/item/reagent_containers/food/snacks/rogue/meat)//Omnivores / Give me your öats bröther for I am starving.
+	food_type = list(/obj/item/reagent_containers/food/snacks/grown/wheat,/obj/item/reagent_containers/food/snacks/grown/oat,/obj/item/reagent_containers/food/snacks/grown/potato/rogue,/obj/item/reagent_containers/food/snacks/rogue/meat)//Omnivores / Give me your öats bröther for I am starving.
 	tame_chance = 25
 	bonus_tame_chance = 15
 	footstep_type = FOOTSTEP_MOB_SHOE
@@ -197,7 +197,7 @@
 	environment_smash = ENVIRONMENT_SMASH_NONE
 	retreat_distance = 0
 	minimum_distance = 0
-	food_type = list(/obj/item/reagent_containers/food/snacks/grown/oat,/obj/item/reagent_containers/food/snacks/grown/potato/rogue,/obj/item/reagent_containers/food/snacks/rogue/meat)//Omnivores / Give me your öats bröther for I am starving.
+	food_type = list(/obj/item/reagent_containers/food/snacks/grown/wheat,/obj/item/reagent_containers/food/snacks/grown/oat,/obj/item/reagent_containers/food/snacks/grown/potato/rogue,/obj/item/reagent_containers/food/snacks/rogue/meat)//Omnivores / Give me your öats bröther for I am starving.
 	footstep_type = FOOTSTEP_MOB_SHOE
 	pooptype = /obj/item/natural/poo/horse
 	STACON = 15

--- a/code/modules/mob/living/simple_animal/rogue/game/saiga.dm
+++ b/code/modules/mob/living/simple_animal/rogue/game/saiga.dm
@@ -46,6 +46,7 @@
 				/obj/item/reagent_containers/food/snacks/grown/wheat,
 				/obj/item/reagent_containers/food/snacks/grown/oat,
 				/obj/item/reagent_containers/food/snacks/grown/apple,
+				/obj/item/reagent_containers/food/snacks/grown/maize
 				)
 	tame_chance = 25
 	bonus_tame_chance = 15

--- a/code/modules/roguetown/roguecrafting/hunting.dm
+++ b/code/modules/roguetown/roguecrafting/hunting.dm
@@ -5,8 +5,28 @@
 	// I don't want people to use this to substitute actual hunting
 	xp_modifier = 0.1
 
+/datum/crafting_recipe/roguetown/hunting/baito
+	name = "bait (oats)"
+	result = /obj/item/bait
+	reqs = list(
+		/obj/item/storage/roguebag = 1,
+		/obj/item/reagent_containers/food/snacks/grown/oat = 2,
+		)
+	subtype_reqs = TRUE
+	craftdiff = 2
+
+/datum/crafting_recipe/roguetown/hunting/baitr
+	name = "bait (rice)"
+	result = /obj/item/bait
+	reqs = list(
+		/obj/item/storage/roguebag = 1,
+		/obj/item/reagent_containers/food/snacks/grown/rice = 2,
+		)
+	subtype_reqs = TRUE
+	craftdiff = 2
+
 /datum/crafting_recipe/roguetown/hunting/bait
-	name = "bait"
+	name = "bait (wheat)"
 	result = /obj/item/bait
 	reqs = list(
 		/obj/item/storage/roguebag = 1,

--- a/code/modules/roguetown/roguecrafting/items.dm
+++ b/code/modules/roguetown/roguecrafting/items.dm
@@ -209,7 +209,7 @@
 /datum/crafting_recipe/roguetown/survival/zigbox
 	name = "zigbox"
 	result = /obj/item/storage/belt/rogue/pouch/zigarrete
-	reqs = /obj/item/paper/scroll = 2
+	reqs = list(/obj/item/paper/scroll = 2)
 	req_table = TRUE
 	craftdiff = 2
 

--- a/code/modules/roguetown/roguecrafting/items.dm
+++ b/code/modules/roguetown/roguecrafting/items.dm
@@ -206,6 +206,13 @@
 	structurecraft = /obj/machinery/tanningrack
 	craftdiff = 1
 
+/datum/crafting_recipe/roguetown/survival/zigbox
+	name = "zigbox"
+	result = /obj/item/storage/belt/rogue/pouch/zigarrete
+	reqs = /obj/item/paper/scroll = 2
+	req_table = TRUE
+	craftdiff = 2
+
 /datum/crafting_recipe/roguetown/survival/prosthetic/woodleftarm
 	name = "wood arm (L)"
 	result = list(/obj/item/bodypart/l_arm/prosthetic/woodleft)


### PR DESCRIPTION
## About The Pull Request

* Makes bait craftable by oats and rice, expanding variety for soilson to work on outside of just wheat
* Chickens now also consume rice grain as feed
* Cows, fogbeasts, and saigas now consume maize/corn as feed (In case you ever want to spoil them I suppose)
* Pigs can also consume wheat grain, as they do in real life.
* Empty zigboxes can be crafted with Apprentice crafting and 2 scrolls with a table. 
  * Had the thought to make it 3 scrolls and tallow but that was probably too high for base price of 5 at the bathhouse.
  * Alternatively, make crafting zigbox requires tallow, but makes it craft 3 at once, so this is more a soilson/homesteader way of home-making and selling/transporting zigs? I don't think it's a problem to let everyone have empty boxes for zig though.

## Testing Evidence

<img width="1003" height="315" alt="ภาพ" src="https://github.com/user-attachments/assets/80ec7efb-85f9-45ce-8af2-2a848bb7e298" />

## Why It's Good For The Game

Just a general QoL for Soilsons and Homesteaders, this shouldn't really impact anything but I have seen people requested these little variety changes over discord. If they so wish, they could have a rice-only farm filled with chicken if they want, or a corn-cow factory.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Adds craftable zigboxes.
add: Allows oat and rice grain to be made into grain bait.
add: Chickens now also eat rice.
add: Cows, fogbeasts, and saigas now also eat corn.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
