### PR TITLE
Parchment Background Loading Quick-Fix

### DIFF
--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -192,6 +192,7 @@
 		return
 	if(in_range(user, src) || isobserver(user))
 //		var/obj/screen/read/R = user.hud_used.reads
+		user << browse_rsc('html/book.png')
 		var/dat = {"<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\" \"http://www.w3.org/TR/html4/loose.dtd\">
 			<html><head><style type=\"text/css\">
 			body { background-image:url('book.png');background-repeat: repeat; }</style></head><body scroll=yes>"}


### PR DESCRIPTION
## About The Pull Request

Makes the parchment background now load reliably instead of occurring seemingly randomly.

This happened due to the background not being loaded into the client's cache when trying to _read_ a letter. It does, however, load it in when someone tries to write it or read a manuscript or book. Very weird stuff, should solve those white-background letters once and for all.

## Testing Evidence

<img width="517" height="419" alt="image" src="https://github.com/user-attachments/assets/4972f03b-959c-4885-9f41-f99fa76b8630" />

## Why It's Good For The Game

It just is.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Background for parchments now load reliably.
/:cl:


