### PR TITLE
Terrorbog Desertation Package

### DIFF
--- a/code/modules/clothing/rogueclothes/headwear/adjusthoods.dm
+++ b/code/modules/clothing/rogueclothes/headwear/adjusthoods.dm
@@ -67,6 +67,12 @@
 	desc = "A head's best friend, worn and proven by aeon's grip, its once-vibrant colors long worn out after its former owner deserted their post."
 	color = "#7a8138"
 
+/obj/item/clothing/head/roguetown/roguehood/bogman/black
+	color = CLOTHING_BLACK
+
+/obj/item/clothing/head/roguetown/roguehood/bogman/brown
+	color = "#997C4F"
+
 /obj/item/clothing/head/roguetown/roguehood/black
 	color = CLOTHING_BLACK
 

--- a/code/modules/clothing/rogueclothes/headwear/adjusthoods.dm
+++ b/code/modules/clothing/rogueclothes/headwear/adjusthoods.dm
@@ -63,6 +63,8 @@
 	color = CLOTHING_RED
 
 /obj/item/clothing/head/roguetown/roguehood/bogman
+	name = "bogman's hood"
+	desc = "A head's best friend, worn and proven by aeon's grip, its once-vibrant colors long worn out after its former owner deserted their post."
 	color = "#7a8138"
 
 /obj/item/clothing/head/roguetown/roguehood/black

--- a/code/modules/clothing/rogueclothes/headwear/adjusthoods.dm
+++ b/code/modules/clothing/rogueclothes/headwear/adjusthoods.dm
@@ -62,6 +62,9 @@
 /obj/item/clothing/head/roguetown/roguehood/red
 	color = CLOTHING_RED
 
+/obj/item/clothing/head/roguetown/roguehood/bogman
+	color = "#7a8138"
+
 /obj/item/clothing/head/roguetown/roguehood/black
 	color = CLOTHING_BLACK
 

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/deserter.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/deserter.dm
@@ -226,8 +226,9 @@
 		/datum/skill/misc/swimming = SKILL_LEVEL_JOURNEYMAN, // Worse at swimming than the above class.
 		/datum/skill/misc/reading = SKILL_LEVEL_NOVICE,
 		/datum/skill/misc/athletics = SKILL_LEVEL_EXPERT,
-		/datum/skill/misc/riding = SKILL_LEVEL_APPRENTICE, // Able to steal saigas for some hit and runs, doesn't start w/ one.
 		/datum/skill/misc/tracking = SKILL_LEVEL_NOVICE,
+		/datum/skill/craft/carpentry = SKILL_LEVEL_APPRENTICE, //So you can repair your heater shield + build in the bogs
+		/datum/skill/labor/lumberjacking = SKILL_LEVEL_APPRENTICE, //Ditto
 	)
 
 /datum/outfit/job/roguetown/wretch/deserter/pre_equip(mob/living/carbon/human/H)
@@ -239,14 +240,14 @@
 		switch(weapon_choice)
 			if("Warhammer & Shield")
 				beltr = /obj/item/rogueweapon/mace/warhammer/steel
-				backl = /obj/item/rogueweapon/shield/iron
+				backl = /obj/item/rogueweapon/shield/heater
 			if("Sabre & Shield")
 				beltr = /obj/item/rogueweapon/scabbard/sword
 				r_hand = /obj/item/rogueweapon/sword/sabre
-				backl = /obj/item/rogueweapon/shield/wood
+				backl = /obj/item/rogueweapon/shield/heater
 			if("Axe & Shield")
 				beltr = /obj/item/rogueweapon/stoneaxe/woodcut/steel
-				backl = /obj/item/rogueweapon/shield/iron
+				backl = /obj/item/rogueweapon/shield/heater
 			if("Billhook")
 				r_hand = /obj/item/rogueweapon/spear/billhook
 				backl = /obj/item/rogueweapon/scabbard/gwstrap

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/deserter.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/deserter.dm
@@ -281,7 +281,6 @@
 			"Pigface Bascinet"		= /obj/item/clothing/head/roguetown/helmet/bascinet/pigface,
 			"Hounskull Bascinet"	= /obj/item/clothing/head/roguetown/helmet/bascinet/pigface/hounskull,
 			"Klappvisier Bascinet"	= /obj/item/clothing/head/roguetown/helmet/bascinet/etruscan,
-			"Savoyard Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/guard,
 			"Volfskulle Bascinet"		= /obj/item/clothing/head/roguetown/helmet/heavy/volfplate,
 			"Visored Sallet"		= /obj/item/clothing/head/roguetown/helmet/sallet/visored,
 			"Snouted Visored Sallet"		= /obj/item/clothing/head/roguetown/helmet/sallet/visored/snouted,

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/deserter.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/deserter.dm
@@ -32,6 +32,7 @@
 		/datum/skill/misc/athletics = SKILL_LEVEL_EXPERT,
 		/datum/skill/misc/climbing = SKILL_LEVEL_EXPERT,
 		/datum/skill/misc/riding = SKILL_LEVEL_EXPERT,
+		/datum/skill/misc/medicine = SKILL_LEVEL_APPRENTICE, //no miracles to deal w/ stabs through plate armor
 		/datum/skill/misc/reading = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/hunting = SKILL_LEVEL_APPRENTICE,
 	)
@@ -227,6 +228,7 @@
 		/datum/skill/misc/reading = SKILL_LEVEL_NOVICE,
 		/datum/skill/misc/athletics = SKILL_LEVEL_EXPERT,
 		/datum/skill/misc/tracking = SKILL_LEVEL_NOVICE,
+		/datum/skill/misc/medicine = SKILL_LEVEL_APPRENTICE, //No miracles to deal w/ stabs through plate/maile armor
 		/datum/skill/craft/carpentry = SKILL_LEVEL_APPRENTICE, //So you can repair your heater shield + build in the bogs
 		/datum/skill/labor/lumberjacking = SKILL_LEVEL_APPRENTICE, //Ditto
 	)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/deserter.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/deserter.dm
@@ -276,6 +276,7 @@
 		head = helmets[helmchoice]
 
 		var/armors = list(
+			"Cuirass"			= /obj/item/clothing/suit/roguetown/armor/plate/cuirass,
 			"Brigandine"		= /obj/item/clothing/suit/roguetown/armor/brigandine,
 			"Half-Plate"		= /obj/item/clothing/suit/roguetown/armor/plate/iron,
 			"Scalemail"			= /obj/item/clothing/suit/roguetown/armor/plate/scale,
@@ -283,13 +284,24 @@
 		var/armorchoice = input(H, "Choose your armor.", "TAKE UP ARMOR") as anything in armors
 		armor = armors[armorchoice]
 
+		var/cloaks = list("Bog Green","Black","Brown and Longcoat")
+		var/cloak_choice = input(H, "Choose your cloak.", "FOR THE BOG") as anything in cloaks
+		switch(cloak_choice)
+			if("Bog Green")
+				cloak = /obj/item/clothing/cloak/tabard/stabard/bog
+				mask = /obj/item/clothing/head/roguetown/roguehood/bogman
+			if("Black")
+				cloak = /obj/item/clothing/cloak/tabard/stabard/dungeon
+				mask = /obj/item/clothing/head/roguetown/roguehood/bogman/black
+			if("Brown and Longcoat")
+				cloak = /obj/item/clothing/suit/roguetown/armor/longcoat/brown
+				mask = /obj/item/clothing/head/roguetown/roguehood/bogman/brown
+
 		wretch_select_bounty(H)
 
-	mask = /obj/item/clothing/head/roguetown/roguehood/bogman
 	shirt = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk
 	pants = /obj/item/clothing/under/roguetown/chainlegs
 	neck = /obj/item/clothing/neck/roguetown/bevor
-	cloak = /obj/item/clothing/cloak/tabard/stabard/bog
 	wrists = /obj/item/clothing/wrists/roguetown/bracers
 	gloves = /obj/item/clothing/gloves/roguetown/chain
 	shoes = /obj/item/clothing/shoes/roguetown/boots/armor/iron

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/deserter.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/deserter.dm
@@ -264,14 +264,6 @@
 
 	add_verb(H, /mob/proc/haltyell) //Ex-Garrisoner
 
-	add_verb(H, list(/mob/living/carbon/human/mind/proc/setorders)) //if its problematic, trim this down. Brotherhood Recruitment is a must.
-	if(H.mind)
-		H.mind.AddSpell(new /datum/action/cooldown/spell/order/movemovemove)
-		H.mind.AddSpell(new /datum/action/cooldown/spell/order/takeaim)
-		H.mind.AddSpell(new /datum/action/cooldown/spell/order/hold)
-		H.mind.AddSpell(new /datum/action/cooldown/spell/order/onfeet)
-		H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/convertrole/brotherhood)
-
 		/*
 		meant to be less knightly-helmets and more in-line with banditry, brigand loadouts and such so, so no armlets
 

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/deserter.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/deserter.dm
@@ -194,8 +194,8 @@
 
 	class_select_category = CLASS_CAT_WARRIOR
 	category_tags = list(CTAG_WRETCH)
-	maximum_possible_slots = 5 // very solid, statline but not super unique all-rounder. We don't want more than 5 people in the terrorbogs immune to it without a hag's intervention at worst.
-	//frankly, this is probably not going to happen consistantly. If it does uhh, honestly. hilarious.
+	//frankly, this is probably not going to happen consistantly with a massive tide of bogmen. If it does uhh, honestly. hilarious.
+	//Worst case nuke this to 5 slots, or 4. If it becomes a problem.
 
 	subclass_stashed_items = list(
 		"Armor Plates" =	/obj/item/repair_kit/metal,
@@ -271,10 +271,17 @@
 		H.mind.AddSpell(new /datum/action/cooldown/spell/order/onfeet)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/convertrole/brotherhood)
 
+		/*
+		meant to be less knightly-helmets and more in-line with banditry, brigand loadouts and such so, so no armlets
+
+		we limit this so you have to look moderately evil or suspiciously wearing old-style helmets
+		*/
 		var/helmets = list(
 			"Pigface Bascinet"		= /obj/item/clothing/head/roguetown/helmet/bascinet/pigface,
 			"Hounskull Bascinet"	= /obj/item/clothing/head/roguetown/helmet/bascinet/pigface/hounskull,
 			"Klappvisier Bascinet"	= /obj/item/clothing/head/roguetown/helmet/bascinet/etruscan,
+			"Savoyard Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/guard,
+			"Volfskulle Bascinet"		= /obj/item/clothing/head/roguetown/helmet/heavy/volfplate,
 			"Visored Sallet"		= /obj/item/clothing/head/roguetown/helmet/sallet/visored,
 			"Snouted Visored Sallet"		= /obj/item/clothing/head/roguetown/helmet/sallet/visored/snouted,
 			"Knight's Helmet"	= /obj/item/clothing/head/roguetown/helmet/heavy/knight/old,

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/deserter.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/deserter.dm
@@ -259,8 +259,8 @@
 				backl = /obj/item/rogueweapon/scabbard/gwstrap
 			if("Crossbow")
 				H.adjust_skillrank_up_to(/datum/skill/combat/crossbows, SKILL_LEVEL_EXPERT, TRUE)
-				r_hand = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
-				backl = /obj/item/quiver/bolt/standard
+				backl = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
+				beltr = /obj/item/quiver/bolt/standard
 
 	add_verb(H, /mob/proc/haltyell) //Ex-Garrisoner
 

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/deserter.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/deserter.dm
@@ -6,8 +6,8 @@
 	outfit = /datum/outfit/job/roguetown/wretch/deserter
 	class_select_category = CLASS_CAT_WARRIOR
 	category_tags = list(CTAG_WRETCH)
-	traits_applied = list(TRAIT_HEAVYARMOR, TRAIT_NOBLE)
-	maximum_possible_slots = 2 //Ideal role for fraggers. Better to limit it.
+	traits_applied = list(TRAIT_HEAVYARMOR, TRAIT_NOBLE, TRAIT_BOGWALKER)
+	maximum_possible_slots = 2 //Ideal role for fraggers. Better to limit it. Powerful like T4 heretic w/ heretical plate armor in that they're a bog-blessed, plate user, w/ orders, riding and expert in most weaponry.
 
 	cmode_music = 'sound/music/cmode/antag/combat_thewall.ogg' // same as new hedgeknight music
 	// Deserter are the knight-equivalence. They get a balanced, straightforward 2 2 3 statspread to endure and overcome.
@@ -31,8 +31,9 @@
 		/datum/skill/combat/unarmed = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/athletics = SKILL_LEVEL_EXPERT,
 		/datum/skill/misc/climbing = SKILL_LEVEL_EXPERT,
-		/datum/skill/misc/riding = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/misc/riding = SKILL_LEVEL_EXPERT,
 		/datum/skill/misc/reading = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/misc/hunting = SKILL_LEVEL_APPRENTICE,
 	)
 	subclass_virtues = list(
 		/datum/virtue/utility/riding
@@ -45,6 +46,9 @@
 	..()
 	to_chat(H, span_warning("You were once a venerated and revered knight - now, a traitor who abandoned your liege. You lyve the lyfe of an outlaw, shunned and looked down upon by society."))
 	H.dna.species.soundpack_m = GLOB.voice_packs[/datum/voicepack/male/warrior]
+
+	add_verb(H, /mob/proc/haltyell) //Ex-Garrisoner
+
 	add_verb(H, list(/mob/living/carbon/human/mind/proc/setorders))
 	if(H.mind)
 		H.mind.AddSpell(new /datum/action/cooldown/spell/order/movemovemove)
@@ -65,7 +69,9 @@
 			"Samshir",
 			"Ssangsudo",
 			"Shashka + Shield",
-			"Steel Poleaxe"
+			"Steel Poleaxe",
+			"Steel Flameberge",
+			"Grand Mace"
 		)
 		var/weapon_choice = input(H, "Choose your weapon.", "TAKE UP ARMS") as anything in weapons
 		H.set_blindness(0)
@@ -107,6 +113,12 @@
 			if("Steel Poleaxe")
 				r_hand = /obj/item/rogueweapon/greataxe/steel/knight
 				backr = /obj/item/rogueweapon/scabbard/gwstrap
+			if("Steel Flameberge")
+				r_hand = /obj/item/rogueweapon/greatsword/grenz/flamberge
+				backr = /obj/item/rogueweapon/scabbard/gwstrap
+			if("Grand Mace")
+				r_hand = /obj/item/rogueweapon/mace/goden/steel
+				backl = /obj/item/rogueweapon/scabbard/gwstrap
 
 		var/helmets = list(
 			"Pigface Bascinet"	= /obj/item/clothing/head/roguetown/helmet/bascinet/pigface,
@@ -140,10 +152,11 @@
 			head = helmets[helmchoice]
 
 		var/armors = list(
+			"Fullplate"			= /obj/item/clothing/suit/roguetown/armor/plate/full,
+			"Fluted Fullplate"		= /obj/item/clothing/suit/roguetown/armor/plate/full/fluted,
 			"Brigandine"		= /obj/item/clothing/suit/roguetown/armor/brigandine,
-			"Coat of Plates"	= /obj/item/clothing/suit/roguetown/armor/brigandine/heavy,
-			"Steel Cuirass"		= /obj/item/clothing/suit/roguetown/armor/plate/cuirass,
-			"Fluted Cuirass"	= /obj/item/clothing/suit/roguetown/armor/plate/cuirass/fluted,
+			"Coat of Plates"		= /obj/item/clothing/suit/roguetown/armor/brigandine/heavy,
+			"Half-Plate"		= /obj/item/clothing/suit/roguetown/armor/plate,
 			"Lamellar Scalemail"		= /obj/item/clothing/suit/roguetown/armor/plate/scale/steppe,
 			"Haraate Brigandine"		= /obj/item/clothing/suit/roguetown/armor/brigandine/haraate,
 		)
@@ -151,12 +164,13 @@
 		armor = armors[armorchoice]
 		wretch_select_bounty(H)
 	gloves = /obj/item/clothing/gloves/roguetown/plate
-	pants = /obj/item/clothing/under/roguetown/chainlegs
+	pants = /obj/item/clothing/under/roguetown/platelegs
 	neck = /obj/item/clothing/neck/roguetown/bevor
+	cloak = /obj/item/clothing/cloak/tabard/black
 	shirt = /obj/item/clothing/suit/roguetown/armor/chainmail
 	wrists = /obj/item/clothing/wrists/roguetown/bracers
 	shoes = /obj/item/clothing/shoes/roguetown/boots/armor
-	belt = /obj/item/storage/belt/rogue/leather/steel
+	belt = /obj/item/storage/belt/rogue/leather/steel/tasset //less meta
 	beltl = /obj/item/storage/belt/rogue/pouch/coins/poor
 	backl = /obj/item/storage/backpack/rogue/satchel //gwstraps landing on backr asyncs with backpack_contents
 	backpack_contents = list(
@@ -171,11 +185,11 @@
 	name = "Deserter"
 	tutorial = "You had your post. You had your duty. Dissatisfied, lacking in morale, or simply thinking yourself better than it. - You decided to walk. Now it follows you everywhere you go."
 	outfit = /datum/outfit/job/roguetown/wretch/desertergeneric
-	maximum_possible_slots = 2 //Ideal role for fraggers. Better to limit it.
+	//uncapped, BOG. BOG. BOG. (Jokes aside, their main strength is bogwalker, downside is no D/E + heretical weaponry + miracles + high sneak + whatever else other wretches have)
 
-	cmode_music = 'sound/music/cmode/antag/combat_thewall.ogg' // same as new hedgeknight music
+	cmode_music = 'sound/music/cmode/antag/combat_cutpurse.ogg' // same as regular bandits
 	// Slightly more rounded. These can be nudged as needed.
-	traits_applied = list(TRAIT_MEDIUMARMOR)
+	traits_applied = list(TRAIT_MEDIUMARMOR, TRAIT_BOGWALKER)
 	subclass_stats = list(
 		STATKEY_STR = 2,
 		STATKEY_WIL = 2,
@@ -197,7 +211,7 @@
 		/datum/skill/misc/swimming = SKILL_LEVEL_JOURNEYMAN, // Worse at swimming than the above class.
 		/datum/skill/misc/reading = SKILL_LEVEL_NOVICE,
 		/datum/skill/misc/athletics = SKILL_LEVEL_EXPERT,
-		/datum/skill/misc/riding = SKILL_LEVEL_JOURNEYMAN, // That saiga was stolen. Probably.
+		/datum/skill/misc/riding = SKILL_LEVEL_APPRENTICE, // Able to steal saigas for some hit and runs.
 		/datum/skill/misc/tracking = SKILL_LEVEL_NOVICE,
 	)
 /datum/outfit/job/roguetown/wretch/desertergeneric/pre_equip(mob/living/carbon/human/H)
@@ -208,7 +222,7 @@
 		H.set_blindness(0)
 		switch(weapon_choice)
 			if("Warhammer & Shield")
-				beltr = /obj/item/rogueweapon/mace/warhammer
+				beltr = /obj/item/rogueweapon/mace/warhammer/steel
 				backl = /obj/item/rogueweapon/shield/iron
 			if("Sabre & Shield")
 				beltr = /obj/item/rogueweapon/scabbard/sword
@@ -230,13 +244,17 @@
 				H.adjust_skillrank_up_to(/datum/skill/combat/crossbows, SKILL_LEVEL_EXPERT, TRUE)
 				r_hand = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
 				backl = /obj/item/quiver/bolt/standard
-	add_verb(H, list(/mob/living/carbon/human/mind/proc/setorders))
+
+	add_verb(H, /mob/proc/haltyell) //Ex-Garrisoner
+
+	add_verb(H, list(/mob/living/carbon/human/mind/proc/setorders)) //if its problematic, trim this down. Brotherhood Recruitment is a must.
 	if(H.mind)
 		H.mind.AddSpell(new /datum/action/cooldown/spell/order/movemovemove)
 		H.mind.AddSpell(new /datum/action/cooldown/spell/order/takeaim)
 		H.mind.AddSpell(new /datum/action/cooldown/spell/order/hold)
 		H.mind.AddSpell(new /datum/action/cooldown/spell/order/onfeet)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/convertrole/brotherhood)
+
 		var/helmets = list(
 			"Pigface Bascinet"		= /obj/item/clothing/head/roguetown/helmet/bascinet/pigface,
 			"Hounskull Bascinet"	= /obj/item/clothing/head/roguetown/helmet/bascinet/pigface/hounskull,
@@ -264,7 +282,7 @@
 	shirt = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk
 	pants = /obj/item/clothing/under/roguetown/chainlegs
 	neck = /obj/item/clothing/neck/roguetown/bevor
-	cloak = /obj/item/clothing/cloak/tabard/stabard/surcoat
+	cloak = /obj/item/clothing/cloak/tabard/stabard/bog
 	wrists = /obj/item/clothing/wrists/roguetown/bracers
 	gloves = /obj/item/clothing/gloves/roguetown/chain
 	shoes = /obj/item/clothing/shoes/roguetown/boots/armor/iron

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/deserter.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/deserter.dm
@@ -1,9 +1,9 @@
-/datum/advclass/wretch/deserter
+/datum/advclass/wretch/deserter_knight
 	name = "Disgraced Knight"
 	tutorial = "You were once a venerated and revered knight - now, a traitor who abandoned your liege. You lyve the lyfe of an outlaw, shunned and looked down upon by society."
 	allowed_sexes = list(MALE, FEMALE)
 
-	outfit = /datum/outfit/job/roguetown/wretch/deserter
+	outfit = /datum/outfit/job/roguetown/wretch/deserter_knight
 	class_select_category = CLASS_CAT_WARRIOR
 	category_tags = list(CTAG_WRETCH)
 	traits_applied = list(TRAIT_HEAVYARMOR, TRAIT_NOBLE, TRAIT_BOGWALKER)
@@ -42,7 +42,7 @@
 		"Armor Plates" =	/obj/item/repair_kit/metal,
 	)
 
-/datum/outfit/job/roguetown/wretch/deserter/pre_equip(mob/living/carbon/human/H)
+/datum/outfit/job/roguetown/wretch/deserter_knight/pre_equip(mob/living/carbon/human/H)
 	..()
 	to_chat(H, span_warning("You were once a venerated and revered knight - now, a traitor who abandoned your liege. You lyve the lyfe of an outlaw, shunned and looked down upon by society."))
 	H.dna.species.soundpack_m = GLOB.voice_packs[/datum/voicepack/male/warrior]
@@ -181,11 +181,15 @@
 		/obj/item/reagent_containers/glass/bottle/alchemical/healthpot = 1,	//Small health vial
 		)
 
-/datum/advclass/wretch/deserter/generic
+/datum/advclass/wretch/deserter
 	name = "Deserter"
 	tutorial = "You had your post. You had your duty. Dissatisfied, lacking in morale, or simply thinking yourself better than it. - You decided to walk. Now it follows you everywhere you go."
-	outfit = /datum/outfit/job/roguetown/wretch/desertergeneric
+	outfit = /datum/outfit/job/roguetown/wretch/deserter
 	//uncapped, BOG. BOG. BOG. (Jokes aside, their main strength is bogwalker, downside is no D/E + heretical weaponry + miracles + high sneak + whatever else other wretches have)
+
+	subclass_stashed_items = list(
+		"Armor Plates" =	/obj/item/repair_kit/metal,
+	)
 
 	cmode_music = 'sound/music/cmode/antag/combat_cutpurse.ogg' // same as regular bandits
 	// Slightly more rounded. These can be nudged as needed.
@@ -211,10 +215,11 @@
 		/datum/skill/misc/swimming = SKILL_LEVEL_JOURNEYMAN, // Worse at swimming than the above class.
 		/datum/skill/misc/reading = SKILL_LEVEL_NOVICE,
 		/datum/skill/misc/athletics = SKILL_LEVEL_EXPERT,
-		/datum/skill/misc/riding = SKILL_LEVEL_APPRENTICE, // Able to steal saigas for some hit and runs.
+		/datum/skill/misc/riding = SKILL_LEVEL_APPRENTICE, // Able to steal saigas for some hit and runs, doesn't start w/ one.
 		/datum/skill/misc/tracking = SKILL_LEVEL_NOVICE,
 	)
-/datum/outfit/job/roguetown/wretch/desertergeneric/pre_equip(mob/living/carbon/human/H)
+
+/datum/outfit/job/roguetown/wretch/deserter/pre_equip(mob/living/carbon/human/H)
 	..()
 	if(H.mind)
 		var/weapons = list("Warhammer & Shield","Sabre & Shield","Axe & Shield","Billhook","Greataxe","Halberd","Crossbow")
@@ -261,10 +266,7 @@
 			"Klappvisier Bascinet"	= /obj/item/clothing/head/roguetown/helmet/bascinet/etruscan,
 			"Visored Sallet"		= /obj/item/clothing/head/roguetown/helmet/sallet/visored,
 			"Snouted Visored Sallet"		= /obj/item/clothing/head/roguetown/helmet/sallet/visored/snouted,
-			"Sugarloaf Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/bucket/crusader,
-			"Knight's Armet"	= /obj/item/clothing/head/roguetown/helmet/heavy/knight,
 			"Knight's Helmet"	= /obj/item/clothing/head/roguetown/helmet/heavy/knight/old,
-			"Knight's Greatplumed Armet"		= /obj/item/clothing/head/roguetown/helmet/heavy/knight/greatplume,
 		)
 		var/helmchoice = input(H, "Choose your Helm.", "TAKE UP HELMS") as anything in helmets
 		head = helmets[helmchoice]
@@ -279,6 +281,7 @@
 
 		wretch_select_bounty(H)
 
+	mask = /obj/item/clothing/head/roguetown/roguehood/bogman
 	shirt = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk
 	pants = /obj/item/clothing/under/roguetown/chainlegs
 	neck = /obj/item/clothing/neck/roguetown/bevor

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/deserter.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/deserter.dm
@@ -189,7 +189,8 @@
 	name = "Deserter"
 	tutorial = "You had your post. You had your duty. Dissatisfied, lacking in morale, or simply thinking yourself better than it. - You decided to walk. Now it follows you everywhere you go."
 	outfit = /datum/outfit/job/roguetown/wretch/deserter
-	//uncapped, BOG. BOG. BOG. (Jokes aside, their main strength is bogwalker, downside is no D/E + heretical weaponry + miracles + high sneak + whatever else other wretches have)
+	maximum_possible_slots = 5 // very solid, statline but not super unique all-rounder. We don't want more than 5 people in the terrorbogs immune to it without a hag's intervention at worst.
+	//frankly, this is probably not going to happen consistantly. If it does uhh, honestly. hilarious.
 
 	subclass_stashed_items = list(
 		"Armor Plates" =	/obj/item/repair_kit/metal,
@@ -212,6 +213,7 @@
 		/datum/skill/combat/axes = SKILL_LEVEL_EXPERT,
 		/datum/skill/combat/knives = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/whipsflails = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/combat/crossbows = SKILL_LEVEL_JOURNEYMAN, //Unique only case here, pick crossbow if you want to exceed in crossbows. Otherwise you're decently okay at it.
 		/datum/skill/combat/shields = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/wrestling = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/unarmed = SKILL_LEVEL_JOURNEYMAN,

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/deserter.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/deserter.dm
@@ -264,6 +264,14 @@
 
 	add_verb(H, /mob/proc/haltyell) //Ex-Garrisoner
 
+	add_verb(H, list(/mob/living/carbon/human/mind/proc/setorders)) //Kill if problematic
+	if(H.mind)
+		H.mind.AddSpell(new /datum/action/cooldown/spell/order/movemovemove)
+		H.mind.AddSpell(new /datum/action/cooldown/spell/order/takeaim)
+		H.mind.AddSpell(new /datum/action/cooldown/spell/order/hold)
+		H.mind.AddSpell(new /datum/action/cooldown/spell/order/onfeet)
+		H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/convertrole/brotherhood)
+
 		/*
 		meant to be less knightly-helmets and more in-line with banditry, brigand loadouts and such so, so no armlets
 

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/deserter.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/deserter.dm
@@ -71,7 +71,8 @@
 			"Shashka + Shield",
 			"Steel Poleaxe",
 			"Steel Flameberge",
-			"Grand Mace"
+			"Grand Mace",
+			"Polehammer"
 		)
 		var/weapon_choice = input(H, "Choose your weapon.", "TAKE UP ARMS") as anything in weapons
 		H.set_blindness(0)
@@ -118,6 +119,9 @@
 				backr = /obj/item/rogueweapon/scabbard/gwstrap
 			if("Grand Mace")
 				r_hand = /obj/item/rogueweapon/mace/goden/steel
+				backr = /obj/item/rogueweapon/scabbard/gwstrap
+			if("Polehammer")
+				r_hand = /obj/item/rogueweapon/eaglebeak
 				backr = /obj/item/rogueweapon/scabbard/gwstrap
 
 		var/helmets = list(

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/deserter.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/deserter.dm
@@ -118,7 +118,7 @@
 				backr = /obj/item/rogueweapon/scabbard/gwstrap
 			if("Grand Mace")
 				r_hand = /obj/item/rogueweapon/mace/goden/steel
-				backl = /obj/item/rogueweapon/scabbard/gwstrap
+				backr = /obj/item/rogueweapon/scabbard/gwstrap
 
 		var/helmets = list(
 			"Pigface Bascinet"	= /obj/item/clothing/head/roguetown/helmet/bascinet/pigface,

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/deserter.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/deserter.dm
@@ -188,7 +188,12 @@
 /datum/advclass/wretch/deserter
 	name = "Deserter"
 	tutorial = "You had your post. You had your duty. Dissatisfied, lacking in morale, or simply thinking yourself better than it. - You decided to walk. Now it follows you everywhere you go."
+	allowed_sexes = list(MALE, FEMALE)
+
 	outfit = /datum/outfit/job/roguetown/wretch/deserter
+
+	class_select_category = CLASS_CAT_WARRIOR
+	category_tags = list(CTAG_WRETCH)
 	maximum_possible_slots = 5 // very solid, statline but not super unique all-rounder. We don't want more than 5 people in the terrorbogs immune to it without a hag's intervention at worst.
 	//frankly, this is probably not going to happen consistantly. If it does uhh, honestly. hilarious.
 

--- a/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
@@ -32,8 +32,8 @@
 	job_traits = list(TRAIT_STEELHEARTED, TRAIT_OUTLAW, TRAIT_HERESIARCH, TRAIT_SELF_SUSTENANCE, TRAIT_ZURCH)
 	job_subclasses = list(
 		/datum/advclass/wretch/licker,
+		/datum/advclass/wretch/deserter_knight,
 		/datum/advclass/wretch/deserter,
-		/datum/advclass/wretch/deserter/generic,
 		/datum/advclass/wretch/berserker,
 		/datum/advclass/wretch/roguemage,
 		/datum/advclass/wretch/necromancer,

--- a/code/modules/mob/living/carbon/human/npc/skeleton/skeleton_bogguard.dm
+++ b/code/modules/mob/living/carbon/human/npc/skeleton/skeleton_bogguard.dm
@@ -21,6 +21,9 @@
 			head = /obj/item/clothing/head/roguetown/helmet/kettle/iron
 	neck= /obj/item/clothing/neck/roguetown/chaincoif/iron
 	cloak = /obj/item/clothing/cloak/tabard/stabard/bog
+	shoes = /obj/item/clothing/shoes/roguetown/boots/leather
+	if(prob(50))
+		shoes = /obj/item/clothing/shoes/roguetown/boots
 	switch(rand(1, 7))
 		if(1)
 			r_hand = /obj/item/rogueweapon/sword/iron

--- a/code/modules/mob/living/carbon/human/npc/skeleton/skeleton_bogguard.dm
+++ b/code/modules/mob/living/carbon/human/npc/skeleton/skeleton_bogguard.dm
@@ -12,9 +12,9 @@
 		armor = /obj/item/clothing/suit/roguetown/armor/gambeson
 		if(prob(50))
 			armor = /obj/item/clothing/suit/roguetown/armor/chainmail/iron
-	pants = /obj/item/clothing/under/roguetown/chainlegs/iron
+	pants = /obj/item/clothing/under/roguetown/trou/leather
 	if(prob(25))
-		pants = /obj/item/clothing/under/roguetown/heavy_leather_pants
+		pants = /obj/item/clothing/under/roguetown/chainlegs/iron
 	if(prob(50))//HEAD
 		head = /obj/item/clothing/head/roguetown/roguehood/bogman
 		if(prob(60))
@@ -39,7 +39,7 @@
 		if(6)
 			r_hand = /obj/item/rogueweapon/stoneaxe/woodcut
 		if(7)
-			r_hand = /obj/item/rogueweapon/flail
+			r_hand = /obj/item/rogueweapon/mace/cudgel
 			l_hand = /obj/item/rogueweapon/shield/wood
 	H.STASTR = rand(12,14)
 	H.STASPD = 8
@@ -63,16 +63,14 @@
 	backr = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve
 	backl = /obj/item/quiver/randomfill/skeleton
 	if(prob(60))//WRIST
-		wrists = /obj/item/clothing/wrists/roguetown/bracers/iron
+		wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
 	if(prob(90))//SHIRT
 		shirt = /obj/item/clothing/suit/roguetown/shirt/shortshirt/bog
 	if(prob(75))
 		armor = /obj/item/clothing/suit/roguetown/armor/gambeson
 		if(prob(50))
 			armor = /obj/item/clothing/suit/roguetown/armor/chainmail/iron
-	pants = /obj/item/clothing/under/roguetown/chainlegs/iron
-	if(prob(25))
-		pants = /obj/item/clothing/under/roguetown/heavy_leather_pants
+	pants = /obj/item/clothing/under/roguetown/trou/leather
 	if(prob(50))//HEAD
 		head = /obj/item/clothing/head/roguetown/roguehood/bogman
 		if(prob(60))
@@ -96,6 +94,7 @@
 /datum/outfit/job/roguetown/npc/skeleton/npc/bogguard/master/pre_equip(mob/living/carbon/human/H)
 	. = ..()
 	head = /obj/item/clothing/head/roguetown/helmet/bascinet/pigface/hounskull
+	mask = /obj/item/clothing/head/roguetown/roguehood/bogman
 	gloves = /obj/item/clothing/gloves/roguetown/plate
 	pants = /obj/item/clothing/under/roguetown/chainlegs/iron
 	cloak = /obj/item/clothing/cloak/tabard/stabard/bog

--- a/code/modules/mob/living/carbon/human/npc/skeleton/skeleton_bogguard.dm
+++ b/code/modules/mob/living/carbon/human/npc/skeleton/skeleton_bogguard.dm
@@ -21,8 +21,8 @@
 			if(prob(25))
 				pants = /obj/item/clothing/under/roguetown/heavy_leather_pants
 	if(prob(50))//HEAD
-		head = /obj/item/clothing/neck/roguetown/coif
-		if(prob(30))
+		head = /obj/item/clothing/head/roguetown/roguehood/bogman
+		if(prob(60))
 			head = /obj/item/clothing/head/roguetown/helmet/kettle/iron
 	if(prob(50))
 		neck= /obj/item/clothing/neck/roguetown/chaincoif/iron

--- a/code/modules/mob/living/carbon/human/npc/skeleton/skeleton_bogguard.dm
+++ b/code/modules/mob/living/carbon/human/npc/skeleton/skeleton_bogguard.dm
@@ -62,7 +62,26 @@
 	name = "Skeleton Archer"
 	backr = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve
 	backl = /obj/item/quiver/randomfill/skeleton
-	armor = /obj/item/clothing/suit/roguetown/shirt/rags
+	if(prob(60))//WRIST
+		wrists = /obj/item/clothing/wrists/roguetown/bracers/iron
+	if(prob(90))//SHIRT
+		shirt = /obj/item/clothing/suit/roguetown/shirt/shortshirt/bog
+	if(prob(75))
+		armor = /obj/item/clothing/suit/roguetown/armor/gambeson
+		if(prob(50))
+			armor = /obj/item/clothing/suit/roguetown/armor/chainmail/iron
+	pants = /obj/item/clothing/under/roguetown/chainlegs/iron
+	if(prob(25))
+		pants = /obj/item/clothing/under/roguetown/heavy_leather_pants
+	if(prob(50))//HEAD
+		head = /obj/item/clothing/head/roguetown/roguehood/bogman
+		if(prob(60))
+			head = /obj/item/clothing/head/roguetown/helmet/kettle/iron
+	neck= /obj/item/clothing/neck/roguetown/chaincoif/iron
+	cloak = /obj/item/clothing/cloak/tabard/stabard/bog
+	shoes = /obj/item/clothing/shoes/roguetown/boots/leather
+	if(prob(50))
+		shoes = /obj/item/clothing/shoes/roguetown/boots
 	head = null
 	mask = null
 	neck = null

--- a/code/modules/mob/living/carbon/human/npc/skeleton/skeleton_bogguard.dm
+++ b/code/modules/mob/living/carbon/human/npc/skeleton/skeleton_bogguard.dm
@@ -4,40 +4,43 @@
 
 /datum/outfit/job/roguetown/npc/skeleton/npc/bogguard/pre_equip(mob/living/carbon/human/H)
 	..()
-	if(prob(50))//WRIST
-		wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
-	if(prob(10))//ARMOUR
-		armor = /obj/item/clothing/suit/roguetown/armor/chainmail/iron
-	if(prob(50))//SHIRT
-		shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/light
-		if(prob(15))
-			shirt = /obj/item/clothing/suit/roguetown/armor/gambeson
-			if(prob(15))
-				shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy
-	if(prob(50))//PANTS
-		pants = /obj/item/clothing/under/roguetown/tights/vagrant
-		if(prob(25))
-			pants = /obj/item/clothing/under/roguetown/chainlegs/iron
-			if(prob(25))
-				pants = /obj/item/clothing/under/roguetown/heavy_leather_pants
+	if(prob(60))//WRIST
+		wrists = /obj/item/clothing/wrists/roguetown/bracers/iron
+	if(prob(90))//SHIRT
+		shirt = /obj/item/clothing/suit/roguetown/shirt/shortshirt/bog
+	if(prob(75))
+		armor = /obj/item/clothing/suit/roguetown/armor/gambeson
+		if(prob(50))
+			armor = /obj/item/clothing/suit/roguetown/armor/chainmail/iron
+	pants = /obj/item/clothing/under/roguetown/chainlegs/iron
+	if(prob(25))
+		pants = /obj/item/clothing/under/roguetown/heavy_leather_pants
 	if(prob(50))//HEAD
 		head = /obj/item/clothing/head/roguetown/roguehood/bogman
 		if(prob(60))
 			head = /obj/item/clothing/head/roguetown/helmet/kettle/iron
-	if(prob(50))
-		neck= /obj/item/clothing/neck/roguetown/chaincoif/iron
-	if(prob(50))//CLOAK
-		cloak = /obj/item/clothing/cloak/tabard/stabard/bog
-	switch(rand(1, 3))
+	neck= /obj/item/clothing/neck/roguetown/chaincoif/iron
+	cloak = /obj/item/clothing/cloak/tabard/stabard/bog
+	switch(rand(1, 7))
 		if(1)
 			r_hand = /obj/item/rogueweapon/sword/iron
 		if(2)
 			r_hand = /obj/item/rogueweapon/spear
 		if(3)
 			r_hand = /obj/item/rogueweapon/mace
+		if(4)
+			r_hand = /obj/item/rogueweapon/spear/militia
+		if(5)
+			r_hand = /obj/item/rogueweapon/sword/iron
+			l_hand = /obj/item/rogueweapon/shield/wood
+		if(6)
+			r_hand = /obj/item/rogueweapon/stoneaxe/woodcut
+		if(7)
+			r_hand = /obj/item/rogueweapon/flail
+			l_hand = /obj/item/rogueweapon/shield/wood
 	H.STASTR = rand(12,14)
 	H.STASPD = 8
-	H.STACON = 3
+	H.STACON = 4
 	H.STAWIL = 8
 	H.STAINT = 1
 	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)

--- a/code/modules/mob/living/carbon/human/npc/soldiers/bog_deserters.dm
+++ b/code/modules/mob/living/carbon/human/npc/soldiers/bog_deserters.dm
@@ -486,7 +486,7 @@ GLOBAL_LIST_INIT(bogman_aggro, world.file2list("strings/rt/bogmanaggrolines.txt"
 	..()
 	backr = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve
 	backl = /obj/item/quiver/npc
-	add_random_deserter_cloak_better(H)
+	add_random_deserter_cloak(H)
 	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/vagrant
 	armor = /obj/item/clothing/suit/roguetown/shirt/rags
 	head = null
@@ -517,7 +517,7 @@ GLOBAL_LIST_INIT(bogman_aggro, world.file2list("strings/rt/bogmanaggrolines.txt"
 	..()
 	backr = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow/iron
 	backl = /obj/item/quiver/bolt/npc
-	add_random_deserter_cloak_better(H)
+	add_random_deserter_cloak(H)
 	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/vagrant
 	armor = /obj/item/clothing/suit/roguetown/shirt/rags
 	head = null

--- a/code/modules/mob/living/carbon/human/npc/soldiers/bog_deserters.dm
+++ b/code/modules/mob/living/carbon/human/npc/soldiers/bog_deserters.dm
@@ -280,8 +280,9 @@
 	add_random_deserter_armor_hard(H)
 	add_random_deserter_cloak(H)
 	//Head Gear
+	mask = /obj/item/clothing/head/roguetown/roguehood/bogman
 	neck = /obj/item/clothing/neck/roguetown/chaincoif/full
-	head = /obj/item/clothing/head/roguetown/helmet/heavy/knight/skettle
+	head = /obj/item/clothing/head/roguetown/helmet/heavy/guard/bogman/iron
 	//wrist Gear
 	gloves = /obj/item/clothing/gloves/roguetown/plate/iron
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/iron
@@ -435,7 +436,8 @@
 	add_random_deserter_cloak(H)
 	//Head Gear
 	neck = /obj/item/clothing/neck/roguetown/chaincoif/full
-	head = /obj/item/clothing/head/roguetown/helmet/heavy/knight/skettle
+	mask = /obj/item/clothing/head/roguetown/roguehood/bogman
+	head = /obj/item/clothing/head/roguetown/helmet/heavy/guard/bogman/iron
 	//wrist Gear
 	gloves = /obj/item/clothing/gloves/roguetown/plate/iron
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/iron

--- a/code/modules/mob/living/carbon/human/npc/soldiers/bog_deserters.dm
+++ b/code/modules/mob/living/carbon/human/npc/soldiers/bog_deserters.dm
@@ -25,18 +25,21 @@
 			mask = /obj/item/clothing/head/roguetown/roguehood/bogman/brown
 
 /datum/outfit/job/roguetown/human/northern/bog_deserters/proc/add_random_deserter_weapon(mob/living/carbon/human/H)
-	var/random_deserter_weapon = rand(1,3)
+	var/random_deserter_weapon = rand(1,4)
 	switch(random_deserter_weapon)
 		if(1)
 			r_hand = /obj/item/rogueweapon/sword/iron
 			l_hand = /obj/item/rogueweapon/shield/heater
 		if(2)
-			r_hand = /obj/item/rogueweapon/spear
+			r_hand = /obj/item/rogueweapon/mace/cudgel
+			l_hand = /obj/item/rogueweapon/shield/heater
 		if(3)
+			r_hand = /obj/item/rogueweapon/spear
+		if(4)
 			r_hand = /obj/item/rogueweapon/stoneaxe/woodcut
 
 /datum/outfit/job/roguetown/human/northern/bog_deserters/proc/add_random_deserter_weapon_hard(mob/living/carbon/human/H)
-	var/add_random_deserter_weapon_hard = rand(1,4)
+	var/add_random_deserter_weapon_hard = rand(1,5)
 	switch(add_random_deserter_weapon_hard)
 		if(1)
 			r_hand = /obj/item/rogueweapon/sword/iron
@@ -49,6 +52,8 @@
 		if(4)
 			r_hand = /obj/item/rogueweapon/flail
 			l_hand = /obj/item/rogueweapon/shield/heater
+		if(5)
+			r_hand = /obj/item/rogueweapon/woodstaff/militia
 
 /datum/outfit/job/roguetown/human/northern/bog_deserters/proc/add_random_deserter_beltl_stuff(mob/living/carbon/human/H)
 	var/add_random_deserter_beltl_stuff = rand(1,7)

--- a/code/modules/mob/living/carbon/human/npc/soldiers/bog_deserters.dm
+++ b/code/modules/mob/living/carbon/human/npc/soldiers/bog_deserters.dm
@@ -558,7 +558,7 @@ GLOBAL_LIST_INIT(bogman_aggro, world.file2list("strings/rt/bogmanaggrolines.txt"
 /datum/outfit/job/roguetown/human/northern/bog_deserters/better_gear/marshal/pre_equip(mob/living/carbon/human/H)
 	..()
 	armor = /obj/item/clothing/suit/roguetown/armor/plate/full/iron
-	head = /obj/item/clothing/head/roguetown/helmet/heavy/guard/bogman/iron
+	head = /obj/item/clothing/head/roguetown/helmet/heavy/knight/old/iron
 	gloves = /obj/item/clothing/gloves/roguetown/plate/iron
 	H.STASTR = 15
 	H.STACON = 12

--- a/code/modules/mob/living/carbon/human/npc/soldiers/bog_deserters.dm
+++ b/code/modules/mob/living/carbon/human/npc/soldiers/bog_deserters.dm
@@ -15,7 +15,7 @@ GLOBAL_LIST_INIT(bogman_aggro, world.file2list("strings/rt/bogmanaggrolines.txt"
 			cloak = /obj/item/clothing/suit/roguetown/armor/longcoat/brown
 
 /datum/outfit/job/roguetown/human/northern/bog_deserters/proc/add_random_deserter_cloak_better(mob/living/carbon/human/H)
-	var/random_deserter_cloak_better = rand(1,4)
+	var/random_deserter_cloak_better = rand(1,3)
 	switch(random_deserter_cloak_better)
 		if(1)
 			cloak = /obj/item/clothing/cloak/tabard/stabard/bog

--- a/code/modules/mob/living/carbon/human/npc/soldiers/bog_deserters.dm
+++ b/code/modules/mob/living/carbon/human/npc/soldiers/bog_deserters.dm
@@ -11,6 +11,19 @@
 		if(3)
 			cloak = /obj/item/clothing/suit/roguetown/armor/longcoat/brown
 
+/datum/outfit/job/roguetown/human/northern/bog_deserters/proc/add_random_deserter_cloak_better(mob/living/carbon/human/H)
+	var/random_deserter_cloak_better = rand(1,4)
+	switch(random_deserter_cloak_better)
+		if(1)
+			cloak = /obj/item/clothing/cloak/tabard/stabard/bog
+			mask = /obj/item/clothing/head/roguetown/roguehood/bogman
+		if(2)
+			cloak = /obj/item/clothing/cloak/tabard/stabard/dungeon
+			mask = /obj/item/clothing/head/roguetown/roguehood/bogman/black
+		if(3)
+			cloak = /obj/item/clothing/suit/roguetown/armor/longcoat/brown
+			mask = /obj/item/clothing/head/roguetown/roguehood/bogman/brown
+
 /datum/outfit/job/roguetown/human/northern/bog_deserters/proc/add_random_deserter_weapon(mob/living/carbon/human/H)
 	var/random_deserter_weapon = rand(1,3)
 	switch(random_deserter_weapon)
@@ -278,9 +291,8 @@
 	//Chest Gear
 	shirt = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/iron
 	add_random_deserter_armor_hard(H)
-	add_random_deserter_cloak(H)
+	add_random_deserter_cloak_better(H)
 	//Head Gear
-	mask = /obj/item/clothing/head/roguetown/roguehood/bogman
 	neck = /obj/item/clothing/neck/roguetown/chaincoif/full
 	head = /obj/item/clothing/head/roguetown/helmet/heavy/guard/bogman/iron
 	//wrist Gear
@@ -433,10 +445,9 @@
 	//Chest Gear
 	shirt = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/iron
 	add_random_deserter_armor_hard(H)
-	add_random_deserter_cloak(H)
+	add_random_deserter_cloak_better(H)
 	//Head Gear
 	neck = /obj/item/clothing/neck/roguetown/chaincoif/full
-	mask = /obj/item/clothing/head/roguetown/roguehood/bogman
 	head = /obj/item/clothing/head/roguetown/helmet/heavy/guard/bogman/iron
 	//wrist Gear
 	gloves = /obj/item/clothing/gloves/roguetown/plate/iron

--- a/code/modules/mob/living/carbon/human/npc/soldiers/bog_deserters.dm
+++ b/code/modules/mob/living/carbon/human/npc/soldiers/bog_deserters.dm
@@ -1,6 +1,9 @@
 
 //After the bogfort fell to undead, the remaining guard who didn't flea turned to bandirty. Wellarmed and trained.
 //These guys use alot of iron stuff with small amounts of steel mixed in, not really one for finetuned balance might be too hard or easy idk. Going off vibes atm
+
+GLOBAL_LIST_INIT(bogman_aggro, world.file2list("strings/rt/bogmanaggrolines.txt")) //unique lines, BOG! BOG! BOG! (these guys are paradoxally smarter and stupider than brigands in the woods, also more aggressive and violent)
+
 /datum/outfit/job/roguetown/human/northern/bog_deserters/proc/add_random_deserter_cloak(mob/living/carbon/human/H)
 	var/random_deserter_cloak = rand(1,4)
 	switch(random_deserter_cloak)
@@ -132,7 +135,7 @@
 /mob/living/carbon/human/species/human/northern/bog_deserters/after_creation()
 	..()
 	AddComponent(/datum/component/ai_aggro_system)
-	SEND_SIGNAL(src, COMSIG_MOB_MODIFY_AGGRO_LINES, GLOB.highwayman_aggro, TRUE)
+	SEND_SIGNAL(src, COMSIG_MOB_MODIFY_AGGRO_LINES, GLOB.bogman_aggro, TRUE)
 	job = "Garrison Deserter"
 	ADD_TRAIT(src, TRAIT_NOMOOD, TRAIT_GENERIC)
 	ADD_TRAIT(src, TRAIT_NOHUNGER, TRAIT_GENERIC)
@@ -344,7 +347,7 @@
 
 /mob/living/carbon/human/species/human/northern/bog_deserters/tosser/after_creation()
 	AddComponent(/datum/component/ai_aggro_system)
-	SEND_SIGNAL(src, COMSIG_MOB_MODIFY_AGGRO_LINES, GLOB.highwayman_aggro, TRUE)
+	SEND_SIGNAL(src, COMSIG_MOB_MODIFY_AGGRO_LINES, GLOB.bogman_aggro, TRUE)
 	job = "Garrison Deserter"
 	ADD_TRAIT(src, TRAIT_NOMOOD, TRAIT_GENERIC)
 	ADD_TRAIT(src, TRAIT_NOHUNGER, TRAIT_GENERIC)
@@ -483,6 +486,7 @@
 	..()
 	backr = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve
 	backl = /obj/item/quiver/npc
+	add_random_deserter_cloak_better(H)
 	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/vagrant
 	armor = /obj/item/clothing/suit/roguetown/shirt/rags
 	head = null
@@ -513,6 +517,7 @@
 	..()
 	backr = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow/iron
 	backl = /obj/item/quiver/bolt/npc
+	add_random_deserter_cloak_better(H)
 	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/vagrant
 	armor = /obj/item/clothing/suit/roguetown/shirt/rags
 	head = null
@@ -553,7 +558,7 @@
 /datum/outfit/job/roguetown/human/northern/bog_deserters/better_gear/marshal/pre_equip(mob/living/carbon/human/H)
 	..()
 	armor = /obj/item/clothing/suit/roguetown/armor/plate/full/iron
-	head = /obj/item/clothing/head/roguetown/helmet/heavy/knight/iron
+	head = /obj/item/clothing/head/roguetown/helmet/heavy/guard/bogman/iron
 	gloves = /obj/item/clothing/gloves/roguetown/plate/iron
 	H.STASTR = 15
 	H.STACON = 12

--- a/code/modules/spells/spell_types/skills/invoked_aoe/orders.dm
+++ b/code/modules/spells/spell_types/skills/invoked_aoe/orders.dm
@@ -57,8 +57,6 @@
 			if(target.job in affectedjobs)
 				affectedtargets += target
 				continue
-			if(owner.advjob == "Disgraced Knight" && target.advjob == "Disgraced Man at Arms") //Special line so Disgraced Knight can buff Disgraced Man at Arms
-				affectedtargets += target
 		if(!length(affectedtargets))
 			to_chat(owner, span_alert("There are no subordinates close enough to hear my orders!"))
 			return FALSE

--- a/strings/rt/bogmanaggrolines.txt
+++ b/strings/rt/bogmanaggrolines.txt
@@ -12,12 +12,7 @@ Time to pay thine bog toll, sire!
 This one looks like they've got something good!
 Let's see if you put up a better fight than the last fool!
 FOR THE BOG!
-BOOOOOOOOG!!!
-BOOOOG!!!
-FOOOOOOOR THE BOOOOOOG!!!
-FOR THE BOG!!!
 BOG! BOG! BOG!
-BOG FOREVER!
 Hey, we got some wanderers here! +Loot them up+, gang!
 Hey assholes, this is a fucking robbery!
 You ain't gonna take me alive!
@@ -25,18 +20,19 @@ That's a nice head you have on your shoulders!
 I'm going to enjoy cutting you apart!
 Hey, +HEY+, HALT!
 LADS, WE GOT SOME LIVE ONES, PROFITABLE TOO!
-This ain't your fucking bog!
+This ain't your fucking place!
 You ain't built for this place!
-You ain't built for this bog!
+You ain't built for this fucking place!
 I feel quite hungry!
-+FUCK AZURIA!+ BOG FOREVER!
++FUCK AZURIA!+ FREEDOM FOREVER!
 Drop your mammons, your weapon and to the fucking floor!
 Yer mammons or your lyfe!
 Give me yer mammons!
-HEY, INTRUDER IN OUR BOGS, GET OVER HERE!
+HEY, INTRUDER IN OUR PLACE, GET OVER HERE!
 Hey, +this is a fucking robbery+, hit the ground!
 Oi! Oi! Get em gang!
 A free hit! Jump em!
+FREEEEEDOM!
 I WANT THIS CARKER DEAD!
 THROW THEM INTO THE KNEESTINGERS!
 FILL EM WITH ARROWS AND LEECHES!

--- a/strings/rt/bogmanaggrolines.txt
+++ b/strings/rt/bogmanaggrolines.txt
@@ -1,0 +1,51 @@
+Never should have come here!
+Gonna cut your belly open like a blueblood's purse!
+Pay the toll!
+Pay the fucking toll!
++You+ don't belong in this bog!
+Get 'em, gang!
+Let's hope this one is more fun than the last!
+Ground, +NOW+!
+Start running, +start running+!
+The faster you run, the faster you bleed!
+Time to pay thine bog toll, sire!
+This one looks like they've got something good!
+Let's see if you put up a better fight than the last fool!
+FOR THE BOG!
+BOOOOOOOOG!!!
+BOOOOG!!!
+FOOOOOOOR THE BOOOOOOG!!!
+FOR THE BOG!!!
+BOG! BOG! BOG!
+BOG FOREVER!
+Hey, we got some wanderers here! +Loot them up+, gang!
+Hey assholes, this is a fucking robbery!
+You ain't gonna take me alive!
+That's a nice head you have on your shoulders!
+I'm going to enjoy cutting you apart!
+Hey, +HEY+, HALT!
+LADS, WE GOT SOME LIVE ONES, PROFITABLE TOO!
+This ain't your fucking bog!
+You ain't built for this place!
+You ain't built for this bog!
+I feel quite hungry!
++FUCK AZURIA!+ BOG FOREVER!
+Drop your mammons, your weapon and to the fucking floor!
+Yer mammons or your lyfe!
+Give me yer mammons!
+HEY, INTRUDER IN OUR BOGS, GET OVER HERE!
+Hey, +this is a fucking robbery+, hit the ground!
+Oi! Oi! Get em gang!
+A free hit! Jump em!
+I WANT THIS CARKER DEAD!
+THROW THEM INTO THE KNEESTINGERS!
+FILL EM WITH ARROWS AND LEECHES!
+LOOT THE BODY AND THROW THE CORPSE TO DEADITE!
+Kill the WYZARD FIRST!
+Drown the CLERIC FIRST!
+*laugh
+*chuckle
+*cackle
+*giggle
+*rage
+*warcry


### PR DESCRIPTION
## About The Pull Request

Reworks all deserters in the game, wretches and NPCs

**I highly recommend testmerging this first, so we can tell if uncapped wretches w/ orders are problematic - since I want to sort of keep the faction-gimmic of deserter wretches w/ the brotherhood. But worst case we can shoot it to just deserter knights.**

---

**NPCS:**

Featuring THE **BOG GARRISON** [`post-mortem`]

<img width="811" height="438" alt="Screenshot 2026-08-27 213027" src="https://github.com/user-attachments/assets/426cfc9a-f8d8-44f1-a86c-674234ca5fc2" />

Bog guard skeletons are far-more reilably geared and always rock the fit of what they were meant to always be, this should hopefully make them slightly less-trashy mobs. While still being reasonably trash enough to roll over.

---

Bog Deserters have recieved a faceup, they have slightly more variety in weaponry and appearances for their armored varients + slightly less steel.

They now have unique lines, instead of using just highwayman ones.

<img width="540" height="431" alt="Screenshot 2026-08-27 213647" src="https://github.com/user-attachments/assets/948bc8a4-a737-40e1-ab96-c7170e86afd9" />

**Marshals stand out still w/ unique helms + plate armor on examine**

<img width="444" height="146" alt="Screenshot 2026-08-27 214219" src="https://github.com/user-attachments/assets/1945fe3b-7e76-4ef5-ae2f-53c7207506a6" />

---

**Wretches**

**Deserter Knight:**
- gets access to fullplate + Halfplate choices, giving them an edge over profane champions and luxplate heretics where they falter in miracles and abilities, they make up for in stolen high-end gear off-the-bat.
- They remain capped to 2 slots

<img width="1258" height="809" alt="Screenshot 2026-08-27 193310" src="https://github.com/user-attachments/assets/2e6e97a1-3170-4521-94e0-5562f8a01487" />

**Regular Deserters** have been heavily shaken up

<img width="284" height="543" alt="Screenshot 2026-08-27 214330" src="https://github.com/user-attachments/assets/ba9e72e9-52ab-4fbd-b052-378e71c749ce" />

- They no longer get riding skill + free saddleborn
- They no longer (currently) have a cap
- Their statline is shifted slightly more towards survival, making a bog base/toll checkpoint and such

<img width="504" height="516" alt="Screenshot 2026-08-27 214324" src="https://github.com/user-attachments/assets/93958411-feb5-4fd2-9836-bba547a58312" />

- They lost some helm picks, more towards older and most ominious styles of helmet alongside bog garrison clothing picks

- They now **make up their defining trait in having** `trait_bogwalker`, without the need of hag intervention, this means they basically thrive in the terrorbogs unlike other wretches, no longer getting leeched/kneestingered or triggering ambushes in there unless they sprint.

---

Both variants of deserters are able to use the Garrison **HALT!** emote, either way you were both ex-garrison and thusly are able to use such training.

---

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

Its all above sire, spawned in w/ several loadout picks, all work.

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

Deserter Knight was suffering heavily w/ the addition of several wretch classes to stay relevent, moreso w/ miracle buffs + heretic basically getting all of its statline upgraded. Deserter knight should feel more like a miniboss instead of a joke.

Deserter had nothing going for it apart from "deserter knight but shittier", there's a bit more of a defining factor going for them now as a wretch class, w/ the terrorbogs being a huge boon to escape people or plot and scheme from.

---

NPC deserters could have used more varience, we also had a BOGMAN helmet, that was unused, a cardinal sin, no more.

More drip for NPCs, cooler fits to frag.

Bogman skeletons were abysmal to the point I think super easy skeletons were actually dying faster? That can't be right, surely not.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Added bogman hoods
balance: tweaked up deserter NPC styles, they look far more distinctive between levels of being geared
balance: bog guard skeletons are now always semi-geared up
balance: deserter knight has recieved fullplate/half plate armor choices in exchange for their prior weaker armor picks being chopped.
balance: deserter has lost saddleborn + riding skill in exchange for trait_bogwalker
balance: deserter has been redone as a class, as more of a remnant of the bog garrison defectors. You're not allied with bandits sire, but the bogs welcome you all the same. Separating it finally from just MAA but evil.
balance: deserter knight gets more greatweapon picks.
balance: deserter iron warhammer -> steel warhammer
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
