### PR TITLE
Adds File Garden as an allowed link to flavour texts

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -2386,7 +2386,7 @@ Slots: [job.spawn_positions] [job.round_contrib_points ? "RCP: +[job.round_contr
 					to_chat(user, "<span class='notice'>If the song doesn't  play properly, ensure that it's a direct link that opens properly in a browser.</span>")
 					to_chat(user, "<font color = '#d6d6d6'>Leave blank to clear your current song.</font>")
 					to_chat(user, "<font color ='red'>Abuse of this will get you banned.</font>")
-					var/new_extra_link = tgui_input_text(user, "Input the accessory link (https, hosts: discord, catbox):", "Song URL", ooc_extra, max_length = MAX_MESSAGE_LEN, encode = FALSE)
+					var/new_extra_link = tgui_input_text(user, "Input the accessory link (https, hosts: discord, catbox, file garden):", "Song URL", ooc_extra, max_length = MAX_MESSAGE_LEN, encode = FALSE)
 					if(isnull(new_extra_link))
 						return
 					new_extra_link = trim(new_extra_link, MAX_MESSAGE_LEN)
@@ -3314,7 +3314,7 @@ Slots: [job.spawn_positions] [job.round_contrib_points ? "RCP: +[job.round_contr
 		reset_all_customizer_accessory_colors()
 
 /proc/valid_headshot_link(mob/user, value, silent = FALSE, list/valid_extensions = list("jpg", "png", "jpeg"))
-	var/static/link_regex = regex(@"i\.gyazo.com|.\.l3n\.co|images2\.imgbox\.com|thumbs2\.imgbox\.com|files\.catbox\.moe") //gyazo, discord, lensdump, imgbox, catbox
+	var/static/link_regex = regex(@"i\.gyazo.com|.\.l3n\.co|images2\.imgbox\.com|thumbs2\.imgbox\.com|files\.catbox\.moe|file\.garden") //gyazo, discord, lensdump, imgbox, catbox, file garden
 
 	if(!length(value))
 		return FALSE
@@ -3341,7 +3341,7 @@ Slots: [job.spawn_positions] [job.round_contrib_points ? "RCP: +[job.round_contr
 	find_index = findtext(value, link_regex)
 	if(find_index != 9)
 		if(!silent)
-			to_chat(usr, "<span class='warning'>The link must be hosted on one of the following sites: 'Gyazo, Lensdump, Imgbox, Catbox'</span>")
+			to_chat(usr, "<span class='warning'>The link must be hosted on one of the following sites: 'Gyazo, Lensdump, Imgbox, Catbox, File Garden'</span>")
 		return FALSE
 	return TRUE
 


### PR DESCRIPTION
## About The Pull Request

Adds File Garden to the allowed regex for uploading media to FTs.

## Testing Evidence

<img width="767" height="416" alt="image" src="https://github.com/user-attachments/assets/4281d102-78b6-410d-8a4c-e668d4932efa" />

## Why It's Good For The Game

We already have this functionality and links "Sometimes" work. I personally only ever use Gyazo because Catbox seems to work based on the alignment of the sun and moon.

File Garden is, uh, better. But you have to make a free account so w/e.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: File Garden can be used to upload media for flavourtexts, including music/OOC extra/headshots/image galleries.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
