### PR TITLE
fixed ANOTHER necromancer exploit

### DIFF
--- a/code/modules/spells/roguetown/necromancer/raise_undead_formation.dm
+++ b/code/modules/spells/roguetown/necromancer/raise_undead_formation.dm
@@ -71,6 +71,10 @@
 
 		var/mob/living/simple_animal/hostile/rogue/skeleton/S = new skeleton_type(spawn_turf, owner, cabal_affine)
 
+		for(var/obj/item/I as anything in S.loot)
+			if(ispath(I, /obj/item) && I::smeltresult)
+				S.loot -= I // previously, people could infinitely farm iron gear to sell/scrap off of their own skellies
+
 		if(!S)
 			continue
 


### PR DESCRIPTION
## About The Pull Request
apparently necromancer simplemob skellies were also dropping iron-smeltable full-value gear. sigh. now anything with a smeltresult gets removed from their loot on summon; ppl could (and did) use this to farm their own skellies

## Testing Evidence
<img width="307" height="202" alt="image" src="https://github.com/user-attachments/assets/e48c62f7-8cdc-41bd-8cb4-8f7cebda1b44" />

## Why It's Good For The Game
we love necromancer and its incredible potential for bad faith gameplay

## Changelog

:cl:
fix: Necromancer simplemob skeletons no longer drop smeltable/sellable iron gear
/:cl:

