### PR TITLE
Adds a craftable/donor loadout scroll of mirror transform

### DIFF
--- a/code/datums/loadout/loadout_donators.dm
+++ b/code/datums/loadout/loadout_donators.dm
@@ -848,6 +848,10 @@
 	path = /obj/item/enchantingkit/weapon/kadeguandao
 	ckeywhitelist = list("shiroseschnee", "Zerantio")
 
+/datum/loadout_item/donator/mirrortransform
+	name = "Gift - Scroll of Mirror Transform"
+	path = /obj/item/book/granter/spell/mirror_transform
+
 /datum/loadout_item/donator/falling_star
 	name = "Donator Kit - Falling Star"
 	path = /obj/item/enchantingkit/weapon/falling_star

--- a/code/datums/loadout/loadout_donators.dm
+++ b/code/datums/loadout/loadout_donators.dm
@@ -846,7 +846,7 @@
 /datum/loadout_item/donator/kadeguandao
 	name = "Donator Kit - Dawn Cometh"
 	path = /obj/item/enchantingkit/weapon/kadeguandao
-	ckeywhitelist = list("shiroseschnee", "Zerantio")
+	ckeywhitelist = list("shiroseschnee", "Zerantio", "elox2000")
 
 /datum/loadout_item/donator/mirrortransform
 	name = "Gift - Scroll of Mirror Transform"

--- a/code/datums/loadout/loadout_donators.dm
+++ b/code/datums/loadout/loadout_donators.dm
@@ -239,6 +239,10 @@
 	name = "Gift - Kit, Long Jacketed Gambeson"
 	path = /obj/item/enchantingkit/donator_jacketed_gambeson_long
 
+/datum/loadout_item/donator/mirrortransform
+	name = "Gift - Scroll of Mirror Transform"
+	path = /obj/item/book/granter/spell/mirror_transform
+
 // --- GRENZEL REGIONAL ---
 
 /datum/loadout_item/donator/universal/regional/grenzelhat
@@ -847,10 +851,6 @@
 	name = "Donator Kit - Dawn Cometh"
 	path = /obj/item/enchantingkit/weapon/kadeguandao
 	ckeywhitelist = list("shiroseschnee", "Zerantio", "elox2000")
-
-/datum/loadout_item/donator/mirrortransform
-	name = "Gift - Scroll of Mirror Transform"
-	path = /obj/item/book/granter/spell/mirror_transform
 
 /datum/loadout_item/donator/falling_star
 	name = "Donator Kit - Falling Star"

--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -75,9 +75,14 @@
 
 	var/spell
 	var/spellname = "conjure bugs"
+	var/required_skill
+	var/required_skill_level = SKILL_LEVEL_NOVICE
 
 /obj/item/book/granter/spell/already_known(mob/user)
 	if(!spell)
+		return TRUE
+	if(required_skill && user.get_skill_level(required_skill) < required_skill_level)
+		to_chat(user, span_warning("I don't have the skill to understand this scroll!"))
 		return TRUE
 	if(user.mind.has_spell(spell, specific = TRUE))
 		to_chat(user, span_warning("You've already read this one!"))
@@ -248,6 +253,27 @@ UNDER NO CIRCUMSTANCE SHOULD ANY OF THE BOOKS BE GIVEN OUT INTO SPAWNERS OR TO B
 	remarks = list("Mediolanum ventis..", "Sana damnatorum..", "Frigidus ossa mortuorum..")
 
 /obj/item/book/granter/spell/bonechill/onlearned(mob/living/carbon/user)
+	..()
+	if(oneuse)
+		name = "siphoned scroll"
+		desc = "A scroll once inscribed with magical scripture. The surface is now barren of knowledge, siphoned by someone else. It's utterly useless."
+		icon_state = "scroll"
+		user.visible_message(span_warning("[src] has had its magic ink ripped from the scroll!"))
+
+/obj/item/book/granter/spell/mirror_transform
+	name = "Scroll of Mirror Transform"
+	spell = /datum/action/cooldown/spell/mirror_transform
+	spellname = "Mirror Transform"
+	desc = "A scroll to change one's forme. Requires some form of past arcyne experience to understand."
+	required_skill = /datum/skill/magic/arcane
+	icon_state ="scrolldarkred"
+	icon = 'icons/roguetown/items/misc.dmi'
+	oneuse = TRUE
+	drop_sound = 'sound/foley/dropsound/paper_drop.ogg'
+	pickup_sound = 'sound/blank.ogg'
+	remarks = list("Corpus meum est sicut mens mea...", "Forma mea, transitoria..", "Pulchritudinem videbunt...")
+
+/obj/item/book/granter/spell/mirror_transform/onlearned(mob/living/carbon/user)
 	..()
 	if(oneuse)
 		name = "siphoned scroll"

--- a/code/modules/roguetown/roguejobs/mages/arcana_crafting.dm
+++ b/code/modules/roguetown/roguejobs/mages/arcana_crafting.dm
@@ -20,6 +20,13 @@
 	reqs = list(/obj/item/rogueore/cinnabar = 1,
 				/datum/reagent/medicine/manapot = 15)
 
+/datum/crafting_recipe/roguetown/arcana/mirror_transform_scroll
+	name = "Scroll of Mirror Transform"
+	result = /obj/item/book/granter/spell/mirror_transform
+	reqs = list (/obj/item/rogueore/cinnabar = 1,
+				/datum/reagent/medicine/manapot =  10,
+				/obj/item/paper/scroll = 1)
+
 /datum/crafting_recipe/roguetown/arcana/infernalfeather
 	name = "infernal feather"
 	result = /obj/item/natural/feather/infernal


### PR DESCRIPTION
## About The Pull Request

Adds a scroll granting mirror transform to the donator spawn menu. The scrolls requires at least novice arcyne skill to be able to read unlike the others scrolls (this also implements a variable to check for that, idt there was one before since spell granters are fairly sparse) and a crafting recipe to create the scroll as well, so that it's accessible to normal players too.

The recipe to craft is fairly accessible, not too different from Chalk's recipe.

(Also entirely out of scope this add's a friend's ckey to a prior item i made)

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->
<img width="336" height="30" alt="image" src="https://github.com/user-attachments/assets/475a0395-d3ef-47b0-ac5b-3a4eb1120f8f" />
<img width="527" height="219" alt="image" src="https://github.com/user-attachments/assets/23265b6b-4ce8-4afd-a4b3-328187b53d7d" />
<img width="444" height="147" alt="image" src="https://github.com/user-attachments/assets/fee54bbd-9654-4328-bbe6-a86a940c7f64" />
<img width="466" height="512" alt="image" src="https://github.com/user-attachments/assets/4dfc2533-730c-4411-a445-d43aa3cf12bb" />
<img width="502" height="178" alt="image" src="https://github.com/user-attachments/assets/5ce4687f-9a90-46bb-b066-0024b714e15d" />

## Why It's Good For The Game

Mirror TF is, for the most part, a sex-change spell for people who like to have control over their scenes while not having both bits, or the occasional person who enjoys more obscure stuff like shapeshifting characters. It has an incredibly obtuse menu, and I doubt people will find a way to power-game with this in any sense that matters ((saving 1 spell-point poggers))
Beyond that, this is a nice way to get around most classes that cannot take arcpot for Mirror TF, requiring arcane skill (so they still have to take it) which has gotten in the way of my, and a few friend's, wants to play certain classes. At some point I'd like to experiment with making it not

If this somehow has issue behind being filtered by 5 dollars and the worst menu to ever be in the game, I'll cry and accept my fate.

## Changelog

:cl:
Adds a new mirror transform scroll, craftable via a recipe and in the donor loadout menu, only readable with arcane skill. (Mostly made to circumvent ArcPot restrictions for a purely flavor spell)
/:cl: