### PR TITLE
[FIX] Gem Bracelets Now Cover Arms.

### DIFF
--- a/code/modules/clothing/rogueclothes/wrists.dm
+++ b/code/modules/clothing/rogueclothes/wrists.dm
@@ -343,6 +343,7 @@
 /obj/item/clothing/wrists/roguetown/gem
 	name = "gem bracelet base"
 	desc = "You shouldn't be seeing this."
+	body_parts_covered = ARMS
 	slot_flags = ITEM_SLOT_WRISTS
 	armor = ARMOR_PLATE
 	max_integrity = ARMOR_INT_SIDE_CLOTH


### PR DESCRIPTION
## About The Pull Request

* Fixes oversight where gem bracers have armor but no covering attributed to it.

## Testing Evidence

<img width="601" height="350" alt="ภาพ" src="https://github.com/user-attachments/assets/460c404c-8e3c-4ad7-879b-87f658c530ff" />

## Why It's Good For The Game

* Bugfix

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Gembracers now covers arms, previously broken.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
