### PR TITLE
Adds Quarterstaffs and Empty Surgeon Bag to Silverfaces

### DIFF
--- a/code/modules/cargo/packsrogue/merchant/tools.dm
+++ b/code/modules/cargo/packsrogue/merchant/tools.dm
@@ -88,6 +88,11 @@
 	cost = 80
 	contains = list(/obj/item/storage/belt/rogue/surgery_bag)
 
+/datum/supply_pack/rogue/tools/surgeonsbagempty
+	name = "Surgeon's bag, Empty"
+	cost = 15
+	contains = list(/obj/item/storage/belt/rogue/surgery_bag/empty)
+
 /datum/supply_pack/rogue/tools/soapps
 	name = "Soap"
 	cost = 10

--- a/code/modules/cargo/packsrogue/merchant/weapons/merch_weapons_melee_iron.dm
+++ b/code/modules/cargo/packsrogue/merchant/weapons/merch_weapons_melee_iron.dm
@@ -139,6 +139,11 @@
 	cost = 40 // 2 Iron Ingot
 	contains = list(/obj/item/rogueweapon/mace/goden)
 
+/datum/supply_pack/rogue/iron_weapons/quarterstaff
+	name = "Quarterstaff"
+	cost = 30 // 1 Iron Ingot, 1 Small Log
+	contains = list(/obj/item/rogueweapon/woodstaff/quarterstaff/iron)
+
 /datum/supply_pack/rogue/iron_weapons/maul
 	name = "Maul"
 	cost = 40 // 2 Iron Ingot
@@ -161,7 +166,7 @@
 
 /datum/supply_pack/rogue/iron_weapons/ironshield
 	name = "Shield, Iron"
-	cost = 40 // 2 iron 
+	cost = 40 // 2 iron
 	contains = list(/obj/item/rogueweapon/shield/iron)
 
 /datum/supply_pack/rogue/iron_weapons/towershield

--- a/code/modules/cargo/packsrogue/merchant/weapons/merch_weapons_melee_steel.dm
+++ b/code/modules/cargo/packsrogue/merchant/weapons/merch_weapons_melee_steel.dm
@@ -195,6 +195,11 @@
 	cost = 105 // 3 Steel Ingot
 	contains = list(/obj/item/rogueweapon/mace/maul/grand)
 
+/datum/supply_pack/rogue/steel_weapons/quarterstaff
+	name = "Quarterstaff"
+	cost = 45 // 1 Steel Ingot, 1 Small Log
+	contains = list(/obj/item/rogueweapon/woodstaff/quarterstaff/steel)
+
 /datum/supply_pack/rogue/steel_weapons/partizan
 	name = "Partizan"
 	cost = 80 // 2 Steel Ingot, 1 Small Log. Slight increase cuz gated behind skill 4


### PR DESCRIPTION
## About The Pull Request

* QoL mostly, adds iron and steel quarterstaff to silverfaces as well as an empty surgeon bag.

## Testing Evidence

<img width="803" height="607" alt="ภาพ" src="https://github.com/user-attachments/assets/33549426-4518-45fb-a4c4-521d01316385" />

## Why It's Good For The Game

* Quarterstaff as of current can only be crafted using carpentry + staff and ingot, which... is very inconvenient, requiring you to find a carpenter which isn't always present, or level up carpentry yourself. Adding them to Silverface following the pricing rules lets them be more accessible with enough coin. Doing it manually is still going to be cheaper, though.
* Also a QoL, people have been asking for surgeon bag in silverface so that they can put their own improvised tools in them instead of having to buy the costly one. I don't know if 15 is too much, but I reference it from buying empty quiver.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Adds quarterstaffs to Smithy's Silverface.
add: Adds empty surgeon bag to Silverface.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
