### PR TITLE
Deserter Package [without NPC tweaks]

### DIFF
--- a/code/modules/clothing/rogueclothes/headwear/adjusthoods.dm
+++ b/code/modules/clothing/rogueclothes/headwear/adjusthoods.dm
@@ -62,6 +62,17 @@
 /obj/item/clothing/head/roguetown/roguehood/red
 	color = CLOTHING_RED
 
+/obj/item/clothing/head/roguetown/roguehood/bogman
+	name = "bogman's hood"
+	desc = "A head's best friend, worn and proven by aeon's grip, its once-vibrant colors long worn out after its former owner deserted their post."
+	color = "#7a8138"
+
+/obj/item/clothing/head/roguetown/roguehood/bogman/black
+	color = CLOTHING_BLACK
+
+/obj/item/clothing/head/roguetown/roguehood/bogman/brown
+	color = "#997C4F"
+
 /obj/item/clothing/head/roguetown/roguehood/black
 	color = CLOTHING_BLACK
 

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/deserter.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/deserter.dm
@@ -1,13 +1,13 @@
-/datum/advclass/wretch/deserter
+/datum/advclass/wretch/deserter_knight
 	name = "Disgraced Knight"
 	tutorial = "You were once a venerated and revered knight - now, a traitor who abandoned your liege. You lyve the lyfe of an outlaw, shunned and looked down upon by society."
 	allowed_sexes = list(MALE, FEMALE)
 
-	outfit = /datum/outfit/job/roguetown/wretch/deserter
+	outfit = /datum/outfit/job/roguetown/wretch/deserter_knight
 	class_select_category = CLASS_CAT_WARRIOR
 	category_tags = list(CTAG_WRETCH)
-	traits_applied = list(TRAIT_HEAVYARMOR, TRAIT_NOBLE)
-	maximum_possible_slots = 2 //Ideal role for fraggers. Better to limit it.
+	traits_applied = list(TRAIT_HEAVYARMOR, TRAIT_NOBLE, TRAIT_BOGWALKER)
+	maximum_possible_slots = 2 //Ideal role for fraggers. Better to limit it. Powerful like T4 heretic w/ heretical plate armor in that they're a bog-blessed, plate user, w/ orders, riding and expert in most weaponry.
 
 	cmode_music = 'sound/music/cmode/antag/combat_thewall.ogg' // same as new hedgeknight music
 	// Deserter are the knight-equivalence. They get a balanced, straightforward 2 2 3 statspread to endure and overcome.
@@ -31,8 +31,10 @@
 		/datum/skill/combat/unarmed = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/athletics = SKILL_LEVEL_EXPERT,
 		/datum/skill/misc/climbing = SKILL_LEVEL_EXPERT,
-		/datum/skill/misc/riding = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/misc/riding = SKILL_LEVEL_EXPERT,
+		/datum/skill/misc/medicine = SKILL_LEVEL_APPRENTICE, //no miracles to deal w/ stabs through plate armor
 		/datum/skill/misc/reading = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/misc/hunting = SKILL_LEVEL_APPRENTICE,
 	)
 	subclass_virtues = list(
 		/datum/virtue/utility/riding
@@ -41,10 +43,13 @@
 		"Armor Plates" =	/obj/item/repair_kit/metal,
 	)
 
-/datum/outfit/job/roguetown/wretch/deserter/pre_equip(mob/living/carbon/human/H)
+/datum/outfit/job/roguetown/wretch/deserter_knight/pre_equip(mob/living/carbon/human/H)
 	..()
 	to_chat(H, span_warning("You were once a venerated and revered knight - now, a traitor who abandoned your liege. You lyve the lyfe of an outlaw, shunned and looked down upon by society."))
 	H.dna.species.soundpack_m = GLOB.voice_packs[/datum/voicepack/male/warrior]
+
+	add_verb(H, /mob/proc/haltyell) //Ex-Garrisoner
+
 	add_verb(H, list(/mob/living/carbon/human/mind/proc/setorders))
 	if(H.mind)
 		H.mind.AddSpell(new /datum/action/cooldown/spell/order/movemovemove)
@@ -65,7 +70,10 @@
 			"Samshir",
 			"Ssangsudo",
 			"Shashka + Shield",
-			"Steel Poleaxe"
+			"Steel Poleaxe",
+			"Steel Flameberge",
+			"Grand Mace",
+			"Polehammer"
 		)
 		var/weapon_choice = input(H, "Choose your weapon.", "TAKE UP ARMS") as anything in weapons
 		H.set_blindness(0)
@@ -107,6 +115,15 @@
 			if("Steel Poleaxe")
 				r_hand = /obj/item/rogueweapon/greataxe/steel/knight
 				backr = /obj/item/rogueweapon/scabbard/gwstrap
+			if("Steel Flameberge")
+				r_hand = /obj/item/rogueweapon/greatsword/grenz/flamberge
+				backr = /obj/item/rogueweapon/scabbard/gwstrap
+			if("Grand Mace")
+				r_hand = /obj/item/rogueweapon/mace/goden/steel
+				backr = /obj/item/rogueweapon/scabbard/gwstrap
+			if("Polehammer")
+				r_hand = /obj/item/rogueweapon/eaglebeak
+				backr = /obj/item/rogueweapon/scabbard/gwstrap
 
 		var/helmets = list(
 			"Pigface Bascinet"	= /obj/item/clothing/head/roguetown/helmet/bascinet/pigface,
@@ -140,10 +157,11 @@
 			head = helmets[helmchoice]
 
 		var/armors = list(
+			"Fullplate"			= /obj/item/clothing/suit/roguetown/armor/plate/full,
+			"Fluted Fullplate"		= /obj/item/clothing/suit/roguetown/armor/plate/full/fluted,
 			"Brigandine"		= /obj/item/clothing/suit/roguetown/armor/brigandine,
-			"Coat of Plates"	= /obj/item/clothing/suit/roguetown/armor/brigandine/heavy,
-			"Steel Cuirass"		= /obj/item/clothing/suit/roguetown/armor/plate/cuirass,
-			"Fluted Cuirass"	= /obj/item/clothing/suit/roguetown/armor/plate/cuirass/fluted,
+			"Coat of Plates"		= /obj/item/clothing/suit/roguetown/armor/brigandine/heavy,
+			"Half-Plate"		= /obj/item/clothing/suit/roguetown/armor/plate,
 			"Lamellar Scalemail"		= /obj/item/clothing/suit/roguetown/armor/plate/scale/steppe,
 			"Haraate Brigandine"		= /obj/item/clothing/suit/roguetown/armor/brigandine/haraate,
 		)
@@ -151,12 +169,13 @@
 		armor = armors[armorchoice]
 		wretch_select_bounty(H)
 	gloves = /obj/item/clothing/gloves/roguetown/plate
-	pants = /obj/item/clothing/under/roguetown/chainlegs
+	pants = /obj/item/clothing/under/roguetown/platelegs
 	neck = /obj/item/clothing/neck/roguetown/bevor
+	cloak = /obj/item/clothing/cloak/tabard/black
 	shirt = /obj/item/clothing/suit/roguetown/armor/chainmail
 	wrists = /obj/item/clothing/wrists/roguetown/bracers
 	shoes = /obj/item/clothing/shoes/roguetown/boots/armor
-	belt = /obj/item/storage/belt/rogue/leather/steel
+	belt = /obj/item/storage/belt/rogue/leather/steel/tasset //less meta
 	beltl = /obj/item/storage/belt/rogue/pouch/coins/poor
 	backl = /obj/item/storage/backpack/rogue/satchel //gwstraps landing on backr asyncs with backpack_contents
 	backpack_contents = list(
@@ -167,15 +186,25 @@
 		/obj/item/reagent_containers/glass/bottle/alchemical/healthpot = 1,	//Small health vial
 		)
 
-/datum/advclass/wretch/deserter/generic
+/datum/advclass/wretch/deserter
 	name = "Deserter"
 	tutorial = "You had your post. You had your duty. Dissatisfied, lacking in morale, or simply thinking yourself better than it. - You decided to walk. Now it follows you everywhere you go."
-	outfit = /datum/outfit/job/roguetown/wretch/desertergeneric
-	maximum_possible_slots = 2 //Ideal role for fraggers. Better to limit it.
+	allowed_sexes = list(MALE, FEMALE)
 
-	cmode_music = 'sound/music/cmode/antag/combat_thewall.ogg' // same as new hedgeknight music
+	outfit = /datum/outfit/job/roguetown/wretch/deserter
+
+	class_select_category = CLASS_CAT_WARRIOR
+	category_tags = list(CTAG_WRETCH)
+	//frankly, this is probably not going to happen consistantly with a massive tide of bogmen. If it does uhh, honestly. hilarious.
+	//Worst case nuke this to 5 slots, or 4. If it becomes a problem.
+
+	subclass_stashed_items = list(
+		"Armor Plates" =	/obj/item/repair_kit/metal,
+	)
+
+	cmode_music = 'sound/music/cmode/antag/combat_cutpurse.ogg' // same as regular bandits
 	// Slightly more rounded. These can be nudged as needed.
-	traits_applied = list(TRAIT_MEDIUMARMOR)
+	traits_applied = list(TRAIT_MEDIUMARMOR, TRAIT_BOGWALKER)
 	subclass_stats = list(
 		STATKEY_STR = 2,
 		STATKEY_WIL = 2,
@@ -190,6 +219,7 @@
 		/datum/skill/combat/axes = SKILL_LEVEL_EXPERT,
 		/datum/skill/combat/knives = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/whipsflails = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/combat/crossbows = SKILL_LEVEL_JOURNEYMAN, //Unique only case here, pick crossbow if you want to exceed in crossbows. Otherwise you're decently okay at it.
 		/datum/skill/combat/shields = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/wrestling = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/unarmed = SKILL_LEVEL_JOURNEYMAN,
@@ -197,10 +227,13 @@
 		/datum/skill/misc/swimming = SKILL_LEVEL_JOURNEYMAN, // Worse at swimming than the above class.
 		/datum/skill/misc/reading = SKILL_LEVEL_NOVICE,
 		/datum/skill/misc/athletics = SKILL_LEVEL_EXPERT,
-		/datum/skill/misc/riding = SKILL_LEVEL_JOURNEYMAN, // That saiga was stolen. Probably.
 		/datum/skill/misc/tracking = SKILL_LEVEL_NOVICE,
+		/datum/skill/misc/medicine = SKILL_LEVEL_APPRENTICE, //No miracles to deal w/ stabs through plate/maile armor
+		/datum/skill/craft/carpentry = SKILL_LEVEL_APPRENTICE, //So you can repair your heater shield + build in the bogs
+		/datum/skill/labor/lumberjacking = SKILL_LEVEL_APPRENTICE, //Ditto
 	)
-/datum/outfit/job/roguetown/wretch/desertergeneric/pre_equip(mob/living/carbon/human/H)
+
+/datum/outfit/job/roguetown/wretch/deserter/pre_equip(mob/living/carbon/human/H)
 	..()
 	if(H.mind)
 		var/weapons = list("Warhammer & Shield","Sabre & Shield","Axe & Shield","Billhook","Greataxe","Halberd","Crossbow")
@@ -208,15 +241,15 @@
 		H.set_blindness(0)
 		switch(weapon_choice)
 			if("Warhammer & Shield")
-				beltr = /obj/item/rogueweapon/mace/warhammer
-				backl = /obj/item/rogueweapon/shield/iron
+				beltr = /obj/item/rogueweapon/mace/warhammer/steel
+				backl = /obj/item/rogueweapon/shield/heater
 			if("Sabre & Shield")
 				beltr = /obj/item/rogueweapon/scabbard/sword
 				r_hand = /obj/item/rogueweapon/sword/sabre
-				backl = /obj/item/rogueweapon/shield/wood
+				backl = /obj/item/rogueweapon/shield/heater
 			if("Axe & Shield")
 				beltr = /obj/item/rogueweapon/stoneaxe/woodcut/steel
-				backl = /obj/item/rogueweapon/shield/iron
+				backl = /obj/item/rogueweapon/shield/heater
 			if("Billhook")
 				r_hand = /obj/item/rogueweapon/spear/billhook
 				backl = /obj/item/rogueweapon/scabbard/gwstrap
@@ -228,30 +261,38 @@
 				backl = /obj/item/rogueweapon/scabbard/gwstrap
 			if("Crossbow")
 				H.adjust_skillrank_up_to(/datum/skill/combat/crossbows, SKILL_LEVEL_EXPERT, TRUE)
-				r_hand = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
-				backl = /obj/item/quiver/bolt/standard
-	add_verb(H, list(/mob/living/carbon/human/mind/proc/setorders))
+				backl = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
+				beltr = /obj/item/quiver/bolt/standard
+
+	add_verb(H, /mob/proc/haltyell) //Ex-Garrisoner
+
+	add_verb(H, list(/mob/living/carbon/human/mind/proc/setorders)) //Kill if problematic
 	if(H.mind)
 		H.mind.AddSpell(new /datum/action/cooldown/spell/order/movemovemove)
 		H.mind.AddSpell(new /datum/action/cooldown/spell/order/takeaim)
 		H.mind.AddSpell(new /datum/action/cooldown/spell/order/hold)
 		H.mind.AddSpell(new /datum/action/cooldown/spell/order/onfeet)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/convertrole/brotherhood)
+
+		/*
+		meant to be less knightly-helmets and more in-line with banditry, brigand loadouts and such so, so no armlets
+
+		we limit this so you have to look moderately evil or suspiciously wearing old-style helmets
+		*/
 		var/helmets = list(
 			"Pigface Bascinet"		= /obj/item/clothing/head/roguetown/helmet/bascinet/pigface,
 			"Hounskull Bascinet"	= /obj/item/clothing/head/roguetown/helmet/bascinet/pigface/hounskull,
 			"Klappvisier Bascinet"	= /obj/item/clothing/head/roguetown/helmet/bascinet/etruscan,
+			"Volfskulle Bascinet"		= /obj/item/clothing/head/roguetown/helmet/heavy/volfplate,
 			"Visored Sallet"		= /obj/item/clothing/head/roguetown/helmet/sallet/visored,
 			"Snouted Visored Sallet"		= /obj/item/clothing/head/roguetown/helmet/sallet/visored/snouted,
-			"Sugarloaf Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/bucket/crusader,
-			"Knight's Armet"	= /obj/item/clothing/head/roguetown/helmet/heavy/knight,
 			"Knight's Helmet"	= /obj/item/clothing/head/roguetown/helmet/heavy/knight/old,
-			"Knight's Greatplumed Armet"		= /obj/item/clothing/head/roguetown/helmet/heavy/knight/greatplume,
 		)
 		var/helmchoice = input(H, "Choose your Helm.", "TAKE UP HELMS") as anything in helmets
 		head = helmets[helmchoice]
 
 		var/armors = list(
+			"Cuirass"			= /obj/item/clothing/suit/roguetown/armor/plate/cuirass,
 			"Brigandine"		= /obj/item/clothing/suit/roguetown/armor/brigandine,
 			"Half-Plate"		= /obj/item/clothing/suit/roguetown/armor/plate/iron,
 			"Scalemail"			= /obj/item/clothing/suit/roguetown/armor/plate/scale,
@@ -259,12 +300,24 @@
 		var/armorchoice = input(H, "Choose your armor.", "TAKE UP ARMOR") as anything in armors
 		armor = armors[armorchoice]
 
+		var/cloaks = list("Bog Green","Black","Brown and Longcoat")
+		var/cloak_choice = input(H, "Choose your cloak.", "FOR THE BOG") as anything in cloaks
+		switch(cloak_choice)
+			if("Bog Green")
+				cloak = /obj/item/clothing/cloak/tabard/stabard/bog
+				mask = /obj/item/clothing/head/roguetown/roguehood/bogman
+			if("Black")
+				cloak = /obj/item/clothing/cloak/tabard/stabard/dungeon
+				mask = /obj/item/clothing/head/roguetown/roguehood/bogman/black
+			if("Brown and Longcoat")
+				cloak = /obj/item/clothing/suit/roguetown/armor/longcoat/brown
+				mask = /obj/item/clothing/head/roguetown/roguehood/bogman/brown
+
 		wretch_select_bounty(H)
 
 	shirt = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk
 	pants = /obj/item/clothing/under/roguetown/chainlegs
 	neck = /obj/item/clothing/neck/roguetown/bevor
-	cloak = /obj/item/clothing/cloak/tabard/stabard/surcoat
 	wrists = /obj/item/clothing/wrists/roguetown/bracers
 	gloves = /obj/item/clothing/gloves/roguetown/chain
 	shoes = /obj/item/clothing/shoes/roguetown/boots/armor/iron

--- a/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
@@ -32,8 +32,8 @@
 	job_traits = list(TRAIT_STEELHEARTED, TRAIT_OUTLAW, TRAIT_HERESIARCH, TRAIT_SELF_SUSTENANCE, TRAIT_ZURCH)
 	job_subclasses = list(
 		/datum/advclass/wretch/licker,
+		/datum/advclass/wretch/deserter_knight,
 		/datum/advclass/wretch/deserter,
-		/datum/advclass/wretch/deserter/generic,
 		/datum/advclass/wretch/berserker,
 		/datum/advclass/wretch/roguemage,
 		/datum/advclass/wretch/necromancer,

--- a/code/modules/spells/spell_types/skills/invoked_aoe/orders.dm
+++ b/code/modules/spells/spell_types/skills/invoked_aoe/orders.dm
@@ -57,7 +57,7 @@
 			if(target.job in affectedjobs)
 				affectedtargets += target
 				continue
-			if(owner.advjob == "Disgraced Knight" && target.advjob == "Disgraced Man at Arms") //Special line so Disgraced Knight can buff Disgraced Man at Arms
+			if(owner.advjob == "Disgraced Knight" && target.advjob == "Deserter") //Special line so Disgraced Knight can buff Disgraced Man at Arms
 				affectedtargets += target
 		if(!length(affectedtargets))
 			to_chat(owner, span_alert("There are no subordinates close enough to hear my orders!"))

--- a/code/modules/spells/spell_types/skills/invoked_aoe/orders.dm
+++ b/code/modules/spells/spell_types/skills/invoked_aoe/orders.dm
@@ -57,8 +57,6 @@
 			if(target.job in affectedjobs)
 				affectedtargets += target
 				continue
-			if(owner.advjob == "Disgraced Knight" && target.advjob == "Disgraced Knight") //Special line so Disgraced Knight can buff fellow Disgraced knights
-				affectedtargets += target
 		if(!length(affectedtargets))
 			to_chat(owner, span_alert("There are no subordinates close enough to hear my orders!"))
 			return FALSE

--- a/code/modules/spells/spell_types/skills/invoked_aoe/orders.dm
+++ b/code/modules/spells/spell_types/skills/invoked_aoe/orders.dm
@@ -57,7 +57,9 @@
 			if(target.job in affectedjobs)
 				affectedtargets += target
 				continue
-			if(owner.advjob == "Disgraced Knight" && target.advjob == "Deserter") //Special line so Disgraced Knight can buff Disgraced Man at Arms
+			if(owner.advjob == "Disgraced Knight" && target.advjob == "Deserter") //Special line so Disgraced Knight can buff Deserter
+				affectedtargets += target
+			if(owner.advjob == "Deserter" && target.advjob == "Disgraced Knight") //Special line so Deserter can do the reverse. Both can brotherhood recruit (ATM, might axe that)
 				affectedtargets += target
 		if(!length(affectedtargets))
 			to_chat(owner, span_alert("There are no subordinates close enough to hear my orders!"))

--- a/code/modules/spells/spell_types/skills/invoked_aoe/orders.dm
+++ b/code/modules/spells/spell_types/skills/invoked_aoe/orders.dm
@@ -57,9 +57,7 @@
 			if(target.job in affectedjobs)
 				affectedtargets += target
 				continue
-			if(owner.advjob == "Disgraced Knight" && target.advjob == "Deserter") //Special line so Disgraced Knight can buff Deserter
-				affectedtargets += target
-			if(owner.advjob == "Deserter" && target.advjob == "Disgraced Knight") //Special line so Deserter can do the reverse. Both can brotherhood recruit (ATM, might axe that)
+			if(owner.advjob == "Disgraced Knight" && target.advjob == "Disgraced Knight") //Special line so Disgraced Knight can buff fellow Disgraced knights
 				affectedtargets += target
 		if(!length(affectedtargets))
 			to_chat(owner, span_alert("There are no subordinates close enough to hear my orders!"))


### PR DESCRIPTION
## About The Pull Request

See:

https://github.com/Azure-Peak/Azure-Peak/pull/8819

Redoes deserter classes w/out the changes for bogman NPCs and skeletons - Since a refactor may be due for NPC loadouts due to how much unnecessary code overlap there is - also because frankly I may have unleashed a bit too much feature creep instead of being to-the-point. so here go.

---

I recommend a testmerge since I'm still on-edge about uncapped deserters (**knights are still capped**) w/ recruitverbs + orders but they need it if they want to operate outside of the terrorbogs. - They have it mostly to make up for maile + no D/E.

---

**Deserter Knight:**
- gets access to fullplate + Halfplate choices, giving them an edge over profane champions and luxplate heretics where they falter in miracles and abilities, they make up for in stolen high-end gear off-the-bat.
- They remain capped to 2 slots

<img width="1258" height="809" alt="Screenshot 2026-08-27 193310" src="https://github.com/user-attachments/assets/2e6e97a1-3170-4521-94e0-5562f8a01487" />

**Regular Deserters** have been heavily shaken up

<img width="284" height="543" alt="Screenshot 2026-08-27 214330" src="https://github.com/user-attachments/assets/ba9e72e9-52ab-4fbd-b052-378e71c749ce" />

- They no longer get riding skill + free saddleborn.
- They no longer (currently) have a cap on slots, like outlaws/poachers/berserkers/etc.
- Their statline is shifted slightly more towards survival, making a bog base/toll checkpoint and such

<img width="504" height="516" alt="Screenshot 2026-08-27 214324" src="https://github.com/user-attachments/assets/93958411-feb5-4fd2-9836-bba547a58312" />

- They lost some helm picks, more towards older and most ominious styles of helmet alongside bog garrison clothing picks

- They now **make up their defining trait in having** `trait_bogwalker`, without the need of hag intervention, this means they basically thrive in the terrorbogs unlike other wretches, no longer getting leeched/kneestingered or triggering ambushes in there unless they sprint.

---

Both variants of deserters are able to use the Garrison **HALT!** emote, either way you were both ex-garrison and thusly are able to use such training.

Both variants have apprentice medicine to make up for the fact you're going to be taking wounds and probably not healing them off or pushing through them as much as heretics and such w/ miracles. - I'd argue berserker should get this too but that's for another PR.


<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

Check that PR for the rest but screenshots are above sire. it all works.

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

Gives them more distinction

Deserter Knight was suffering heavily w/ the addition of several wretch classes to stay relevent, moreso w/ miracle buffs + heretic basically getting all of its statline upgraded. Deserter knight should feel more like a miniboss instead of a joke.

Deserter had nothing going for it apart from "deserter knight but shittier", there's a bit more of a defining factor going for them now as a wretch class, w/ the terrorbogs being a huge boon to escape people or plot and scheme from.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Added bogman hoods
balance: deserter knight has recieved fullplate/half plate armor choices in exchange for their prior weaker armor picks being chopped.
balance: deserter has lost saddleborn + riding skill in exchange for trait_bogwalker
balance: deserter has been redone as a class, as more of a remnant of the bog garrison defectors. You're not allied with bandits sire, but the bogs welcome you all the same. Separating it finally from just MAA but evil.
balance: deserter knight gets more greatweapon picks.
balance: deserter iron warhammer -> steel warhammer
refactor: removes unused ordering code for ordering disgraced MAAs from deserter knights.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
