### PR TITLE
zigs now get blown the fuck up if you pinch 'em twice

### DIFF
--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -349,6 +349,20 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		user.visible_message(span_notice("[user] pinches out [src] with [user.p_their()] fingers."), \
 				span_notice("I pinch out [src] with my fingers."))
 		extinguish()
+		smoketime -= 60 // takes half off
+		if(smoketime <= 0)
+			var/turf/location = get_turf(src)
+			if(iscarbon(loc))
+				var/mob/living/carbon/M = loc
+				M.dropItemToGround(src, silent = TRUE)
+				M.mouth = new type_butt(M)
+				M.dropItemToGround(M.mouth, silent = FALSE)
+				to_chat(user, span_notice("[src] didn\'t have enough in it to withstand my pinch!"))
+			else
+				new type_butt(location)
+				user.visible_message(span_notice("[user] pinches [src], the last of it's contents shriveling to naught!"))
+			qdel(src)
+
 		return 1
 	return ..()
 
@@ -746,6 +760,27 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 			return ..()
 
 /obj/item/clothing/mask/cigarette/pipe/attack_self(mob/user)
+	var/turf/location = get_turf(user)
+	if(lit)
+		name = copytext(name,5,length(name)+1)
+		user.visible_message(span_notice("[user] puts out [src]."), span_notice("I put out [src]."))
+		lit = 0
+		set_light_on(FALSE)
+		update_icon_state()
+		STOP_PROCESSING(SSobj, src)
+		return
+	if(!lit && smoketime > 0)
+		smoketime = 0
+		to_chat(user, span_notice("I empty [src] onto [location]."))
+		new /obj/item/ash(location)
+		packeditem = 0
+		reagents.clear_reagents()
+//		name = "empty [initial(name)]"
+	return
+
+// pipes should NOT inherit the being-destroyed part of zigarette behavior so we do this instead.
+// its a little dumb but should work, just copied the attack_self. DO NOT CALL PARENT!!!!
+/obj/item/clothing/mask/cigarette/pipe/attack_right(mob/user)
 	var/turf/location = get_turf(user)
 	if(lit)
 		name = copytext(name,5,length(name)+1)


### PR DESCRIPTION
## About The Pull Request
- the 17 smoker vices arent gonna like this one!
- zigs now deplete 60 smoketime (half) on pinching them out yourself. this does not apply to pipes, nor does it apply to putting them out in water, ETC. this just prevents you from having one zig you light and then immediately pinch out to satisfy smoker. will this stop gamers? no. but it will make their lives mildly more annoying
- buy 2-3 zigs instead of one now. theyre like 5 mammon IDFK man.
- pipes literally already did this so you can also just buy a pipe. very cool!
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
- chiefed dat hoe several times. tested pipes, too. it seems fine? the pipe code sucks ass idk if it NEEDS to call parent for some reason or why the put-out code returned 1.

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
- power gamers destroyed 5ever.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: zigs now lose 60 (half) smoketime per manual pinch-out.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
