### PR TITLE
Fixes sheaths but removes a redundant line

### DIFF
--- a/code/game/objects/items/holster_component.dm
+++ b/code/game/objects/items/holster_component.dm
@@ -137,9 +137,10 @@
 	if(!move_after(user, sheathe_time, target = user))
 		return FALSE
 
-	sheathed.forceMove(user.loc)
-	sheathed.pickup(user)
-	user.put_in_hands(sheathed)
+	// store the reference somewhere in case sheathed gets nulled.
+	var/obj/item/rogueweapon/drawn = sheathed
+	drawn.pickup(user)
+	user.put_in_hands(drawn)
 	sheathed = null
 	update_icon(user)
 


### PR DESCRIPTION
## About The Pull Request

I was also looking at the same issue. This is the same fix as bear except it removes a redundant line.

## Testing Evidence

https://cdn.discordapp.com/attachments/1287370680115138642/1536048791973658634/reference.mp4?ex=6a79fc6a&is=6a78aaea&hm=e56ee3c938b669cafd33fce09b1e340bed2f3d21f2d7b126896223ab42a7bdb3&

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
Bug bad 

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: sheaths work correctly again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
