### PR TITLE
[Bugfix] Attempts to squash a abyssor vision bonus reward list picking bug

### DIFF
--- a/code/modules/roguetown/roguemachine/abyssorcult/dream_rune.dm
+++ b/code/modules/roguetown/roguemachine/abyssorcult/dream_rune.dm
@@ -157,7 +157,13 @@
 				continue
 
 			Q.required_phrase = pick(Q.possible_phrases)
-			var/chosen_bonus_path = pick(Q.possible_bonus_rewards)
+			var/chosen_bonus_path
+			var/list/bonus_keys = list()
+			for(var/key in Q.possible_bonus_rewards)
+				bonus_keys += key
+
+			if(length(bonus_keys))
+				chosen_bonus_path = pick(bonus_keys)
 
 			tier_choices.Add(list(list(
 				"quest" = Q,
@@ -210,15 +216,15 @@
 
 	// DEBUG ONLY
 	// for(var/mob/living/carbon/human/H in GLOB.human_list)
-	//	if(H == seeker || H.stat == DEAD)
-	//		continue
-	//	if(!H.mind || !H.mind.assigned_role)
-	//		continue
-	//	if(Q.is_valid_target(H, seeker))
-	//		valid_targets += H
+	// 	if(H == seeker || H.stat == DEAD)
+	// 		continue
+	// 	if(!H.mind || !H.mind.assigned_role)
+	// 		continue
+	// 	if(Q.is_valid_target(H, seeker))
+	// 		valid_targets += H
 
 	// if(length(valid_targets))
-	//	return pick(valid_targets)
+	// 	return pick(valid_targets)
 
 	return null
 


### PR DESCRIPTION
## About The Pull Request
Not sure this will fix it, but there was a runtime about it, so now keys are cached instead of reading them directly from the datums just in case there's associative list issues.

## Testing Evidence
Tested, couldn't reproduce the bug, so this is kind of shooting a blank. Didn't seem to alter regular behavior.

## Why It's Good For The Game
fix?

## Changelog

:cl:
fix: Attempt at fixing a abyssor quest selection runtime
/:cl:


