### PR TITLE
Buff Fire Curtain but makes AI avoid it and make throwing into fire curtain ldss effective

### DIFF
--- a/code/modules/spells/spell_types/wizard/pyromancy/fire_curtain.dm
+++ b/code/modules/spells/spell_types/wizard/pyromancy/fire_curtain.dm
@@ -1,13 +1,17 @@
-#define CURTAIN_TICK_DAMAGE 30
+#define CURTAIN_TICK_DAMAGE 50
+#define CURTAIN_SCORCH_PER_TICK 2
+#define CURTAIN_THROWN_BURN_COOLDOWN (2 SECONDS)
+#define CURTAIN_THROWN_GRACE (1 SECONDS)
 #define CURTAIN_BURN_KEY "curtain_burn"
+#define CURTAIN_GRACE_KEY "curtain_grace"
 
 /datum/action/cooldown/spell/fire_curtain
 	button_icon = 'icons/mob/actions/mage_pyromancy.dmi'
 	name = "Fire Curtain"
 	desc = "Conjure a 5x2 curtain of flame at a target location, perpendicular to your facing. \
-	After a 2-second telegraph, the fire erupts. Burning for 10 seconds. \
-	The fire does not block movement but will burn anything that passes through or stands in it. \
-	You are not immune to your own curtain.\n\
+	After a 3-second telegraph, the fire erupts. Burning for 10 seconds. \
+	The fire does not block movement but will burn anything that passes through or stands in it, \
+	applying two scorched stacks per burn. You are not immune to your own curtain.\n\
 	Fire spells apply scorched effects - at 4 scorched, an armor piercing wound is applied to the head or chest: whichever you are aiming at, and randomly if aiming elsewhere."
 	button_icon_state = "fire_curtain"
 	sound = 'sound/magic/fireball.ogg'
@@ -47,6 +51,7 @@
 /datum/action/cooldown/spell/fire_curtain/get_spell_statistics(mob/living/user)
 	var/list/stats = ..()
 	stats += span_info("Damage: [CURTAIN_TICK_DAMAGE] burn per second (up to [DisplayTimeText(curtain_life)] in the flames)")
+	stats += span_info("Scorched: [CURTAIN_SCORCH_PER_TICK] stacks per burn")
 	return stats
 
 /datum/action/cooldown/spell/fire_curtain/cast(atom/cast_on)
@@ -126,10 +131,11 @@
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	light_outer_range = LIGHT_RANGE_FIRE
 	light_color = LIGHT_COLOR_FIRE
-	object_slowdown = 15
+	ai_path_weight = 15
 	var/lifetime = 10 SECONDS
 	var/tick_damage = CURTAIN_TICK_DAMAGE
 	var/burn_cooldown = 1 SECONDS
+	var/list/burn_times
 	var/datum/weakref/caster_ref
 	var/aim_zone
 
@@ -150,21 +156,32 @@
 /obj/effect/curtain_fire/Crossed(atom/movable/AM, oldLoc)
 	. = ..()
 	if(isliving(AM))
-		burn_occupant(AM)
+		var/mob/living/L = AM
+		burn_occupant(L, !!L.throwing)
 
 /obj/effect/curtain_fire/process(seconds_per_tick)
 	var/turf/T = get_turf(src)
 	if(!isturf(T))
 		return
 	for(var/mob/living/L in T)
-		burn_occupant(L)
+		burn_occupant(L, !!L.throwing)
 
-/obj/effect/curtain_fire/proc/burn_occupant(mob/living/L)
+/obj/effect/curtain_fire/proc/burn_occupant(mob/living/L, involuntary = FALSE)
 	if(HAS_TRAIT(L, TRAIT_NOFIRE))
 		return
-	if(L.mob_timers[CURTAIN_BURN_KEY] && world.time < L.mob_timers[CURTAIN_BURN_KEY])
+	// Grace timer for those who were involuntarily thrown into the fire curtain so that it doesn't instaproc charred in involuntary situation
+	if(L.mob_timers[CURTAIN_GRACE_KEY] && world.time < L.mob_timers[CURTAIN_GRACE_KEY])
 		return
-	L.mob_timers[CURTAIN_BURN_KEY] = world.time + burn_cooldown
+	var/mob_key = REF(L)
+	if(involuntary)
+		if(L.mob_timers[CURTAIN_BURN_KEY] && world.time < L.mob_timers[CURTAIN_BURN_KEY])
+			return
+	else if(LAZYACCESS(burn_times, mob_key) && world.time < burn_times[mob_key])
+		return
+	L.mob_timers[CURTAIN_BURN_KEY] = world.time + CURTAIN_THROWN_BURN_COOLDOWN
+	LAZYSET(burn_times, mob_key, world.time + burn_cooldown)
+	if(involuntary)
+		L.mob_timers[CURTAIN_GRACE_KEY] = world.time + CURTAIN_THROWN_GRACE
 	var/hit_zone = aim_zone || BODY_ZONE_CHEST
 	var/mob/living/carbon/human/caster = caster_ref?.resolve()
 	if(istype(caster) && !QDELETED(caster))
@@ -174,8 +191,12 @@
 		var/fallback_zone = check_zone(hit_zone)
 		var/armor_block = L.run_armor_check(fallback_zone, "fire", blade_dulling = BCLASS_BURN, damage = tick_damage, no_debuff = TRUE)
 		L.apply_damage(tick_damage, BURN, fallback_zone, armor_block)
-	apply_scorch_stack(L, 1, hit_zone)
+	apply_scorch_stack(L, CURTAIN_SCORCH_PER_TICK, hit_zone)
 	L.emote("pain", forced = TRUE)
 
 #undef CURTAIN_TICK_DAMAGE
+#undef CURTAIN_SCORCH_PER_TICK
+#undef CURTAIN_THROWN_BURN_COOLDOWN
+#undef CURTAIN_THROWN_GRACE
 #undef CURTAIN_BURN_KEY
+#undef CURTAIN_GRACE_KEY


### PR DESCRIPTION
## About The Pull Request
Fire Curtain has always been the most underwhelming part of the Pyro Toolkit but avoided buffs largely because it is quite powerful in PVE. This tries to solve both issues. 

- Fire Curtain now applies 2 scorched stack if you run through it. 
- If you get THROWN into it (I.e. Fire Blast), it will applies a grace period of 2 seconds for any ticking flame proccing on you, meaning eating a FBlast into a Fire Curtain will NOT instantly proc charred, while running across it will. 
- AI should avoid it more aggressively

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Tested locally

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
A small tuning of Pyro's No.4 spell

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Fire Curtain now applies 2 scorched stack if you run through it, If you get THROWN into it (I.e. Fire Blast), it will applies a grace period of 2 seconds for any ticking flame proccing on you, meaning eating a FBlast into a Fire Curtain will NOT instantly proc charred, while running across it will. AI should avoid it more aggressively
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
