### PR TITLE
Bump monk/thug skin armors up, swap monk skin to meditation repair.

### DIFF
--- a/code/modules/clothing/rogueclothes/armor/manual.dm
+++ b/code/modules/clothing/rogueclothes/armor/manual.dm
@@ -341,7 +341,6 @@
 	</br>To give into despair and hopelessness, however, is to rob all meaning from His sacrifice. \
 	</br>Heaven's gate closed to us long ago, yet His children persist; as as long as they do, so must I. \
 	</br>Happiness must be fought for."
-	max_integrity = ARMOR_INT_CHEST_LIGHT_MASTER //a leather armor.
 
 /*
  * EMOTE ARMOUR

--- a/code/modules/clothing/rogueclothes/armor/manual.dm
+++ b/code/modules/clothing/rogueclothes/armor/manual.dm
@@ -53,7 +53,25 @@
 /obj/item/clothing/suit/roguetown/armor/manual/proc/worn_on_body(mob/living/carbon/human/user)
 	return user?.wear_armor == src || user?.wear_shirt == src
 
-//35% repair per proc, procs taking ~10-11s for sewing, pushup set, or meditation emote. Thus ~30-33s to fullrepair.
+/*
+ * DESIGN VISION - Fen
+ */
+//TIME
+//Repair time is roughly based on apprentice armor repair, with a slight penalty. Ballpark 20-30s for a single layer, 35-40s for two.
+//Pushup skin repairs in 2 sets (20-22s), but only one layer, the other needs resting. If both were on pushup repair, 3 sets (~30s) because stamina management etc is already a drawback.
+//Sewable skin repairs in ~21s, but only one layer at a time, so ~42s total. Slow, but anywhere and can focus-repair a specific layer on demand.
+//Resting skin repairs in 20s, both layers simultaniously, making it the fastest to mend, but also most restrictive on mending conditions.
+//Meditation skin repairs in 40s, both layers simultaniously. Tattoo armors drop this to 30s (one meditation cycle) because they suffer honorbound restrictions.
+
+//STATS
+//The default skin armor is equivalent to a full-body gambeson + chest-only leather armor. This makes it decent, but outclassed by real light armor that upgrades to heavy gambeson/arming jacket and leather coat/light brigadine.
+//Skin armor should be easier to use and more convenient than using actual armor, usually by having better coverage at roundstart, but never be able to reach the heights that a proper/high end light armor setup can, for most roles. Essentially, they are not optimal, but are comfortable.
+//Roles that have on-spawn access to high quality armor / faction wealth can have their gambeson layer be a heavy gambeson without issue (disciple).
+//Theoretically, skin armors with medium/heavy typing could have a similar relationship to generic armor of those tiers.
+
+//UNIQUE CASES
+//If a role has a gimmick (rage, miracles, magic etc), or is on a limited power budget (advent, noncombatant) the above should always apply.
+//However, if the role's  gimmick is its skin armor (most notably ruma, partially mistwalker), then it can step away from that baseline to a degree. Note that Honorbound or equivalent is advised to manage layering potential on full-body skins with advanced protection types (plate, maille etc), or head coverage (skin + helm + coif + arming cap all on the same zone is pain, and also makes chest the boring easy target again).
 
 
 /*
@@ -85,6 +103,7 @@
 	name = "harmonious skin"
 	desc = "Exotic skin armor that can be renewed via meditation. If you see this ingame, something went wrong."
 	blocking_behavior = SAMEWEAR
+	repair_fraction = 0.25 //mends both layers at once, so is a bit slower.
 
 /obj/item/clothing/suit/roguetown/armor/manual/meditation/equipped(mob/user, slot, initial = FALSE)
 	. = ..()
@@ -113,6 +132,12 @@
 /obj/item/clothing/suit/roguetown/armor/manual/meditation/body
 	body_parts_covered = COVERAGE_FULL //everything but head and it's subzones (neck, skull, ears, eyes, nose, mouth)
 	body_parts_inherent = COVERAGE_FULL
+	armor = ARMOR_PADDED
+	max_integrity = ARMOR_INT_CHEST_LIGHT_MEDIUM //defaults to a gambeson
+
+/obj/item/clothing/suit/roguetown/armor/manual/meditation/body/monk
+	name = "tough skin"
+	desc = "Do you forsake protection for enlightenment, or in repentance for past transgressions?"
 
 /obj/item/clothing/suit/roguetown/armor/manual/meditation/body/disciple //alternative repair option for sojourner.
 	name = "enduring skin"
@@ -122,10 +147,10 @@
 	</br>To give into despair and hopelessness, however, is to rob all meaning from His sacrifice. \
 	</br>Heaven's gate closed to us long ago, yet His children persist; as as long as they do, so must I. \
 	</br>Happiness must be fought for."
-	armor = ARMOR_PADDED
+	repair_fraction = 0.35 //Single layer, so back to default rate.
 	max_integrity = ARMOR_INT_CHEST_LIGHT_MASTER //a heavy gambeson.
 
-/obj/item/clothing/suit/roguetown/armor/manual/meditation/body/easttats //Only for roles with Honorbound, as the restrictions offset the better head coverage.
+/obj/item/clothing/suit/roguetown/armor/manual/meditation/body/easttats //Only for roles with Honorbound, as the restrictions offset the better head coverage & repair rate.
 	icon_state = "easttats"
 	icon = 'icons/roguetown/clothing/shirts.dmi'
 	mob_overlay_icon = 'icons/roguetown/clothing/onmob/shirts.dmi'
@@ -133,6 +158,7 @@
 	body_parts_covered = COVERAGE_FULL | COVERAGE_HEAD | NECK //This does not cover eyes/nose/mouth. Use a mask.
 	body_parts_inherent = COVERAGE_FULL | COVERAGE_HEAD | NECK
 	//allowed_race = NON_DWARVEN_RACE_TYPES
+	repair_fraction = 0.35 //It fully mends within a 30s meditation cycle.
 	repairmsg_end = "The tattoos flow more calmly, as the meditation renews their strength."
 	repairmsg_continue = "The tattoos mend some of their abuse..."
 
@@ -162,8 +188,15 @@
 	body_parts_covered = COVERAGE_VEST
 	body_parts_inherent = COVERAGE_VEST
 	blocksound = SOFTHIT
+	armor = ARMOR_LEATHER
+	max_integrity = ARMOR_INT_CHEST_LIGHT_MASTER //defaults to a leather armor
 
-/obj/item/clothing/suit/roguetown/armor/manual/meditation/chest/easttats
+/obj/item/clothing/suit/roguetown/armor/manual/meditation/chest/monk
+	name = "tough chest"
+	desc = "Do you forsake protection for enlightenment, or in repentance for past transgressions?"
+
+/obj/item/clothing/suit/roguetown/armor/manual/meditation/chest/easttats //Again, only for honorbound roles.
+	repair_fraction = 0.35
 	repairmsg_end = "The tattoos flow more calmly, as the meditation renews their strength."
 	repairmsg_continue = "The tattoos mend some of their abuse..."
 
@@ -174,10 +207,8 @@
 	max_integrity = ARMOR_INT_CHEST_PLATE_BRIGANDINE - ARMOR_INT_CHEST_PLATE_BRIGANDINE_WEIGHT_MODIFIER //Identical to a suit of light brig.
 
 /obj/item/clothing/suit/roguetown/armor/manual/meditation/chest/easttats/mistwalker
-	name = "seon-mul core"
+	name = "seon-mul core" //Baseline for shoring up chest integ, less flashy than ruma since mistwalker power budget is in Journey's End.
 	desc = "The flowing clouds of the Ruma are but fleeting shadow across the plains, pale imitation of Xinyi's spiritual alchemy. Imperfect, impotent. Their legend is one writ in avarice and hate.</br></br>Recount yours in love."
-	armor = ARMOR_LEATHER
-	max_integrity = ARMOR_INT_CHEST_LIGHT_MASTER //A leather armor.
 
 
 /*
@@ -185,7 +216,7 @@
  */
 
 /obj/item/clothing/suit/roguetown/armor/manual/tool
-	repair_fraction = 0.35 //35% per 7s of sewing, ~21s to full. Have to mend both layers seperately.
+	repair_fraction = 0.35 //35% per 7s of sewing, ~21s to full. Have to mend both layers seperately, so ~42s total.
 	var/list/repair_items[] = list(
 		/obj/item/needle = 'sound/foley/sewflesh.ogg',
 		/obj/item/needle/thorn = 'sound/foley/sewflesh.ogg',
@@ -377,12 +408,6 @@
 /obj/item/clothing/suit/roguetown/armor/manual/emote/prayer
 	repair_emotes = list("pray")
 
-/obj/item/clothing/suit/roguetown/armor/manual/emote/prayer/monk
-	name = "tough skin"
-	desc = "Do you forsake protection for enlightenment, or in repentance for past transgressions?"
-	armor = ARMOR_PADDED
-	max_integrity = ARMOR_INT_CHEST_LIGHT_BASE //A light gambeson.
-
 /*
  * REST ARMOUR
  */
@@ -447,7 +472,6 @@
 /obj/item/clothing/suit/roguetown/armor/manual/resting/body/thug
 	name = "calloused skin"
 	desc = "A brawler's hide, thickened by a hard life. A spell of rest is enough to knit it whole again."
-	max_integrity = ARMOR_INT_CHEST_LIGHT_BASE //a light gambeson.
 
 /obj/item/clothing/suit/roguetown/armor/manual/resting/body/barbarian
 	name = "hardened skin"
@@ -473,12 +497,6 @@
 /obj/item/clothing/suit/roguetown/armor/manual/resting/chest/thug
 	name = "calloused chest"
 	desc = "A brawler's hide, thickened by a hard life. A spell of rest is enough to knit it whole again."
-	max_integrity = ARMOR_INT_CHEST_LIGHT_BASE //A leather armor with light gambeson integ.
-
-/obj/item/clothing/suit/roguetown/armor/manual/resting/chest/monk
-	name = "tough chest"
-	desc = "Do you forsake protection for enlightenment, or in repentance for past transgressions?"
-	max_integrity = ARMOR_INT_CHEST_LIGHT_BASE //A leather armor with light gambeson integ.
 
 /obj/item/clothing/suit/roguetown/armor/manual/resting/chest/barbarian
 	name = "hardened chest"

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
@@ -67,15 +67,17 @@
 		var/weapons = list("Penance - Unarmored","Pugilist","Katar","Knuckledusters","Quarterstaff")
 		var/weapon_choice = input(H, "Choose your weapon.", "TAKE UP ARMS") as anything in weapons
 		switch(weapon_choice)
-			if("Penance - Unarmored") // Loses Dodge Expert, gains Enduring and a weaker Skin Armor.
+			if("Penance - Unarmored") // Loses Dodge Expert, gains Enduring, swaps light armor for skin armor.
 				ADD_TRAIT(H, TRAIT_NOPAINSTUN, JOB_TRAIT)
-				H.change_stat(STATKEY_LCK, 1) // better pity bonus
+				H.change_stat(STATKEY_CON, 1)
 				if(HAS_TRAIT(H, TRAIT_PSYDONIAN_GRIT))
-					armor = /obj/item/clothing/suit/roguetown/armor/manual/tool/needle/chest/monke //a leather armor. Bonus durability over other monks, but you have to stitch it up.
+					armor = /obj/item/clothing/suit/roguetown/armor/manual/tool/needle/chest/monke //a leather armor. Sewing repair.
 					shirt = /obj/item/clothing/suit/roguetown/armor/manual/tool/needle/body/monke //a gambeson.
+					H.adjust_skillrank_up_to(/datum/skill/craft/sewing, SKILL_LEVEL_NOVICE, TRUE) //since enduring makes psydonic willpower redundant.
+					H.adjust_skillrank_up_to(/datum/skill/misc/medicine, SKILL_LEVEL_NOVICE, TRUE)
 				else
-					armor = /obj/item/clothing/suit/roguetown/armor/manual/resting/chest/monk //leather armor with light gambeson integ, this one needs resting.
-					shirt = /obj/item/clothing/suit/roguetown/armor/manual/emote/prayer/monk //a light gambeson, repaired by praying.
+					armor = /obj/item/clothing/suit/roguetown/armor/manual/meditation/chest/monk //a leather armor. Meditation repair.
+					shirt = /obj/item/clothing/suit/roguetown/armor/manual/meditation/body/monk //a gambeson.
 				H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, SKILL_LEVEL_EXPERT, TRUE)
 				H.adjust_skillrank_up_to(/datum/skill/combat/wrestling, SKILL_LEVEL_EXPERT, TRUE)
 				gloves = /obj/item/clothing/gloves/roguetown/bandages/weighted

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/thug.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/thug.dm
@@ -191,8 +191,8 @@
 	backr = /obj/item/storage/backpack/rogue/satchel
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
 	neck = /obj/item/storage/belt/rogue/pouch/coins/poor
-	armor = /obj/item/clothing/suit/roguetown/armor/manual/resting/chest/thug //leather armor with light gambeson integ.
-	shirt = /obj/item/clothing/suit/roguetown/armor/manual/resting/body/thug //a light gambeson.
+	armor = /obj/item/clothing/suit/roguetown/armor/manual/resting/chest/thug //a leather armor.
+	shirt = /obj/item/clothing/suit/roguetown/armor/manual/resting/body/thug //a gambeson.
 	backpack_contents = list(
 				/obj/item/rogueweapon/huntingknife = 1,
 				/obj/item/recipe_book/leatherworking = 1,


### PR DESCRIPTION
## About The Pull Request

Another followup to https://github.com/Azure-Peak/Azure-Peak/pull/8417, this one focused on touching up the weakest of the skin armors on adventurer monk (nonpsydonic) and towner big fella. These were initially statted in a very conservative manner due to the roles impacted / miracles & unarmed being involved, but testing and feedback has shown they kinda just suck at that benchmark, and that tradeoffs are already present in other areas (ie, the monk lacks Thickblooded as a counterweight to its miracle healing, and loses Dodge Expert to gain Enduring).

So both of those are just getting set to the baseline gambeson + chest-only leather armor that the other advents are at.

In addition, the mix of prayer and resting repair for the monk was a bit awkward, so the repair for its skin layers has been unified on meditation (on your patron's teachings, perhaps), at ~25% per 10 seconds, or 40 seconds total to repair from broken.

The psydonic monk no longer has bonus integrity as it's token refund for the fact that Enduring kind of makes Psydonic Willpower redundant. Instead it gets novice medicine + sewing skills, thematic to the fact that they will be stitching their skin up frequently.


## Testing Evidence

Non-psydonic monk skins
<img width="570" height="280" alt="image" src="https://github.com/user-attachments/assets/c58c53d5-b702-48f1-bba5-66784a581803" />
<img width="566" height="281" alt="image" src="https://github.com/user-attachments/assets/5179ca8f-8753-4852-a7d2-4ececc1a9013" />

Thug skins
<img width="562" height="279" alt="image" src="https://github.com/user-attachments/assets/221d9f4e-b08a-436b-af55-ba60cde3f951" />
<img width="569" height="278" alt="image" src="https://github.com/user-attachments/assets/cf9facea-2326-4834-bbc6-8421e11a804f" />

Psydonic monk skills
<img width="278" height="323" alt="image" src="https://github.com/user-attachments/assets/8d61b68e-cee2-423a-bee2-01c1a5358626" />


## Why It's Good For The Game

Makes skin armor on these roles a viable (yet not optimal) alternative to light armor.
Makes managing skin armor repair on monks less painful.

## Changelog

:cl:
balance: Towner big fella skin armor buffed to the usual gambeson + leather armor benchmark.
balance: Adventurer monk (non-psydonic) skin armor buffed to the usual gambeson + leather armor benchmark, and adjusted to use meditation repair (25% per 10s, ~40s total), rather than the two layers differing between prayer and resting repair.
balance: Adventurer monk (psydonic) no longer has bonus integrity over other monks to make up for Enduring rendering Psydonic Willpower redundant. Instead gains novice sewing + medicine skills.
/:cl:
