### PR TITLE
[QoL] Makes Mindlink Fading More Noticable

### DIFF
--- a/code/modules/spells/spell_types/wizard/utility/mindlink.dm
+++ b/code/modules/spells/spell_types/wizard/utility/mindlink.dm
@@ -98,8 +98,8 @@
 	if(!link)
 		return
 
-	to_chat(link.owner, span_warning("The mindlink with [link.target] fades away..."))
-	to_chat(link.target, span_warning("The mindlink with [link.owner] fades away..."))
+	to_chat(link.owner, span_notice("The mindlink with [link.target] fades away..."))
+	to_chat(link.target, span_notice("The mindlink with [link.owner] fades away..."))
 
 	GLOB.mindlinks -= link
 	qdel(link)


### PR DESCRIPTION
## About The Pull Request

* Mindlink fading is now more noticable, more in-line with other minelink span_notice over the 75% font size warning.

## Testing Evidence

<img width="630" height="240" alt="ภาพ" src="https://github.com/user-attachments/assets/74f527f3-450d-4c97-8e38-3aa8c2665925" />

## Why It's Good For The Game

* The 75% smaller font for mindlink fading in red combined with no safecheck for using ,Y means that often times you accidentally speak to nobody, since the fade warning does not stand out when you are also in other conversations or doing work/mechanics/combat.
* I don't know if 'missing the link-break' is supposed to be intentional, but this is a minor QoL changes that will benefit people who is hard of reading, color distinguishing (especially colorblindness), and smaller text font (due to more odd screen ratio or otherwise).

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
qol: Mindlink fading is now more noticable.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
