### PR TITLE
gives cosmetic claws to half-kin too

### DIFF
--- a/code/modules/mob/living/carbon/human/cosmetic_claws.dm
+++ b/code/modules/mob/living/carbon/human/cosmetic_claws.dm
@@ -14,6 +14,15 @@
 		CLAW_STYLE_CHITINOUS = /datum/intent/unarmed/punch/cosmetic_claw/chitinous,
 	)
 
+/datum/species/demihuman
+	cosmetic_claw_types = list(
+		CLAW_STYLE_RETRACTABLE = /datum/intent/unarmed/punch/cosmetic_claw/retractable,
+		CLAW_STYLE_HOOKED = /datum/intent/unarmed/punch/cosmetic_claw/hooked,
+		CLAW_STYLE_HEAVY = /datum/intent/unarmed/punch/cosmetic_claw/heavy,
+		CLAW_STYLE_TALONS = /datum/intent/unarmed/punch/cosmetic_claw/talons,
+		CLAW_STYLE_CHITINOUS = /datum/intent/unarmed/punch/cosmetic_claw/chitinous,
+	)
+
 /datum/species/anthromorphsmall
 	cosmetic_claw_types = list(
 		CLAW_STYLE_RETRACTABLE = /datum/intent/unarmed/punch/cosmetic_claw/retractable,

--- a/code/modules/mob/living/carbon/human/cosmetic_claws.dm
+++ b/code/modules/mob/living/carbon/human/cosmetic_claws.dm
@@ -23,6 +23,15 @@
 		CLAW_STYLE_CHITINOUS = /datum/intent/unarmed/punch/cosmetic_claw/chitinous,
 	)
 
+/datum/species/dullahan
+	cosmetic_claw_types = list(
+		CLAW_STYLE_RETRACTABLE = /datum/intent/unarmed/punch/cosmetic_claw/retractable,
+		CLAW_STYLE_HOOKED = /datum/intent/unarmed/punch/cosmetic_claw/hooked,
+		CLAW_STYLE_HEAVY = /datum/intent/unarmed/punch/cosmetic_claw/heavy,
+		CLAW_STYLE_TALONS = /datum/intent/unarmed/punch/cosmetic_claw/talons,
+		CLAW_STYLE_CHITINOUS = /datum/intent/unarmed/punch/cosmetic_claw/chitinous,
+	)
+
 /datum/species/anthromorphsmall
 	cosmetic_claw_types = list(
 		CLAW_STYLE_RETRACTABLE = /datum/intent/unarmed/punch/cosmetic_claw/retractable,


### PR DESCRIPTION
## About The Pull Request

Extends the retractable claw cosmetic stuff to Half-Kin too

## Testing Evidence

<img width="314" height="95" alt="image" src="https://github.com/user-attachments/assets/c6d137fe-50e3-4bdc-8eb7-8d239143e6da" />

## Why It's Good For The Game

I think having more cosmetic choices available is cool and i think it makes sense for them to have it

## Changelog

:cl:
add: Half-Kin can use cosmetic claw effects now too
/:cl:

