### PR TITLE
Fixes age mods not working

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/_classagemods.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/_classagemods.dm
@@ -10,7 +10,7 @@
 	if(H.age == target_age)
 		if(length(stat_mods))
 			for(var/stat in stat_mods)
-				H.change_stat(stat_mods[stat])
+				H.change_stat(stat, stat_mods[stat])
 		if(length(skill_mods))
 			for(var/S in skill_mods)
 				var/datum/skill/skill = S


### PR DESCRIPTION
This hasn't worked for a long time, appparently.

## About The Pull Request

Old age mods were not working. Now they are.

## Testing Evidence

Battlemaster Veteran before - no +1 WIL

<img width="137" height="211" alt="Screenshot 2026-08-29 184216" src="https://github.com/user-attachments/assets/3e7e3be5-1f64-45e7-bb5f-dfad4760ebcb" />


Battlemaster Veteran now - +1 WIL

<img width="152" height="213" alt="image" src="https://github.com/user-attachments/assets/155acc0c-ddf5-4da6-861d-571de9c32029" />


## Why It's Good For The Game

Give the hags and geezers their life support back.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Fixes Old age mods for classes not applying.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
