### PR TITLE
fix veshlie error sprite

### DIFF
--- a/code/modules/roguetown/roguemachine/merchant/_goldface.dm
+++ b/code/modules/roguetown/roguemachine/merchant/_goldface.dm
@@ -68,6 +68,8 @@
 	)
 	var/is_public = FALSE // Whether it is a public access vendor.
 	var/extra_fee = 0 // Public-tier Porters/Gnomes margin tacked onto base price. Meant to make publicface very unprofitable until Gnomes are unlocked and the margin flows to the Merchant Fund.
+	/// Icon file used for the vendor-merch overlay in update_icon(). Separate from icon so subtypes can use a different base sprite without breaking the overlay.
+	var/overlay_icon = 'icons/roguetown/misc/machines.dmi'
 	/// Running tally of Crown import tariff actually collected via this specific machine.
 	var/tariff_collected_here = 0
 	/// Running tally of Crown import tariff that WOULD have been owed but was dodged
@@ -214,7 +216,7 @@
 		set_light(0)
 		return
 	set_light(1, 1, 1, l_color = "#1b7bf1")
-	add_overlay(mutable_appearance(icon, "vendor-merch"))
+	add_overlay(mutable_appearance(overlay_icon, "vendor-merch"))
 
 
 /obj/structure/roguemachine/goldface/attackby(obj/item/P, mob/user, params)


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->
Fixes the wretchcat overlay error
## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->
<img width="337" height="347" alt="1788023223377205155" src="https://github.com/user-attachments/assets/7ed75c21-f857-46a7-95a3-ca55be5f178b" />

## Why It's Good For The Game
Bugfix
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: vile veshlie no longer plays cs source
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
