### PR TITLE
Weapon Touch Ups - Various :)

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/alt_grip.dm
+++ b/code/game/objects/items/rogueweapons/melee/alt_grip.dm
@@ -427,7 +427,6 @@
 
 /datum/alt_grip/mordhau
 	name = "mordhau"
-	two_handed = TRUE
 
 /datum/alt_grip/mordhau/sword
 	grip_intents = list(
@@ -462,7 +461,6 @@
 	)
 	var_overrides = list(
 		"wlength" = WLENGTH_SHORT,
-		"wdefense" = 2
 	)
 
 /datum/alt_grip/mordhau/sword/frei

--- a/code/game/objects/items/rogueweapons/melee/alt_grip.dm
+++ b/code/game/objects/items/rogueweapons/melee/alt_grip.dm
@@ -462,7 +462,7 @@
 	)
 	var_overrides = list(
 		"wlength" = WLENGTH_SHORT,
-		"wdefense" = -2
+		"wdefense" = 2
 	)
 
 /datum/alt_grip/mordhau/sword/frei

--- a/code/game/objects/items/rogueweapons/melee/alt_grip.dm
+++ b/code/game/objects/items/rogueweapons/melee/alt_grip.dm
@@ -427,6 +427,7 @@
 
 /datum/alt_grip/mordhau
 	name = "mordhau"
+	two_handed = TRUE
 
 /datum/alt_grip/mordhau/sword
 	grip_intents = list(
@@ -461,6 +462,7 @@
 	)
 	var_overrides = list(
 		"wlength" = WLENGTH_SHORT,
+		"wdefense" = -2
 	)
 
 /datum/alt_grip/mordhau/sword/frei

--- a/code/game/objects/items/rogueweapons/melee/axe/axes.dm
+++ b/code/game/objects/items/rogueweapons/melee/axe/axes.dm
@@ -660,6 +660,7 @@
 	desc = "A poleaxe, fitted with a reinforced shaft and a beaked axhead of steel. It is the ultimate weapon for a well-seasoned knight, capable of \
 	humbling any foe that may assail their presence. </br>'Away with you, vile beggar!'"
 	icon_state = "steelpoleaxe"
+	special = /datum/special_intent/side_sweep
 	max_blade_int = 300
 
 /obj/item/rogueweapon/greataxe/steel/knight/attackby(obj/item/W, mob/living/user, params)

--- a/code/game/objects/items/rogueweapons/melee/axe/axes.dm
+++ b/code/game/objects/items/rogueweapons/melee/axe/axes.dm
@@ -655,7 +655,7 @@
 
 /obj/item/rogueweapon/greataxe/steel/knight
 	possible_item_intents = list(/datum/intent/axe/cut, /datum/intent/axe/chop, /datum/intent/mace/strike)
-	gripped_intents = list(/datum/intent/axe/cut/long, /datum/intent/axe/chop/long, /datum/intent/mace/strike, /datum/intent/axe/rangedthrust)
+	gripped_intents = list(/datum/intent/axe/cut/long, /datum/intent/axe/chop/long, /datum/intent/mace/strike/poleaxe, /datum/intent/spear/thrust/militia)
 	name = "poleaxe"
 	desc = "A poleaxe, fitted with a reinforced shaft and a beaked axhead of steel. It is the ultimate weapon for a well-seasoned knight, capable of \
 	humbling any foe that may assail their presence. </br>'Away with you, vile beggar!'"

--- a/code/game/objects/items/rogueweapons/melee/blunt.dm
+++ b/code/game/objects/items/rogueweapons/melee/blunt.dm
@@ -150,17 +150,7 @@
 	maxrange = 5
 
 /datum/intent/mace/strike/poleaxe
-	name = "strike"
-	blade_class = BCLASS_BLUNT
-	attack_verb = list("strikes", "hits")
-	hitsound = list('sound/combat/hits/blunt/metalblunt (1).ogg', 'sound/combat/hits/blunt/metalblunt (2).ogg', 'sound/combat/hits/blunt/metalblunt (3).ogg')
-	chargetime = 0
 	damfactor = 1.2
-	penfactor = PEN_NONE
-	swingdelay = 0
-	icon_state = "instrike"
-	item_d_type = "blunt"
-	intent_intdamage_factor = BLUNT_DEFAULT_INT_DAMAGEFACTOR
 
 //blunt objs ฅ^•ﻌ•^ฅ
 

--- a/code/game/objects/items/rogueweapons/melee/blunt.dm
+++ b/code/game/objects/items/rogueweapons/melee/blunt.dm
@@ -149,6 +149,19 @@
 	desc = "A titanic blow that delivers Strength-scaling knockback and slowdown to the target. The amount of inflicted knockback scales off your Strength, ranging from X (1 tile) to XV (5 tiles). </br>Actively drains stamina while being charged up. </br>Cannot inflict any knockback or slowdown if your Strength is below X. </br>Cannot be used consecutively more than every 5 seconds on the same target. </br>Prone targets halve the knockback distance. </br>Not fully charging the attack limits knockback to 1 tile."
 	maxrange = 5
 
+/datum/intent/mace/strike/poleaxe
+	name = "strike"
+	blade_class = BCLASS_BLUNT
+	attack_verb = list("strikes", "hits")
+	hitsound = list('sound/combat/hits/blunt/metalblunt (1).ogg', 'sound/combat/hits/blunt/metalblunt (2).ogg', 'sound/combat/hits/blunt/metalblunt (3).ogg')
+	chargetime = 0
+	damfactor = 1.2
+	penfactor = PEN_NONE
+	swingdelay = 0
+	icon_state = "instrike"
+	item_d_type = "blunt"
+	intent_intdamage_factor = BLUNT_DEFAULT_INT_DAMAGEFACTOR
+
 //blunt objs ฅ^•ﻌ•^ฅ
 
 /obj/item/rogueweapon/mace

--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -283,8 +283,8 @@
 	late fourteenth century, this noble sidearm - born from Grenzelhoftian imitations of the Otavan estoc - is proudly displayed on Azuria's official coat-of-arms."
 	icon_state = "aplongsword"
 	sheathe_icon = "aplongsword"
-	force = 18
-	force_wielded = 22
+	force = 20
+	force_wielded = 25
 	possible_item_intents = list(
 		/datum/intent/sword/thrust,
 		/datum/intent/sword/strike,

--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -283,8 +283,8 @@
 	late fourteenth century, this noble sidearm - born from Grenzelhoftian imitations of the Otavan estoc - is proudly displayed on Azuria's official coat-of-arms."
 	icon_state = "aplongsword"
 	sheathe_icon = "aplongsword"
-	force = 20
-	force_wielded = 25
+	force = 18
+	force_wielded = 22
 	possible_item_intents = list(
 		/datum/intent/sword/thrust,
 		/datum/intent/sword/strike,
@@ -674,8 +674,9 @@
 	Psydonian longswords, but it's notably lighter."
 	force = 26
 	force_wielded = 31
-	possible_item_intents = list(/datum/intent/sword/cut, /datum/intent/sword/strike)
-	gripped_intents = list(/datum/intent/sword/cut, /datum/intent/sword/strike, /datum/intent/sword/chop)
+	possible_item_intents = list(/datum/intent/sword/cut/arming, /datum/intent/sword/strike)
+	gripped_intents = list(/datum/intent/sword/cut/long, /datum/intent/sword/strike, /datum/intent/sword/chop)
+	alt_grips = list()
 	icon_state = "marlin"
 	item_state = "marlin"
 	parrysound = list('sound/combat/parry/bladed/bladedthin (1).ogg', 'sound/combat/parry/bladed/bladedthin (2).ogg', 'sound/combat/parry/bladed/bladedthin (3).ogg')

--- a/code/game/objects/items/rogueweapons/melee/swords/greatswords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords/greatswords.dm
@@ -389,7 +389,7 @@
 	inhand_x_dimension = 64
 	inhand_y_dimension = 64
 	force = 20
-	force_wielded = 25
+	force_wielded = 28
 	possible_item_intents = list(
 		/datum/intent/sword/thrust,
 		/datum/intent/sword/strike,

--- a/code/game/objects/items/rogueweapons/melee/swords/sword_intents.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords/sword_intents.dm
@@ -460,9 +460,7 @@
 /datum/intent/sword/thrust/estoc
 	name = "thrust"
 	penfactor = PEN_HEAVY	// Penetrates mail/plate at same-tier 20%. Estoc's purpose — point blank, telegraphed.
-	swingdelay_type = SWINGDELAY_PENALTY
-	damfactor = 1.3
-	swingdelay = 0.6 SECONDS
+	damfactor = 1.1
 
 /datum/intent/sword/thrust/estoc/lunge
 	name = "lunge"

--- a/code/game/objects/items/rogueweapons/melee/swords/sword_intents.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords/sword_intents.dm
@@ -460,14 +460,15 @@
 /datum/intent/sword/thrust/estoc
 	name = "thrust"
 	penfactor = PEN_HEAVY	// Penetrates mail/plate at same-tier 20%. Estoc's purpose — point blank, telegraphed.
-	damfactor = 1.1
+	damfactor = 1.2
+	swingdelay = 0.5 SECONDS
 
 /datum/intent/sword/thrust/estoc/lunge
 	name = "lunge"
 	icon_state = "inlance"
 	attack_verb = list("lunges")
 	penfactor = PEN_LIGHT	// Fast attrition thrust — light pen, no swingdelay, quick clickcd.
-	damfactor = 1.1
+	damfactor = 1.2
 	swingdelay = 0
 	clickcd = CLICK_CD_QUICK
 	reach = 2

--- a/code/game/objects/items/rogueweapons/melee/swords/sword_intents.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords/sword_intents.dm
@@ -468,7 +468,7 @@
 	icon_state = "inlance"
 	attack_verb = list("lunges")
 	penfactor = PEN_LIGHT	// Fast attrition thrust — light pen, no swingdelay, quick clickcd.
-	damfactor = 1.2
+	damfactor = 1.1
 	swingdelay = 0
 	clickcd = CLICK_CD_QUICK
 	reach = 2


### PR DESCRIPTION
## About The Pull Request

Touches up on vaaaarrrious weapons, mostly ones that have been a bit left behind. The Poleaxe got touched like 4 times and then was just left there, for example, and the Shalal Sabre didn't get ANY of the updates to the Lsword despite being a sidegrade to the lsword, making a worse Lsword w/ 1 more damage. Funny! We'll see. hmu in dev balance @reachheaventhroughforce if you have any issues, comments, or concerns abt this and we can talk. 

## Testing Evidence

<img width="474" height="616" alt="image" src="https://github.com/user-attachments/assets/4bc993d3-71e4-47d3-9f38-1cd5b6cc77dc" />
<img width="1895" height="647" alt="image" src="https://github.com/user-attachments/assets/fbf46003-9743-42d8-bcd1-36a59395c3e4" />
<img width="448" height="539" alt="image" src="https://github.com/user-attachments/assets/be6276bb-ec8c-4f0f-8d6b-f3bc18f5d4ef" />



## Why It's Good For The Game

Going down the list! 

Estoc - Was left behind by the pen update and the existence of the stecher, and halfsword. At the moment, it has the same force and same intents as the stecher - which - does the same thing but better?? Otherwise, halfsword of the longsword allows you to pen 3-pips at 5 more force, as well. This is bizarre. The balance to this thing pre-pen update that made it better than spears at armorpenning was that it had 10 more pen and therefore did more damage through armor, but now they do the same thing - which means that spears have no swingdelay, pen the same, and all have 5 more damage. Funny. Instead, to make this thing a true dedicated anti-armor weapon it basically has nothing else but it can pen 3-Pip at 1 tile at a short delay but no rigid intent, now.

Poleaxe - Sort've left behind with no real purpose in terms of axe weapons / Knightly weapons, so instead I just expanded it's whole bit of versatility, making it's mace intent a bit better and it's stab intent have 2-Pen instead of one pen. I might nerf it's cut if it turns out too strong if this gets TM'd, but we'll see. 

Shalal Sabre - This was just completely unmaintained. Supposed to be a longsword sidegrade weapon but it never got the cut updates that lsword got during the pen refactor so it was just worse in all ways. Instead of having yet another Weapon But Same I decided to remove it's mordhau and halfsword (you cannot do either of these on a sabre) and give it a better cut, sort've like a Kmesser. 

## Changelog

:cl:
balance: Estoc given +3 force and had the rigid intent removed from it's swing.
balance: Poleaxe given an improved mace and stab intent + a weapon special. 
balance: Shalal Sabre Given better cut intents. 
/:cl:

