### PR TITLE
Known Menu QOL Update

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -312,7 +312,7 @@ GLOBAL_LIST_EMPTY(personal_objective_minds)
 		if(fcolor && fjob)
 			if (fheresy)
 				contents +="<B><font color=#f1d669>[fheresy]</font></B> "
-			contents += "<B>[link ? "<a style='margin: 0px; padding: 0px;' href='?src=[REF(H)];task=view_headshot'>" : ""]<font color=#[fcolor];text-shadow:0 0 10px #8d5958, 0 0 20px #8d5958, 0 0 30px #8d5958, 0 0 40px #8d5958, 0 0 50px #e60073, 0 0 60px #8d5958, 0 0 70px #8d5958;>[P]</font>[link ? "</a>" : ""]</B><BR>[fjob], [capitalize(fgender)], [fspecies], [fage]"
+			contents += "<B>[link ? "<a style='margin: 0px; padding: 0px;' href='?src=[REF(H)];task=view_headshot;overridevisible=1'>" : ""]<font color=#[fcolor];text-shadow:0 0 10px #8d5958, 0 0 20px #8d5958, 0 0 30px #8d5958, 0 0 40px #8d5958, 0 0 50px #e60073, 0 0 60px #8d5958, 0 0 70px #8d5958;>[P]</font>[link ? "</a>" : ""]</B><BR>[fjob], [capitalize(fgender)], [fspecies], [fage]"
 			contents += "<BR>"
 
 	var/datum/browser/popup = new(user, "PEOPLEIKNOW", "", 260, 400)

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -298,10 +298,20 @@ GLOBAL_LIST_EMPTY(personal_objective_minds)
 		var/fage = known_people[P]["FAGE"]
 		var/fspecies = known_people[P]["FSPECIES"]
 		var/fheresy = known_people[P]["FHERESY"]
+		var/link
+		var/mob/living/carbon/human/H
+		for(var/mob/living/carbon/human/cand in GLOB.player_list)
+			if(cand.real_name == P)
+				H = cand
+		if(H)
+			link = (H.flavortext || H.headshot_link || H.ooc_notes)
+			if(fjob == "unknown") // this can be 'unknown' if people are added to our known list too soon in roundstart; so we want to refresh the cache here
+				known_people[P]["FJOB"] = (H.get_role_title() || "unknown")
+				fjob = known_people[P]["FJOB"]
 		if(fcolor && fjob)
 			if (fheresy)
 				contents +="<B><font color=#f1d669>[fheresy]</font></B> "
-			contents += "<B><font color=#[fcolor];text-shadow:0 0 10px #8d5958, 0 0 20px #8d5958, 0 0 30px #8d5958, 0 0 40px #8d5958, 0 0 50px #e60073, 0 0 60px #8d5958, 0 0 70px #8d5958;>[P]</font></B><BR>[fjob], [capitalize(fgender)], [fspecies], [fage]"
+			contents += "<B>[link ? "<a style='margin: 0px; padding: 0px;' href='?src=[REF(H)];task=view_headshot;overridevisible=1'>" : ""]<font color=#[fcolor];text-shadow:0 0 10px #8d5958, 0 0 20px #8d5958, 0 0 30px #8d5958, 0 0 40px #8d5958, 0 0 50px #e60073, 0 0 60px #8d5958, 0 0 70px #8d5958;>[P]</font>[link ? "</a>" : ""]</B><BR>[fjob], [capitalize(fgender)], [fspecies], [fage]"
 			contents += "<BR>"
 
 	var/datum/browser/popup = new(user, "PEOPLEIKNOW", "", 260, 400)

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -299,6 +299,7 @@ GLOBAL_LIST_EMPTY(personal_objective_minds)
 		var/fspecies = known_people[P]["FSPECIES"]
 		var/fheresy = known_people[P]["FHERESY"]
 		var/link
+		var/rumors
 		var/mob/living/carbon/human/H
 		for(var/mob/living/carbon/human/cand in GLOB.player_list)
 			if(cand.real_name == P)
@@ -306,13 +307,14 @@ GLOBAL_LIST_EMPTY(personal_objective_minds)
 				break
 		if(H)
 			link = (H.flavortext || H.headshot_link || H.ooc_notes)
+			rumors = (length(H.rumour_cached) || length(H.noble_gossip_cached))
 			if(fjob == "unknown") // this can be 'unknown' if people are added to our known list too soon in roundstart; so we want to refresh the cache here
 				known_people[P]["FJOB"] = (H.get_role_title() || "unknown")
 				fjob = known_people[P]["FJOB"]
 		if(fcolor && fjob)
 			if (fheresy)
 				contents +="<B><font color=#f1d669>[fheresy]</font></B> "
-			contents += "<B>[link ? "<a style='margin: 0px; padding: 0px;' href='?src=[REF(H)];task=view_headshot;overridevisible=1'>" : ""]<font color=#[fcolor];text-shadow:0 0 10px #8d5958, 0 0 20px #8d5958, 0 0 30px #8d5958, 0 0 40px #8d5958, 0 0 50px #e60073, 0 0 60px #8d5958, 0 0 70px #8d5958;>[P]</font>[link ? "</a>" : ""]</B><BR>[fjob], [capitalize(fgender)], [fspecies], [fage]"
+			contents += "<B>[link ? "<a style='margin: 0px; padding: 0px;' href='?src=[REF(H)];task=view_headshot;overridevisible=1'>" : ""]<font color=#[fcolor];text-shadow:0 0 10px #8d5958, 0 0 20px #8d5958, 0 0 30px #8d5958, 0 0 40px #8d5958, 0 0 50px #e60073, 0 0 60px #8d5958, 0 0 70px #8d5958;>[P]</font>[link ? "</a>" : ""]</B>[rumors ? " <a style='margin: 0px; padding: 0px;' href='?src=[REF(H)];task=view_rumours_gossip;'>?</a>" : ""]<BR>[fjob], [capitalize(fgender)], [fspecies], [fage]"
 			contents += "<BR>"
 
 	var/datum/browser/popup = new(user, "PEOPLEIKNOW", "", 260, 400)

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -303,6 +303,7 @@ GLOBAL_LIST_EMPTY(personal_objective_minds)
 		for(var/mob/living/carbon/human/cand in GLOB.player_list)
 			if(cand.real_name == P)
 				H = cand
+				break
 		if(H)
 			link = (H.flavortext || H.headshot_link || H.ooc_notes)
 			if(fjob == "unknown") // this can be 'unknown' if people are added to our known list too soon in roundstart; so we want to refresh the cache here
@@ -311,7 +312,7 @@ GLOBAL_LIST_EMPTY(personal_objective_minds)
 		if(fcolor && fjob)
 			if (fheresy)
 				contents +="<B><font color=#f1d669>[fheresy]</font></B> "
-			contents += "<B>[link ? "<a style='margin: 0px; padding: 0px;' href='?src=[REF(H)];task=view_headshot;overridevisible=1'>" : ""]<font color=#[fcolor];text-shadow:0 0 10px #8d5958, 0 0 20px #8d5958, 0 0 30px #8d5958, 0 0 40px #8d5958, 0 0 50px #e60073, 0 0 60px #8d5958, 0 0 70px #8d5958;>[P]</font>[link ? "</a>" : ""]</B><BR>[fjob], [capitalize(fgender)], [fspecies], [fage]"
+			contents += "<B>[link ? "<a style='margin: 0px; padding: 0px;' href='?src=[REF(H)];task=view_headshot'>" : ""]<font color=#[fcolor];text-shadow:0 0 10px #8d5958, 0 0 20px #8d5958, 0 0 30px #8d5958, 0 0 40px #8d5958, 0 0 50px #e60073, 0 0 60px #8d5958, 0 0 70px #8d5958;>[P]</font>[link ? "</a>" : ""]</B><BR>[fjob], [capitalize(fgender)], [fspecies], [fage]"
 			contents += "<BR>"
 
 	var/datum/browser/popup = new(user, "PEOPLEIKNOW", "", 260, 400)

--- a/code/modules/mob/living/carbon/human/examine_tgui.dm
+++ b/code/modules/mob/living/carbon/human/examine_tgui.dm
@@ -10,11 +10,15 @@
 
 	var/mob/viewing
 
+	/// if this is true, you can see name and FT even if they're masked. used by the known characters menu
+	var/override_visible = FALSE
+
 /datum/examine_panel/familiar
 
-/datum/examine_panel/New(mob/holder_mob)
+/datum/examine_panel/New(mob/holder_mob, override = FALSE)
 	if(holder_mob)
 		holder = holder_mob
+	override_visible = override
 
 /datum/examine_panel/Destroy(force)
 	holder = null
@@ -121,17 +125,17 @@
 		var/mob/living/carbon/human/holder_human = holder
 		if(!(holder_human.wear_armor && holder_human.wear_armor.flags_inv) && !(holder_human.wear_shirt && holder_human.wear_shirt.flags_inv))
 			is_naked = TRUE
-		obscured = ((!isobserver(user)) && !holder_human.client?.prefs?.masked_examine) && ((holder_human.wear_mask && (holder_human.wear_mask.flags_inv & HIDEFACE)) || (holder_human.head && (holder_human.head.flags_inv & HIDEFACE)))
+		obscured = ((!override_visible) && ((!isobserver(user)) && !holder_human.client?.prefs?.masked_examine) && ((holder_human.wear_mask && (holder_human.wear_mask.flags_inv & HIDEFACE)) || (holder_human.head && (holder_human.head.flags_inv & HIDEFACE))))
 		flavor_text = obscured ? "Obscured" : holder_human.flavortext_cached
 		flavor_text_nsfw = obscured ? "Obscured" : holder_human.nsfwflavortext_cached
 		ooc_notes += holder_human.ooc_notes_cached
 		ooc_notes_nsfw += holder_human.erpprefs_cached
-		char_name = holder_human.name
+		char_name = (override_visible ? holder_human.real_name : holder_human.name)
 		song_url = holder_human.ooc_extra
 		song_title = holder_human.song_title
 		is_vet = holder_human.check_agevet()
 		if(!obscured)
-			if(vampireplayer && (!SEND_SIGNAL(holder_human, COMSIG_DISGUISE_STATUS))&& !isnull(holder_human.vampire_headshot_link)) //vampire with their disguise down and a valid headshot
+			if(vampireplayer && (!SEND_SIGNAL(holder_human, COMSIG_DISGUISE_STATUS)) && !isnull(holder_human.vampire_headshot_link)) //vampire with their disguise down and a valid headshot
 				headshot = holder_human.vampire_headshot_link
 			else if (lichplayer && !isnull(holder_human.lich_headshot_link))//Lich with a valid headshot
 				headshot = holder_human.lich_headshot_link

--- a/code/modules/mob/living/carbon/human/human_topic.dm
+++ b/code/modules/mob/living/carbon/human/human_topic.dm
@@ -11,7 +11,8 @@ GLOBAL_VAR_INIT(year_integer, text2num(year)) // = 2013???
 	if(href_list["task"] == "view_headshot")
 		if(!ismob(usr))
 			return
-		var/datum/examine_panel/mob_examine_panel = new(src, href_list["overridevisible"])
+		var/mob/M = usr
+		var/datum/examine_panel/mob_examine_panel = new(src, M.mind?.do_i_know(mind))
 		mob_examine_panel.holder = src
 		mob_examine_panel.viewing = usr
 		mob_examine_panel.ui_interact(usr)

--- a/code/modules/mob/living/carbon/human/human_topic.dm
+++ b/code/modules/mob/living/carbon/human/human_topic.dm
@@ -12,7 +12,7 @@ GLOBAL_VAR_INIT(year_integer, text2num(year)) // = 2013???
 		if(!ismob(usr))
 			return
 		var/mob/M = usr
-		var/datum/examine_panel/mob_examine_panel = new(src, M.mind?.do_i_know(mind))
+		var/datum/examine_panel/mob_examine_panel = new(src, (href_list["overridevisible"] && M.mind?.do_i_know(mind)))
 		mob_examine_panel.holder = src
 		mob_examine_panel.viewing = usr
 		mob_examine_panel.ui_interact(usr)

--- a/code/modules/mob/living/carbon/human/human_topic.dm
+++ b/code/modules/mob/living/carbon/human/human_topic.dm
@@ -11,7 +11,7 @@ GLOBAL_VAR_INIT(year_integer, text2num(year)) // = 2013???
 	if(href_list["task"] == "view_headshot")
 		if(!ismob(usr))
 			return
-		var/datum/examine_panel/mob_examine_panel = new(src)
+		var/datum/examine_panel/mob_examine_panel = new(src, href_list["overridevisible"])
 		mob_examine_panel.holder = src
 		mob_examine_panel.viewing = usr
 		mob_examine_panel.ui_interact(usr)


### PR DESCRIPTION
## About The Pull Request
Fixes a bug where, due to some combination of factors including spawn order and advclass selection, people you know at roundstart would show up as "unknown" job and never update. Now, when you open the menu, if they're "unknown job" it'll update that properly.

Clicking someone's name in the known list, assuming they're still online, will now show their examine popup. Note that this does NOT include their chat window examine - but rather the popup window with name, flavortext, and most importantly, ooc notes. This is intended for situations like CM, hag, hand, etc. who will often start knowing their subordinates, but not actually get to SEE them until well into the round. Now, they can check on people from afar, which is VERY useful for checking ooc notes and preserving the illusion that you do, in fact, actually know your coworkers.

By request, if a character has rumors/gossip you have access to, they'll have a ? next to their name that you can click to check them.

## Testing Evidence
<img width="1283" height="704" alt="2026-08-28_13-58" src="https://github.com/user-attachments/assets/9b3ec456-104a-4d32-acf8-35361b1a37e3" />
<img width="1305" height="710" alt="2026-08-28_13-59" src="https://github.com/user-attachments/assets/cbd24490-a1d2-4554-9232-ba9fc3e00a1f" />
Magician's Associate was a class that consistently triggered the bug - and it isn't, here, because by the time you open the known people menu roundstart has resolved and they have a proper job title assigned. Note also that mage associates spawn masked (hood up), but you can see the flavortext anyway - that's unique to examining through the known menu, with the justification that you, well, know each other and should be able to see it. The name showing up as 'moderate man' has already been fixed - again, you can only see real names through masks through the known menu.<br/>

<img width="318" height="215" alt="image" src="https://github.com/user-attachments/assets/5dedc65a-5318-4c18-8ea3-e8c22728a6b7" />
<img width="518" height="48" alt="image" src="https://github.com/user-attachments/assets/bcdcfe3f-0beb-4c6c-bb2a-447871546796" />

## Why It's Good For The Game
Makes playing a member of a faction easier, and should lead to OOC notes becoming far more usable as a feature. Also, it's just nice? And the bug was really starting to annoy me, so it's gone now.

## Changelog

:cl:
fix: Roundstart known characters will no longer have their role title show up as "unknown".
add: Clicking the name of a known character in the known menu will now trigger their headshot/flavortext/ooc notes window. You can do this from anywhere, allowing you to read the OOC notes of all the people that are supposed to, icly, know and work with you. If they have rumors/gossip, a ? will show up next to their name that you can click to view that as well.
/:cl: