### PR TITLE
[Dun World] Itty-Bitty Home Sprucing

### DIFF
--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -4491,6 +4491,7 @@
 /obj/structure/roguewindow/openclose/reinforced{
 	dir = 1
 	},
+/obj/structure/curtain/green,
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
 "aTS" = (
@@ -9372,6 +9373,11 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/magician)
+"bOH" = (
+/obj/structure/roguewindow,
+/obj/structure/curtain/green,
+/turf/open/floor/rogue/blocks/newstone/alt,
+/area/rogue/indoors/town)
 "bOI" = (
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/church,
@@ -15942,6 +15948,7 @@
 /area/rogue/outdoors/woods/southeast)
 "daY" = (
 /obj/structure/roguewindow/openclose/reinforced,
+/obj/structure/curtain/green,
 /turf/open/floor/rogue/blocks/newstone/alt,
 /area/rogue/indoors/town)
 "dba" = (
@@ -57419,6 +57426,7 @@
 	},
 /obj/structure/fluff/railing/border/west,
 /obj/structure/fluff/railing/border/east,
+/obj/structure/curtain/green,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
 "kMw" = (
@@ -74193,6 +74201,7 @@
 /obj/structure/fluff/railing/border/west,
 /obj/structure/fluff/railing/border/east,
 /obj/structure/roguewindow/openclose/reinforced,
+/obj/structure/curtain/green,
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
 "nRH" = (
@@ -80960,6 +80969,7 @@
 /area/rogue/indoors/town/steward)
 "paa" = (
 /obj/structure/roguewindow/openclose/reinforced,
+/obj/structure/curtain/green,
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
 "pae" = (
@@ -107015,8 +107025,8 @@
 /obj/structure/fireaxecabinet/south{
 	pixel_x = -32
 	},
-/obj/structure/bed/rogue/inn/wool,
-/obj/item/bedsheet/rogue/fabric,
+/obj/structure/bed/rogue/inn/wooldouble,
+/obj/item/bedsheet/rogue/fabric_double,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
 "tTb" = (
@@ -109290,6 +109300,7 @@
 /obj/structure/roguewindow/openclose/reinforced{
 	dir = 1
 	},
+/obj/structure/curtain/green,
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
 "upM" = (
@@ -501613,8 +501624,8 @@ aBB
 aBB
 aBB
 afK
-lgb
-lgb
+bOH
+bOH
 afK
 kgg
 kgg


### PR DESCRIPTION
## About The Pull Request

Mimicking a few of the changes Orbis was kind enough to make for us, I added green curtains to the hut northwest of the city and the hut within the grove, and I've also replaced the single bed within the home south of the city with a double bed and bedsheet.

## Testing Evidence

### Images:

<details>
<summary>Map Editor</summary>
<img width="1295" height="987" alt="prEPRJQHZz" src="https://github.com/user-attachments/assets/93d4044d-4d16-48bc-b51b-6eac7d4c37cd" />
<img width="1002" height="1197" alt="YVTZEHEXm1" src="https://github.com/user-attachments/assets/df80a3a7-305a-4ef4-9339-1b921b9ed6b0" />
<img width="1483" height="1107" alt="Ns2RItguJW" src="https://github.com/user-attachments/assets/3fd5d3de-7ec4-4a77-8980-ebbc538bebc9" />
</details>

<details>
<summary>Live Map</summary>
<img width="1228" height="1016" alt="Ror3sH8dC4" src="https://github.com/user-attachments/assets/25cf1a5f-b47d-41ab-8b4c-a4424cf97c36" />
<img width="1117" height="840" alt="iLHtvYfGxf" src="https://github.com/user-attachments/assets/caa3a522-a099-4196-932c-751d05c4d0b9" />
<img width="1113" height="646" alt="wzl2hmO74Y" src="https://github.com/user-attachments/assets/8e8e2f59-5302-44df-b59d-114fe67dda23" />
</details>

## Why It's Good For The Game

Seeing as the huts are isolated from the rest of society, they are deserving of a little more privacy when it comes to their windows. The windows without the muntins are transparent, which is what the northern hut has on its right side, and the windows with the muntins are opaque.

Since the levies seem to often like doing this...

<img width="650" height="784" alt="dreamseeker_373MWoslxy" src="https://github.com/user-attachments/assets/8ca8c93e-02b0-46cb-9bda-a0c811ec4fcd" />

...for reasons unbeknownst to me, anyone who climbs the platforms they build can peer inside that hut, and the cauldron makes it impossible to build a curtain on the window adjacent to it without destroying it.

Lastly, the home with the single bed looks as if it could accommodate a friend or a partner, and it would be troublesome for the pair to have to destroy that bed every round to have it replaced with a double bed—even more so without skill in Carpentry and a Carpenter being absent.

## Changelog

:cl:Fi
map: [Dun World] Added green curtains to the huts for their owners' privacy and replaced the single bed and bedsheet in the home south of the city with a matching double bed and bedsheet.
/:cl: