### PR TITLE
[TM] unifies flourishing + makes it appear onmob

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -74,6 +74,12 @@
 #define TURF_LAYER				1		//If you're on fire
 #define TOTAL_LAYERS			55		//KEEP THIS UP-TO-DATE OR SHIT WILL BREAK ;_;
 
+#define INHAND_FRONT		1
+#define INHAND_BEHIND		2
+
+#define ONMOB_TAG		1
+#define ONMOB_PROP		2
+
 #define BACK_CLOAK_SOUTH_LAYER		(BODY_BEHIND_LAYER+1)
 
 //Human Overlay Index Shortcuts for alternate_worn_layer, layers

--- a/code/__HELPERS/matrices.dm
+++ b/code/__HELPERS/matrices.dm
@@ -27,6 +27,28 @@
 		//doesn't have an object argument because this is "Stacking" with the animate call above
 		//3 billion% intentional
 
+/atom/proc/SpinAnimationAround(offset_x = 0, offset_y = 0, speed = 10, loops = -1, clockwise = 1, segments = 12)
+	if(!segments)
+		return
+	if(!offset_x && !offset_y)
+		return SpinAnimation(speed, loops, clockwise, segments)
+	var/segment = 360/segments
+	if(!clockwise)
+		segment = -segment
+	var/list/matrices = list()
+	for(var/i in 1 to segments)
+		var/matrix/M = matrix()
+		M.Translate(-offset_x, -offset_y)
+		M.Turn(segment*i)
+		M.Translate(offset_x, offset_y)
+		matrices += M
+
+	speed /= segments
+
+	animate(src, transform = matrices[1], time = speed, loops, flags = ANIMATION_PARALLEL)
+	for(var/i in 2 to segments)
+		animate(transform = matrices[i], time = speed)
+
 //Dumps the matrix data in format a-f
 /matrix/proc/tolist()
 	. = list()

--- a/code/game/objects/inhands_rogue.dm
+++ b/code/game/objects/inhands_rogue.dm
@@ -50,6 +50,83 @@ GLOBAL_LIST_INIT(has_behind_cache, list()) // cheaty hack to avoid repeated list
 			sig += "\ref[overlay]"
 	return sig.Join(",")
 
+/obj/item/proc/onmob_prop()
+	var/tag
+	var/list/prop
+	if(altgripped)
+		tag = "altgrip"
+		prop = getonmobprop(tag)
+	if(!prop && wielded)
+		tag = "wielded"
+		prop = getonmobprop(tag)
+	if(!prop)
+		tag = "gen"
+		prop = getonmobprop(tag)
+	return list(tag, prop)
+
+/obj/item/proc/dir_name(check_dir)
+	if(check_dir & NORTH)
+		return "north"
+	if(check_dir & SOUTH)
+		return "south"
+	if(check_dir & EAST)
+		return "east"
+	if(check_dir & WEST)
+		return "west"
+	return "south"
+
+/obj/item/proc/dir_prefix(check_dir)
+	return copytext(dir_name(check_dir), 1, 2)
+
+/obj/item/proc/inhand_index(check_dir)
+	if(!experimental_inhand)
+		return INHAND_FRONT
+	var/list/prop = onmob_prop()[ONMOB_PROP]
+	if(!prop)
+		return INHAND_FRONT
+	return prop["[dir_name(check_dir)]above"] == 1 ? INHAND_FRONT : INHAND_BEHIND
+
+/obj/item/proc/grip_offset(grip_dir = SOUTH, mirrored = FALSE)
+	if(!experimental_inhand)
+		return list(0, 0)
+	var/list/prop = onmob_prop()[ONMOB_PROP]
+	if(!prop)
+		return list(0, 0)
+
+	var/prefix = dir_prefix(grip_dir)
+	var/offset_x = prop["[prefix]x"] || 0
+	var/offset_y = prop["[prefix]y"] || 0
+
+	if(!isnull(prop["gripx"]) || !isnull(prop["gripy"]))
+		var/centre = sprite_size() * 0.5
+		var/local_x = (prop["gripx"] || 0) - centre
+		var/local_y = (prop["gripy"] || 0) - centre
+
+		var/matrix/grip = matrix()
+		switch(prop["[prefix]flip"])
+			if(NORTH, SOUTH)
+				grip.Scale(1, -1)
+			if(EAST, WEST)
+				grip.Scale(-1, 1)
+		grip.Turn(prop["[prefix]turn"] || 0)
+		grip.Scale(prop["shrink"] || 1)
+
+		offset_x += (grip.a * local_x) + (grip.b * local_y) + grip.c
+		offset_y += (grip.d * local_x) + (grip.e * local_y) + grip.f
+
+	if(mirrored)
+		offset_x = -offset_x + (mirror_fix(prop["shrink"], inhand_y_dimension > 32) || 0)
+	return list(offset_x, offset_y)
+
+/obj/item/proc/sprite_size()
+	var/static/list/sizes = list()
+	var/key = "[icon]|[icon_state]"
+	. = sizes[key]
+	if(!.)
+		var/icon/source = icon(icon, icon_state)
+		. = source.Height() || 32
+		sizes[key] = .
+
 /obj/item/proc/get_extra_onmob_index()
 	//perhaps in the future: force items like flasks to use getflaticon to get their filled states and drinking cups too. that's all
 	return

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -880,6 +880,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 
 /obj/item/proc/dropped(mob/user, silent = FALSE)
 	SHOULD_CALL_PARENT(TRUE)
+	end_spin()
 	for(var/X in actions)
 		var/datum/action/A = X
 		A.Remove(user)

--- a/code/game/objects/items/bedsheets.dm
+++ b/code/game/objects/items/bedsheets.dm
@@ -35,7 +35,7 @@ LINEN BINS
 	coverup(user)
 	add_fingerprint(user)
 
-/obj/item/bedsheet/rmb_self(mob/living/user)
+/obj/item/bedsheet/rmb_self(mob/living/user, keybind = FALSE)
 	setDir(turn(dir,180))
 	update_icon()
 	to_chat(user, span_notice("I flip [src]."))

--- a/code/game/objects/items/rogueitems/books.dm
+++ b/code/game/objects/items/rogueitems/books.dm
@@ -77,7 +77,7 @@
 	..()
 	user.update_inv_hands()
 
-/obj/item/book/rogue/rmb_self(mob/user)
+/obj/item/book/rogue/rmb_self(mob/user, keybind = FALSE)
 	attack_right(user)
 	return
 

--- a/code/game/objects/items/rogueitems/broom.dm
+++ b/code/game/objects/items/rogueitems/broom.dm
@@ -20,8 +20,9 @@
 	anvilrepair = /datum/skill/craft/carpentry
 	smeltresult = /obj/item/ash
 	resistance_flags = FLAMMABLE
+	twirly = SKILL_LEVEL_EXPERT
+	twirl_sound = 'sound/combat/sidesweep_hit.ogg'
 	var/sweeping = FALSE
-	COOLDOWN_DECLARE(twirl_cooldown) // Prevents the twirl from spamming chat.
 
 /obj/item/broom/getonmobprop(tag)
 	. = ..()
@@ -41,30 +42,10 @@
 	. = ..()
 	. += span_info("Sweeping time decreases with higher Cooking skill.")
 	. += span_info("STRONG intent will make you do a power-sweeping, targeting a 3x3 area!")
-	. += span_info("You can twirl [src] by right-clicking it in your hand while in combat mode. Doing so safely requires Expert skill; anything less risks harming yourself.")
+	. += span_info("Right-click to twirl it one-handed.")
 
-/obj/item/broom/rmb_self(mob/user)
-	. = ..()
-	SpinAnimation(4, 2)
-	if(!COOLDOWN_FINISHED(src, twirl_cooldown))
-		return
-	COOLDOWN_START(src, twirl_cooldown, 3 SECONDS)
-	// smack thineself loser nerd
-	if(user.get_skill_level(associated_skill) < SKILL_LEVEL_EXPERT && prob(40))
-		var/crit = prob(60)
-		var/critmsg = " <span class='crit'><b>Critical hit!</b> [user] is knocked out!</span>"
-		user.visible_message(span_danger("While trying to twirl [src] [user] flings it instead, hitting [user.p_themselves()] in the head![crit ? critmsg : ""]"), span_userdanger("While trying to twirl [src] you fling it instead, hitting yourself in the head![crit ? critmsg : ""]"))
-		var/mob/living/carbon/human/unfortunate_idiot = user
-		unfortunate_idiot.apply_damage(src.force, BRUTE, BODY_ZONE_PRECISE_SKULL)
-		if(crit)
-			unfortunate_idiot.flash_fullscreen("whiteflash3")
-			unfortunate_idiot.Unconscious(5 SECONDS)
-			playsound(get_turf(unfortunate_idiot), 'sound/combat/tf2crit.ogg', 100, FALSE)
-		playsound(get_turf(unfortunate_idiot), 'sound/misc/bonk.ogg', 100, FALSE)
-		user.dropItemToGround(src, TRUE)
-		return
-	user.visible_message(span_notice("[user] twirls [src] in a dramatic flourish!"), span_notice("You twirl [src] dramatically."))
-	playsound(src, 'sound/combat/sidesweep_hit.ogg', 20, FALSE)
+/obj/item/broom/twirl_fumble(mob/living/user)
+	return twirl_fumble_bonk(user)
 
 /obj/item/broom/proc/sweep_time(mob/living/user)
 	return max(40 - (user.get_skill_level(associated_skill) * 15), 5)

--- a/code/game/objects/items/rogueitems/caparison.dm
+++ b/code/game/objects/items/rogueitems/caparison.dm
@@ -40,7 +40,7 @@
 	animal.update_icon()
 	user.visible_message(span_notice("[user] fits a caparison onto [animal]."), span_notice("I fit a caparison onto [animal]."))
 
-/obj/item/caparison/rmb_self(mob/user)
+/obj/item/caparison/rmb_self(mob/user, keybind = FALSE)
 	attack_right(user)
 
 /obj/item/caparison/attack_right(mob/user)

--- a/code/game/objects/items/rogueitems/dmusicbox.dm
+++ b/code/game/objects/items/rogueitems/dmusicbox.dm
@@ -66,7 +66,7 @@
 			return
 	. = ..()
 
-/obj/item/dmusicbox/rmb_self(mob/user)
+/obj/item/dmusicbox/rmb_self(mob/user, keybind = FALSE)
 	attack_right(user)
 	return
 

--- a/code/game/objects/items/rogueweapons/melee/knives.dm
+++ b/code/game/objects/items/rogueweapons/melee/knives.dm
@@ -144,6 +144,8 @@
 	max_integrity = 175
 	swingsound = list('sound/combat/wooshes/bladed/wooshsmall (1).ogg','sound/combat/wooshes/bladed/wooshsmall (2).ogg','sound/combat/wooshes/bladed/wooshsmall (3).ogg')
 	associated_skill = /datum/skill/combat/knives
+	twirly = SKILL_LEVEL_JOURNEYMAN
+	twirl_verb = "flip"
 	pickup_sound = 'sound/foley/equip/swordsmall2.ogg'
 	throwforce = 12
 	wdefense = 3
@@ -160,8 +162,6 @@
 	inv_storage_delay = 1 SECONDS
 	edelay_type = 1
 
-	//flipping knives has a cooldown on to_chat to reduce chatspam
-	COOLDOWN_DECLARE(flip_cooldown)
 
 /obj/item/rogueweapon/huntingknife/Initialize(mapload)
 	..()
@@ -183,41 +183,12 @@
 			if("onbelt")
 				return list("shrink" = 0.3,"sx" = -2,"sy" = -5,"nx" = 4,"ny" = -5,"wx" = 0,"wy" = -5,"ex" = 2,"ey" = -5,"nturn" = 0,"sturn" = 0,"wturn" = 0,"eturn" = 0,"nflip" = 0,"sflip" = 0,"wflip" = 0,"eflip" = 0,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0)
 
-/obj/item/rogueweapon/huntingknife/get_mechanics_examine(mob/user)
-	. = ..()
-	. += span_info("You can twirl this weapon by right-clicking it in your hand. Doing so safely requires [skill_to_string(SKILL_LEVEL_JOURNEYMAN)] skills; anything less risks harming yourself.")
-
-/obj/item/rogueweapon/huntingknife/rmb_self(mob/user)
-	. = ..()
-	if(.)
-		return
-
-	SpinAnimation(4, 2) // The spin happens regardless of the cooldown
-
-	if(!COOLDOWN_FINISHED(src, flip_cooldown))
-		return
-
-	COOLDOWN_START(src, flip_cooldown, 3 SECONDS)
-	if((user.get_skill_level(/datum/skill/combat/knives) < SKILL_LEVEL_JOURNEYMAN) && prob(40))
-		user.visible_message(
-			span_danger("While trying to flip [src] [user] drops it instead!"),
-			span_userdanger("While trying to flip [src] you drop it instead!"),
-		)
-		var/mob/living/carbon/human/unfortunate_idiot = user
-		var/dropped_knife_target = pick(
-			BODY_ZONE_PRECISE_L_FOOT,
-			BODY_ZONE_PRECISE_R_FOOT,
-			)
-		unfortunate_idiot.apply_damage(src.force, BRUTE, dropped_knife_target)
-		user.dropItemToGround(src, TRUE)
-	else
-		user.visible_message(
-			span_notice("[user] spins [src] around [user.p_their()] finger."),
-			span_notice("You spin [src] around your finger"),
-		)
-		playsound(src, 'sound/foley/equip/swordsmall1.ogg', 20, FALSE)
-
-	return
+/obj/item/rogueweapon/huntingknife/twirl_success(mob/living/user)
+	user.visible_message(
+		span_notice("[user] spins [src] around [user.p_their()] finger."),
+		span_notice("You spin [src] around your finger"),
+	)
+	playsound(src, twirl_sound, 20, FALSE)
 
 /obj/item/rogueweapon/huntingknife/copper
 	name = "copper knife"

--- a/code/game/objects/items/rogueweapons/melee/polearms/polearms.dm
+++ b/code/game/objects/items/rogueweapons/melee/polearms/polearms.dm
@@ -241,6 +241,7 @@
 	resistance_flags = FLAMMABLE
 	special = /datum/special_intent/polearm_backstep
 	twirly = SKILL_LEVEL_EXPERT // safely twirling like, a halberd, is going to be harder than a blunt staff
+	twirl_speed = 6
 
 /obj/item/rogueweapon/spear/short
 	force = 25

--- a/code/game/objects/items/rogueweapons/melee/polearms/staff.dm
+++ b/code/game/objects/items/rogueweapons/melee/polearms/staff.dm
@@ -41,6 +41,7 @@
 	anvilrepair = /datum/skill/craft/carpentry
 	resistance_flags = FLAMMABLE
 	twirly = SKILL_LEVEL_JOURNEYMAN
+	twirl_speed = 6
 
 /obj/item/rogueweapon/woodstaff/getonmobprop(tag)
 	. = ..()

--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -44,6 +44,7 @@
 	edelay_type = 1
 	special = /datum/special_intent/shin_swipe
 	twirly = SKILL_LEVEL_EXPERT // possible, but harder than staves n knives
+	twirl_speed = 6
 
 /obj/item/rogueweapon/sword/Initialize(mapload)
 	. = ..()
@@ -302,7 +303,7 @@
 		return .
 	if(tag)
 		switch(tag)
-			if("gen") return list("shrink" = 0.5, "sx" = -14, "sy" = -8, "nx" = 15, "ny" = -7, "wx" = -10, "wy" = -5, "ex" = 7, "ey" = -6, "northabove" = 0, "southabove" = 1, "eastabove" = 1, "westabove" = 0, "nturn" = -13, "sturn" = 110, "wturn" = -60, "eturn" = -30, "nflip" = 1, "sflip" = 1, "wflip" = 8, "eflip" = 1)
+			if("gen") return list("shrink" = 0.5, "sx" = -14, "sy" = -8, "nx" = 15, "ny" = -7, "wx" = -10, "wy" = -5, "ex" = 7, "ey" = -6, "northabove" = 0, "southabove" = 1, "eastabove" = 1, "westabove" = 0, "nturn" = -13, "sturn" = 110, "wturn" = -60, "eturn" = -30, "nflip" = 1, "sflip" = 1, "wflip" = 8, "eflip" = 1, "gripx" = 20, "gripy" = 20)
 			if("wielded") return list("shrink" = 0.6,"sx" = 9,"sy" = -4,"nx" = -7,"ny" = 1,"wx" = -9,"wy" = 2,"ex" = 10,"ey" = 2,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0,"nturn" = 5,"sturn" = -190,"wturn" = -170,"eturn" = -10,"nflip" = 8,"sflip" = 8,"wflip" = 1,"eflip" = 0)
 			if("onback") return list("shrink" = 0.5, "sx" = -1, "sy" = 2, "nx" = 0, "ny" = 2, "wx" = 2, "wy" = 1, "ex" = 0, "ey" = 1, "nturn" = 0, "sturn" = 0, "wturn" = 70, "eturn" = 15, "nflip" = 1, "sflip" = 1, "wflip" = 1, "eflip" = 1, "northabove" = 1, "southabove" = 0, "eastabove" = 0, "westabove" = 0)
 			if("onbelt") return list("shrink" = 0.4, "sx" = -4, "sy" = -6, "nx" = 5, "ny" = -6, "wx" = 0, "wy" = -6, "ex" = -1, "ey" = -6, "nturn" = 100, "sturn" = 156, "wturn" = 90, "eturn" = 180, "nflip" = 0, "sflip" = 0, "wflip" = 0, "eflip" = 0, "northabove" = 0, "southabove" = 1, "eastabove" = 1, "westabove" = 0)
@@ -770,7 +771,7 @@
 	max_blade_int = 363
 	smelt_bar_num = 2
 
-/obj/item/rogueweapon/sword/long/exe/cloth/rmb_self(mob/user)
+/obj/item/rogueweapon/sword/long/exe/cloth/rmb_self(mob/user, keybind = FALSE)
 	user.changeNext_move(CLICK_CD_MELEE)
 	playsound(user, "clothwipe", 100, TRUE)
 	SEND_SIGNAL(src, COMSIG_COMPONENT_CLEAN_ACT, CLEAN_STRONG)

--- a/code/game/objects/items/rogueweapons/rogueweapon.dm
+++ b/code/game/objects/items/rogueweapons/rogueweapon.dm
@@ -49,8 +49,6 @@
 	var/hoe_damage = null //the durability damage recieved for every work cycle
 	var/work_time = 3 SECONDS // the time it takes to make new soil or till soil
 
-	var/twirly // set this to a skill level to gate twirling. if it's falsy, you can't twirl the weapon. knives and staves are jman, swords are expert
-	COOLDOWN_DECLARE(twirl_cooldown) //twirling has a cooldown on to_chat to reduce chatspam
 
 /obj/item/rogueweapon/Initialize(mapload)
 	. = ..()
@@ -124,33 +122,11 @@
 			ungrip(user)
 		altgrip(user)
 		user.update_inv_hands()
-	else if(twirly)
-		SpinAnimation(4, 2) // The spin happens regardless of the cooldown
-
-		if(!COOLDOWN_FINISHED(src, twirl_cooldown))
-			return ..()
-
-		COOLDOWN_START(src, twirl_cooldown, 3 SECONDS)
-		var/twirlskill = twirly - ((associated_skill == /datum/skill/combat/arcyne) ? 1 : 0) // AA is proliferated quite sparingly, jman AA is like expert in most wskills
-		if((user.get_skill_level(associated_skill) < twirlskill) && prob(40))
-			user.visible_message(
-				span_danger("While trying to twirl [src] [user] drops it instead!"),
-				span_userdanger("While trying to twirl [src] you drop it instead!"),
-			)
-			var/mob/living/carbon/human/unfortunate_idiot = user
-			var/dropped_knife_target = pick(
-				BODY_ZONE_PRECISE_L_FOOT,
-				BODY_ZONE_PRECISE_R_FOOT,
-				)
-			unfortunate_idiot.apply_damage(src.force, BRUTE, dropped_knife_target)
-			user.dropItemToGround(src, TRUE)
-		else
-			user.visible_message(
-				span_notice("[user] twirls [src] in a dramatic flourish!"),
-				span_notice("You twirl [src] dramatically."),
-			)
-			playsound(src, 'sound/foley/equip/swordsmall1.ogg', 20, FALSE)
+		return
 	return ..()
+
+/obj/item/rogueweapon/twirl_skill_needed()
+	return twirly - ((associated_skill == /datum/skill/combat/arcyne) ? 1 : 0)
 
 /obj/item/shaft
 	name = "debug shaft"
@@ -208,5 +184,4 @@
 /obj/item/rogueweapon/get_mechanics_examine(mob/user)
 	. = ..()
 	if(twirly)
-		var/twirlskill = twirly - ((associated_skill == /datum/skill/combat/arcyne) ? 1 : 0)
-		. += span_info("You can twirl this weapon by right-clicking it in your hand[has_altgrip_modes()?" out of combat mode":""]. Doing so safely requires [skill_to_string(twirlskill)] skills; anything less risks harming yourself.")
+		. += span_info("Right-click to twirl it one-handed[has_altgrip_modes()?", out of combat mode":""]. Safe at [skill_to_string(twirl_skill_needed())] skill.")

--- a/code/game/objects/items/spellbooks.dm
+++ b/code/game/objects/items/spellbooks.dm
@@ -127,7 +127,7 @@ Intended to be a reward or a goal for pure mage, allowing them to rebind their a
 	read(user)
 	user.update_inv_hands()
 
-/obj/item/rogueweapon/spellbook/rmb_self(mob/user)
+/obj/item/rogueweapon/spellbook/rmb_self(mob/user, keybind = FALSE)
 	attack_right(user)
 	return
 

--- a/code/game/objects/items/twirling.dm
+++ b/code/game/objects/items/twirling.dm
@@ -1,0 +1,78 @@
+/*
+TWIRL CODE
+*/
+
+/obj/item
+	/// Skill level needed to twirl this safely. Falsy means it can't be twirled at all.
+	var/twirly
+	var/twirl_speed = 4
+	var/fumble_chance = 40
+	var/twirl_verb = "twirl"
+	var/twirl_cmode = FALSE
+	var/twirl_sound = 'sound/foley/equip/swordsmall1.ogg'
+	/// TRUE while a spin visual stands in for our static in-hand overlay.
+	var/inhand_spinning = FALSE
+	/// Store the viscontent to cut spins short.
+	var/atom/movable/flick_visual/spin_visual
+
+	COOLDOWN_DECLARE(twirl_cooldown)
+
+/obj/item/rmb_self(mob/user, keybind = FALSE)
+	. = ..()
+	try_twirl(user)
+
+/obj/item/proc/try_twirl(mob/living/user)
+	if(!twirly || !isliving(user))
+		return FALSE
+	if(twirl_cmode && !user.cmode)
+		return FALSE
+	if(wielded || altgripped)
+		balloon_alert(user, "one-handed only!")
+		return FALSE
+	if(!COOLDOWN_FINISHED(src, twirl_cooldown))
+		return FALSE
+	COOLDOWN_START(src, twirl_cooldown, 3 SECONDS)
+
+	SpinAnimation(twirl_speed, 1)
+	if(iscarbon(user))
+		var/mob/living/carbon/twirler = user
+		twirler.start_spin(src, twirl_speed)
+
+	if((user.get_skill_level(associated_skill) < twirl_skill_needed()) && prob(fumble_chance))
+		twirl_fumble(user)
+	else
+		twirl_success(user)
+	return TRUE
+
+/obj/item/proc/twirl_skill_needed()
+	return twirly
+
+/obj/item/proc/twirl_success(mob/living/user)
+	user.visible_message(
+		span_notice("[user] twirls [src] in a dramatic flourish!"),
+		span_notice("You twirl [src] dramatically."),
+	)
+	playsound(src, twirl_sound, 20, FALSE)
+
+/obj/item/proc/twirl_fumble(mob/living/user)
+	user.visible_message(
+		span_danger("While trying to [twirl_verb] [src] [user] drops it instead!"),
+		span_userdanger("While trying to [twirl_verb] [src] you drop it instead!"),
+	)
+	user.apply_damage(force, BRUTE, pick(BODY_ZONE_PRECISE_L_FOOT, BODY_ZONE_PRECISE_R_FOOT))
+	user.dropItemToGround(src, TRUE)
+
+/obj/item/proc/twirl_fumble_bonk(mob/living/user, fumble_sound = 'sound/misc/bonk.ogg')
+	var/crit = prob(60)
+	var/critmsg = " <span class='crit'><b>Critical hit!</b> [user] is knocked out!</span>"
+	user.visible_message(
+		span_danger("While trying to [twirl_verb] [src] [user] flings it instead, hitting [user.p_themselves()] in the head![crit ? critmsg : ""]"),
+		span_userdanger("While trying to [twirl_verb] [src] you fling it instead, hitting yourself in the head![crit ? critmsg : ""]"),
+	)
+	user.apply_damage(force, BRUTE, BODY_ZONE_PRECISE_SKULL)
+	if(crit)
+		user.flash_fullscreen("whiteflash3")
+		user.Unconscious(5 SECONDS)
+		playsound(get_turf(user), 'sound/combat/tf2crit.ogg', 100, FALSE)
+	playsound(get_turf(user), fumble_sound, 100, FALSE)
+	user.dropItemToGround(src, TRUE)

--- a/code/modules/farming/fermentation_keg.dm
+++ b/code/modules/farming/fermentation_keg.dm
@@ -546,7 +546,7 @@ GLOBAL_LIST_EMPTY(custom_fermentation_recipes)
 	else
 		. += span_notice("The bottle has been unsealed. It cannot be sold anymore.")
 
-/obj/item/reagent_containers/glass/bottle/brewing_bottle/rmb_self(mob/user)
+/obj/item/reagent_containers/glass/bottle/brewing_bottle/rmb_self(mob/user, keybind = FALSE)
 	. = ..()
 	sealed = FALSE
 	sellprice = 0

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hag_class/hag_structures/hag_mirror.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hag_class/hag_structures/hag_mirror.dm
@@ -153,5 +153,5 @@
 		. += span_info("Right-click the mirror to scry with it.")
 		. += span_info("You can only scry people if you know them, or if they are in the bog.")
 
-/obj/item/handmirror/hag/rmb_self(mob/user)
+/obj/item/handmirror/hag/rmb_self(mob/user, keybind = FALSE)
 	src.attack_right(user)

--- a/code/modules/mob/living/carbon/update_icons.dm
+++ b/code/modules/mob/living/carbon/update_icons.dm
@@ -135,76 +135,14 @@
 							observers = null
 							break
 
-		var/mutable_appearance/inhand_overlay
-		var/mutable_appearance/behindhand_overlay
-		if(I.experimental_inhand && !hide_experimental)
-			var/used_prop
-			var/list/prop
-			if(I.altgripped)
-				used_prop = "altgrip"
-				prop = I.getonmobprop(used_prop)
-			if(!prop && I.wielded)
-				used_prop = "wielded"
-				prop = I.getonmobprop(used_prop)
-			if(!prop)
-				used_prop = "gen"
-				prop = I.getonmobprop(used_prop)
-			if(I.force_reupdate_inhand)
-				if(I.onprop?[used_prop])
-					prop = I.onprop[used_prop]
-				else
-					LAZYSET(I.onprop, used_prop, prop)
-			if(!prop)
-				continue
-			var/flipsprite = FALSE
-			if(!(get_held_index_of_item(I) % 2 == 0)) //righthand
-				flipsprite = TRUE
-			inhand_overlay = mutable_appearance(I.getmoboverlay(used_prop,prop,mirrored=flipsprite), layer=-HANDS_LAYER)
-			behindhand_overlay = mutable_appearance(I.getmoboverlay(used_prop,prop,behind=TRUE,mirrored=flipsprite), layer=-HANDS_BEHIND_LAYER)
+		if(I.inhand_spinning)
+			continue
 
-			inhand_overlay = center_image(inhand_overlay, I.inhand_x_dimension, I.inhand_y_dimension)
-			behindhand_overlay = center_image(behindhand_overlay, I.inhand_x_dimension, I.inhand_y_dimension)
-			if(I.icon_y_offset)
-				behindhand_overlay.pixel_y += I.icon_y_offset
-				inhand_overlay.pixel_y += I.icon_y_offset
-			if(I.icon_x_offset)
-				behindhand_overlay.pixel_x += I.icon_x_offset
-				inhand_overlay.pixel_x += I.icon_x_offset
-			if(ishuman(src))
-				var/mob/living/carbon/human/H = src
-				if(H.dna && H.dna.species)
-					if(gender == MALE)
-						if(OFFSET_HANDS in H.dna.species.offset_features)
-							inhand_overlay.pixel_x += H.dna.species.offset_features[OFFSET_HANDS][1]
-							inhand_overlay.pixel_y += H.dna.species.offset_features[OFFSET_HANDS][2]
-							behindhand_overlay.pixel_x += H.dna.species.offset_features[OFFSET_HANDS][1]
-							behindhand_overlay.pixel_y += H.dna.species.offset_features[OFFSET_HANDS][2]
-					else
-						if(OFFSET_HANDS_F in H.dna.species.offset_features)
-							inhand_overlay.pixel_x += H.dna.species.offset_features[OFFSET_HANDS_F][1]
-							inhand_overlay.pixel_y += H.dna.species.offset_features[OFFSET_HANDS_F][2]
-							behindhand_overlay.pixel_x += H.dna.species.offset_features[OFFSET_HANDS_F][1]
-							behindhand_overlay.pixel_y += H.dna.species.offset_features[OFFSET_HANDS_F][2]
-
-			hands += inhand_overlay
-			behindhands += behindhand_overlay
-		else
-			var/icon_file = I.lefthand_file
-			if(get_held_index_of_item(I) % 2 == 0)
-				icon_file = I.righthand_file
-			inhand_overlay = I.build_worn_icon(default_layer = HANDS_LAYER, default_icon_file = icon_file, isinhands = TRUE)
-			if(ishuman(src))
-				var/mob/living/carbon/human/H = src
-				if(H.dna && H.dna.species.sexes)
-					if(gender == MALE)
-						if(OFFSET_HANDS in H.dna.species.offset_features)
-							inhand_overlay.pixel_x += H.dna.species.offset_features[OFFSET_HANDS][1]
-							inhand_overlay.pixel_y += H.dna.species.offset_features[OFFSET_HANDS][2]
-					else
-						if(OFFSET_HANDS_F in H.dna.species.offset_features)
-							inhand_overlay.pixel_x += H.dna.species.offset_features[OFFSET_HANDS_F][1]
-							inhand_overlay.pixel_y += H.dna.species.offset_features[OFFSET_HANDS_F][2]
-			hands += inhand_overlay
+		var/list/built = build_inhand_overlays(I, hide_experimental)
+		if(built[INHAND_FRONT])
+			hands += built[INHAND_FRONT]
+		if(built[INHAND_BEHIND])
+			behindhands += built[INHAND_BEHIND]
 
 	update_inv_cloak() //cloak held items
 
@@ -212,6 +150,117 @@
 	overlays_standing[HANDS_LAYER] = hands
 	apply_overlay(HANDS_BEHIND_LAYER)
 	apply_overlay(HANDS_LAYER)
+
+/mob/living/carbon/proc/build_inhand_overlays(obj/item/I, hide_experimental = FALSE)
+	. = list(null, null)
+	var/mutable_appearance/inhand_overlay
+	var/mutable_appearance/behindhand_overlay
+	if(I.experimental_inhand && !hide_experimental)
+		var/list/resolved = I.onmob_prop()
+		var/used_prop = resolved[ONMOB_TAG]
+		var/list/prop = resolved[ONMOB_PROP]
+		if(I.force_reupdate_inhand)
+			if(I.onprop?[used_prop])
+				prop = I.onprop[used_prop]
+			else
+				LAZYSET(I.onprop, used_prop, prop)
+		if(!prop)
+			return
+		var/flipsprite = FALSE
+		if(!(get_held_index_of_item(I) % 2 == 0)) //righthand
+			flipsprite = TRUE
+		inhand_overlay = mutable_appearance(I.getmoboverlay(used_prop,prop,mirrored=flipsprite), layer=-HANDS_LAYER)
+		behindhand_overlay = mutable_appearance(I.getmoboverlay(used_prop,prop,behind=TRUE,mirrored=flipsprite), layer=-HANDS_BEHIND_LAYER)
+
+		inhand_overlay = center_image(inhand_overlay, I.inhand_x_dimension, I.inhand_y_dimension)
+		behindhand_overlay = center_image(behindhand_overlay, I.inhand_x_dimension, I.inhand_y_dimension)
+		if(I.icon_y_offset)
+			behindhand_overlay.pixel_y += I.icon_y_offset
+			inhand_overlay.pixel_y += I.icon_y_offset
+		if(I.icon_x_offset)
+			behindhand_overlay.pixel_x += I.icon_x_offset
+			inhand_overlay.pixel_x += I.icon_x_offset
+		if(ishuman(src))
+			var/mob/living/carbon/human/H = src
+			if(H.dna && H.dna.species)
+				if(gender == MALE)
+					if(OFFSET_HANDS in H.dna.species.offset_features)
+						inhand_overlay.pixel_x += H.dna.species.offset_features[OFFSET_HANDS][1]
+						inhand_overlay.pixel_y += H.dna.species.offset_features[OFFSET_HANDS][2]
+						behindhand_overlay.pixel_x += H.dna.species.offset_features[OFFSET_HANDS][1]
+						behindhand_overlay.pixel_y += H.dna.species.offset_features[OFFSET_HANDS][2]
+				else
+					if(OFFSET_HANDS_F in H.dna.species.offset_features)
+						inhand_overlay.pixel_x += H.dna.species.offset_features[OFFSET_HANDS_F][1]
+						inhand_overlay.pixel_y += H.dna.species.offset_features[OFFSET_HANDS_F][2]
+						behindhand_overlay.pixel_x += H.dna.species.offset_features[OFFSET_HANDS_F][1]
+						behindhand_overlay.pixel_y += H.dna.species.offset_features[OFFSET_HANDS_F][2]
+	else
+		var/icon_file = I.lefthand_file
+		if(get_held_index_of_item(I) % 2 == 0)
+			icon_file = I.righthand_file
+		inhand_overlay = I.build_worn_icon(default_layer = HANDS_LAYER, default_icon_file = icon_file, isinhands = TRUE)
+		if(ishuman(src))
+			var/mob/living/carbon/human/H = src
+			if(H.dna && H.dna.species.sexes)
+				if(gender == MALE)
+					if(OFFSET_HANDS in H.dna.species.offset_features)
+						inhand_overlay.pixel_x += H.dna.species.offset_features[OFFSET_HANDS][1]
+						inhand_overlay.pixel_y += H.dna.species.offset_features[OFFSET_HANDS][2]
+				else
+					if(OFFSET_HANDS_F in H.dna.species.offset_features)
+						inhand_overlay.pixel_x += H.dna.species.offset_features[OFFSET_HANDS_F][1]
+						inhand_overlay.pixel_y += H.dna.species.offset_features[OFFSET_HANDS_F][2]
+
+	.[INHAND_FRONT] = inhand_overlay
+	.[INHAND_BEHIND] = behindhand_overlay
+
+/mob/living/carbon/proc/start_spin(obj/item/I, speed = 4)
+	if(QDELETED(I) || I.inhand_spinning || !(I in held_items))
+		return
+	var/list/built = build_inhand_overlays(I)
+	var/mutable_appearance/spin_appearance = built[I.inhand_index(dir)]
+	if(!spin_appearance)
+		spin_appearance = built[INHAND_FRONT] || built[INHAND_BEHIND]
+	if(!spin_appearance)
+		return
+
+	I.inhand_spinning = TRUE
+	update_inv_hands()
+
+	var/mirrored = !(get_held_index_of_item(I) % 2 == 0)
+	var/list/grip = I.grip_offset(dir, mirrored)
+
+	var/above = TRUE
+	if(dir & NORTH)
+		above = FALSE
+	else if(dir & SOUTH)
+		above = TRUE
+	else if(dir & EAST)
+		above = mirrored
+	else if(dir & WEST)
+		above = !mirrored
+	spin_appearance.layer = layer + (above ? 0.1 : -0.1)
+
+	var/atom/movable/flick_visual/spin = flick_overlay_view(spin_appearance, speed + 2)
+	if(spin)
+		spin.vis_flags |= VIS_INHERIT_PLANE
+		spin.dir = dir
+		spin.SpinAnimationAround(grip[1], grip[2], speed, 1)
+		I.spin_visual = spin
+
+	addtimer(CALLBACK(I, TYPE_PROC_REF(/obj/item, end_spin)), speed)
+
+/obj/item/proc/end_spin()
+	if(!inhand_spinning)
+		return
+	inhand_spinning = FALSE
+	qdel(spin_visual)
+	spin_visual = null
+
+	var/mob/living/carbon/holder = loc
+	if(istype(holder))
+		holder.update_inv_hands()
 
 /mob/living/carbon/update_warning(datum/intent/I)
 	remove_overlay(HALO_LAYER) //yoink

--- a/code/modules/paperwork/rogue.dm
+++ b/code/modules/paperwork/rogue.dm
@@ -80,7 +80,7 @@
 	update_icon_state()
 	..()
 
-/obj/item/paper/scroll/rmb_self(mob/user)
+/obj/item/paper/scroll/rmb_self(mob/user, keybind = FALSE)
 	attack_right(user)
 	return
 

--- a/code/modules/reagents/reagent_containers/bottle.dm
+++ b/code/modules/reagents/reagent_containers/bottle.dm
@@ -121,7 +121,7 @@ GLOBAL_LIST_INIT(wisdoms, world.file2list("strings/rt/wisdoms.txt"))
 			user.mob_timers["bottleopen_warn"] = world.time
 	return
 
-/obj/item/reagent_containers/glass/bottle/rmb_self(mob/user)
+/obj/item/reagent_containers/glass/bottle/rmb_self(mob/user, keybind = FALSE)
 	. = ..()
 	toggle_cork(user)
 

--- a/code/modules/roguetown/roguemachine/questing/items/quest_writ.dm
+++ b/code/modules/roguetown/roguemachine/questing/items/quest_writ.dm
@@ -167,7 +167,7 @@ GLOBAL_LIST_EMPTY(quest_scrolls)
 	refresh_compass(user)
 	ui_interact(user)
 
-/obj/item/quest_writ/rmb_self(mob/user)
+/obj/item/quest_writ/rmb_self(mob/user, keybind = FALSE)
 	if(!assigned_quest || !opened)
 		return
 	opened = FALSE

--- a/modular/Neu_Food/code/cookware/pan.dm
+++ b/modular/Neu_Food/code/cookware/pan.dm
@@ -23,8 +23,8 @@
 	grid_height = 64
 	anvilrepair = /datum/skill/craft/weaponsmithing
 	obj_flags = CAN_BE_HIT
-
-	COOLDOWN_DECLARE(twirl_cooldown) //twirling has a cooldown on to_chat to reduce chatspam
+	twirly = SKILL_LEVEL_EXPERT
+	twirl_cmode = TRUE
 
 /obj/item/cooking/pan/Initialize()
 	. = ..()
@@ -160,9 +160,9 @@
 	. += span_info("Left-click a loaded pan with an empty hand to see everything it holds. Middle-click takes the pan off the hearth.")
 	. += span_info("As long as the hearth is lit, everything in the pan will cook at once. Take it off the pan to stop the cooking.")
 	. += span_info("Meats, cackleberries, and sliced vegetables are the ideal choices for frying. Other ingredients and recipes might require the gentle caress of an oven, instead.")
-	. += span_info("Leaving a fully fried item on a lit hearth for too long will cause it to burn away.")
+	. += span_info("Leaving a fully baked item on the pan for too long will cause it to burn away.")
 	. += span_info("Use a loaded pan in your hand outside of combat mode to flip it, throwing everything on it onto the table or tile you're facing. If a tray is there, the food lands on the tray instead.")
-	. += span_info("You can twirl [src] by right-clicking it in your hand while in combat mode. Doing so safely requires Expert skill; anything less risks harming yourself.")
+	. += span_info("Right-click in combat mode to twirl it one-handed. Safe at Expert skill.")
 
 /datum/intent/mace/strike/pan
 	hitsound = list('sound/combat/hits/blunt/frying_pan(1).ogg', 'sound/combat/hits/blunt/frying_pan(2).ogg', 'sound/combat/hits/blunt/frying_pan(3).ogg', 'sound/combat/hits/blunt/frying_pan(4).ogg')
@@ -214,31 +214,5 @@
 			if("gen")
 				return list("shrink" = 0.6,"sx" = -7,"sy" = -4,"nx" = 7,"ny" = -4,"wx" = -4,"wy" = -4,"ex" = 2,"ey" = -4,"nturn" = 0,"sturn" = 0,"wturn" = 0,"eturn" = 0,"nflip" = 0,"sflip" = 0,"wflip" = 0,"eflip" = 0,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0)
 
-/obj/item/cooking/pan/rmb_self(mob/user)
-	. = ..()
-	if(. || !user.cmode) // don't want people to accidentally do this while cooking
-		return
-
-	SpinAnimation(4, 2) // The spin happens regardless of the cooldown
-
-	if(!COOLDOWN_FINISHED(src, twirl_cooldown))
-		return
-
-	COOLDOWN_START(src, twirl_cooldown, 3 SECONDS)
-	if((user.get_skill_level(associated_skill) < SKILL_LEVEL_EXPERT) && prob(40))
-		var/crit = prob(60) // separate role to KO
-		var/critmsg = " <span class='crit'><b>Critical hit!</b> [user] is knocked out!</span>"
-		user.visible_message(span_danger("While trying to twirl [src] [user] flings it instead, hitting [user.p_themselves()] in the head![crit ? critmsg : ""]"), span_userdanger("While trying to twirl [src] you fling it instead, hitting yourself in the head![crit ? critmsg : ""]"))
-		var/mob/living/carbon/human/unfortunate_idiot = user
-		unfortunate_idiot.apply_damage(src.force, BRUTE, BODY_ZONE_PRECISE_SKULL)
-		if(crit)
-			unfortunate_idiot.flash_fullscreen("whiteflash3")
-			unfortunate_idiot.Unconscious(5 SECONDS)
-			playsound(get_turf(unfortunate_idiot), 'sound/combat/tf2crit.ogg', 100, FALSE)
-		playsound(get_turf(unfortunate_idiot), 'sound/combat/hits/blunt/frying_pan(1).ogg', 100, FALSE)
-		user.dropItemToGround(src, TRUE)
-	else
-		user.visible_message(span_notice("[user] twirls [src] in a dramatic flourish!"), span_notice("You twirl [src] dramatically."))
-		playsound(src, 'sound/foley/equip/swordsmall1.ogg', 20, FALSE)
-
-	return
+/obj/item/cooking/pan/twirl_fumble(mob/living/user)
+	return twirl_fumble_bonk(user, 'sound/combat/hits/blunt/frying_pan(1).ogg')

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -1291,6 +1291,7 @@
 #include "code\game\objects\items\taster.dm"
 #include "code\game\objects\items\toys.dm"
 #include "code\game\objects\items\trash.dm"
+#include "code\game\objects\items\twirling.dm"
 #include "code\game\objects\items\twstrap.dm"
 #include "code\game\objects\items\weaponry.dm"
 #include "code\game\objects\items\clothes\neck.dm"


### PR DESCRIPTION
## About The Pull Request
[
Lookit this](https://cdn.discordapp.com/attachments/1287370680115138642/1542204576550101062/dreamseeker_TvmvV5Z0Kd.gif?ex=6a90616f&is=6a8f0fef&hm=dc64f58351598cd2b41481364204334179a7495d1fe5339159a12e19a533a867&)

## Testing Evidence

yeah

## Why It's Good For The Game

set out to just make flourishes appear onmob. proceeded to just unify the whole thing cuz the same code copied over n over aint it

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
code: unifies flourishing
add: lets flourishing show up in game
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
