### PR TITLE
changes the required minor version for compiling to 1685

### DIFF
--- a/tools/build/lib/byond.ts
+++ b/tools/build/lib/byond.ts
@@ -163,7 +163,7 @@ export async function DreamMaker(
       throw new Juke.ExitCode(1);
     }
     const requiredMajorVersion = 516;
-    const requiredMinorVersion = 1687;
+    const requiredMinorVersion = 1685;
     const major = Number(version[1]);
     const minor = Number(version[2]);
     if (


### PR DESCRIPTION
## About The Pull Request
Backend only. Devs won't be pestered by compile errors on 1685.
<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
