### PR TITLE
Gives wretches a consistent allowance, removes money from wretchbase

### DIFF
--- a/_maps/map_files/otherz/wretch_coast.dmm
+++ b/_maps/map_files/otherz/wretch_coast.dmm
@@ -8453,7 +8453,6 @@
 /area/rogue/indoors/vampire_manor)
 "JQ" = (
 /obj/structure/table/church,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/money,
 /turf/open/floor/rogue/twig,
 /area/rogue/under/cave/inhumen)
 "JR" = (

--- a/code/game/objects/items/rogueitems/coins.dm
+++ b/code/game/objects/items/rogueitems/coins.dm
@@ -280,6 +280,10 @@
 	. = ..()
 	set_quantity(4) // 20 mammons combine with starting pouch to buy something
 
+/obj/item/roguecoin/silver/pile/wretchpile/Initialize(mapload)
+	. = ..()
+	set_quantity(20) // 100 mammons, perfect for bribing officials and funding gimmicks
+
 /obj/item/roguecoin/gold/pile/Initialize(mapload)
 	. = ..()
 	set_quantity(rand(4,19))

--- a/code/game/objects/items/rogueitems/coins.dm
+++ b/code/game/objects/items/rogueitems/coins.dm
@@ -282,7 +282,7 @@
 
 /obj/item/roguecoin/silver/pile/wretchpile/Initialize(mapload)
 	. = ..()
-	set_quantity(20) // 100 mammons, perfect for bribing officials and funding gimmicks
+	set_quantity(10) // 50 mammons, to avoid being dead broke when latejoining
 
 /obj/item/roguecoin/gold/pile/Initialize(mapload)
 	. = ..()

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/ancient_deathknight.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/ancient_deathknight.dm
@@ -2,7 +2,7 @@
 	name = "Unbound Ancient Death Knight"
 	tutorial = "You were once a Death Knight - a warrior risen from death to serve a master. How long you have been dead - you do not remember anymore. And you find yourself severed from any master's command. Why do you fight? Does it matter? All that you know is to move forward. The world sees you as an abomination. Seek your own path."
 	allowed_sexes = list(MALE, FEMALE)
-	
+
 	outfit = /datum/outfit/job/roguetown/wretch/ancient_deathknight
 	class_select_category = CLASS_CAT_ACCURSED
 	category_tags = list(CTAG_WRETCH)
@@ -80,7 +80,7 @@
 			shirt = /obj/item/clothing/suit/roguetown/armor/gambeson
 			armor = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/paalloy/heavy
 			wrists = /obj/item/clothing/wrists/roguetown/bracers/paalloy/chain
-			
+
 	var/weapon_choice = input(H, "Choose your WEAPON.", "RAGE AGAINST THE LYVING.") as anything in list("Longsword + Shield", "Ancient Greatsword", "Ancient Axe + Shield", "Ancient Mace + Shield", "Ancient Warhammer + Shield", "Bardiche", "Grand Mace")
 	switch(weapon_choice)
 		if("Longsword + Shield")
@@ -115,7 +115,7 @@
 		/obj/item/rogueweapon/huntingknife/idagger/steel/padagger = 1,
 		/obj/item/rogueweapon/scabbard/sheath = 1,
 		/obj/item/natural/feather = 1, //For your helm
-		/obj/item/storage/belt/rogue/pouch/coins/aalloy = 1, //Hilarious
+		/obj/item/storage/belt/rogue/pouch/coins/aalloy/rich = 1, //Hilarious
 	)
 
 	if(H.mind)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/ancient_spellblade.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/ancient_spellblade.dm
@@ -73,7 +73,7 @@
 	backpack_contents = list(
 		/obj/item/rogueweapon/spellbook = 1,
 		/obj/item/natural/feather = 1, //For your helm
-		/obj/item/storage/belt/rogue/pouch/coins/aalloy = 1, //Hilarious
+		/obj/item/storage/belt/rogue/pouch/coins/aalloy/rich = 1, //Hilarious
 		)
 
 	// Chant selection — uses undead faction for "MEMORIES" UI

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/berserker.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/berserker.dm
@@ -35,6 +35,7 @@
 	)
 	subclass_stashed_items = list(
 		"Sewing Kit" =	/obj/item/repair_kit,
+		"Stashed Funds" = /obj/item/roguecoin/silver/pile/wretchpile,
 	)
 
 /datum/outfit/job/roguetown/wretch/berserker

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/deserter.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/deserter.dm
@@ -39,6 +39,7 @@
 	)
 	subclass_stashed_items = list(
 		"Armor Plates" =	/obj/item/repair_kit/metal,
+		"Stashed Funds" = /obj/item/roguecoin/silver/pile/wretchpile,
 	)
 
 /datum/outfit/job/roguetown/wretch/deserter/pre_equip(mob/living/carbon/human/H)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/heretic.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/heretic.dm
@@ -32,6 +32,7 @@
 	)
 	subclass_stashed_items = list(
 		"Armor Plates" =	/obj/item/repair_kit/metal,
+		"Stashed Funds" = /obj/item/roguecoin/silver/pile/wretchpile,
 	)
 
 	extra_context = "This subclass gains the Wound Heal miracle."

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/heretic_spellblade.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/heretic_spellblade.dm
@@ -39,6 +39,7 @@
 	)
 	subclass_stashed_items = list(
 		"Armor Plates" = /obj/item/repair_kit/metal,
+		"Stashed Funds" = /obj/item/roguecoin/silver/pile/wretchpile,
 	)
 
 /datum/outfit/job/roguetown/wretch/heretic_spellblade

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/heretic_spellfist.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/heretic_spellfist.dm
@@ -30,6 +30,7 @@
 	subclass_stashed_items = list(
 		"Sewing Kit" = /obj/item/repair_kit/bad,
 		"Armor Plates" = /obj/item/repair_kit/metal/bad,
+		"Stashed Funds" = /obj/item/roguecoin/silver/pile/wretchpile,
 	)
 
 /datum/outfit/job/roguetown/wretch/heretic_spellfist

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/licker.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/licker.dm
@@ -13,6 +13,10 @@
 	maximum_possible_slots = 2
 	applies_post_equipment = FALSE
 
+	subclass_stashed_items = list(
+		"Stashed Funds" = /obj/item/roguecoin/silver/pile/wretchpile,
+	)
+
 /datum/outfit/job/roguetown/wretch/licker/pre_equip(mob/living/carbon/human/H)
 	..()
 	if(H.mind)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/maestro.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/maestro.dm
@@ -34,6 +34,7 @@
 	)
 	subclass_stashed_items = list(
 		"Sewing Kit" = /obj/item/repair_kit,
+		"Stashed Funds" = /obj/item/roguecoin/silver/pile/wretchpile,
 	)
 
 /datum/outfit/job/roguetown/wretch/maestro/pre_equip(mob/living/carbon/human/H)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/mistwalker.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/mistwalker.dm
@@ -35,6 +35,7 @@
 	)
 	subclass_stashed_items = list(
 		"Sewing Kit" =	/obj/item/repair_kit, //I am sure you'll find a way to repair your bracers
+		"Stashed Funds" = /obj/item/roguecoin/silver/pile/wretchpile,
 	)
 	extra_context = "This subclass gains addition stat points from weapon selection, and is race-limited from: Constructs."
 	adv_stat_ceiling = list(STAT_STRENGTH = 14, STAT_CONSTITUTION = 14, STAT_WILLPOWER = 14) //no thank you to stat stacking

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/munitioneer.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/munitioneer.dm
@@ -44,6 +44,7 @@
 	)
 	subclass_stashed_items = list(
 		"Sewing Kit" =	/obj/item/repair_kit,
+		"Stashed Funds" = /obj/item/roguecoin/silver/pile/wretchpile,
 	)
 /datum/outfit/job/roguetown/wretch/munitioneer/pre_equip(mob/living/carbon/human/H)
 	to_chat(H, span_warning("You are a passable warrior- though weak- but your true strength lies in your ability to bend the resources of Azuria to your will."))

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/necromancer.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/necromancer.dm
@@ -36,6 +36,7 @@
 	)
 	subclass_stashed_items = list(
 		"Sewing Kit" =	/obj/item/repair_kit,
+		"Stashed Funds" = /obj/item/roguecoin/silver/pile/wretchpile,
 	)
 
 /datum/outfit/job/roguetown/wretch/necromancer/pre_equip(mob/living/carbon/human/H)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/outlaw.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/outlaw.dm
@@ -34,6 +34,7 @@
 	)
 	subclass_stashed_items = list(
 		"Sewing Kit" =	/obj/item/repair_kit,
+		"Stashed Funds" = /obj/item/roguecoin/silver/pile/wretchpile,
 	)
 
 /datum/outfit/job/roguetown/wretch/outlaw/pre_equip(mob/living/carbon/human/H)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/pariah.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/pariah.dm
@@ -42,6 +42,7 @@
 	)
 	subclass_stashed_items = list(
 		"Sewing Kit" =	/obj/item/repair_kit,
+		"Stashed Funds" = /obj/item/roguecoin/silver/pile/wretchpile,
 	)
 	extra_context = "This class is restricted to the Elf, Half-Elf, and Dark Elf species."
 

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/plaguebearer.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/plaguebearer.dm
@@ -32,6 +32,7 @@
 	)
 	subclass_stashed_items = list(
 		"Sewing Kit" =	/obj/item/repair_kit,
+		"Stashed Funds" = /obj/item/roguecoin/silver/pile/wretchpile,
 		"Poison Arrows Quiver" = /obj/item/quiver/poisonarrows,
 	)
 

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/poacher.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/poacher.dm
@@ -38,6 +38,7 @@
 	)
 	subclass_stashed_items = list(
 		"Sewing Kit" =	/obj/item/repair_kit,
+		"Stashed Funds" = /obj/item/roguecoin/silver/pile/wretchpile,
 	)
 
 /datum/outfit/job/roguetown/wretch/poacher/pre_equip(mob/living/carbon/human/H)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/profane_champion.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/profane_champion.dm
@@ -28,7 +28,10 @@
 		/datum/skill/misc/swimming = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/reading = SKILL_LEVEL_JOURNEYMAN,
 	)
-	subclass_stashed_items = list("Armor Plates"=/obj/item/repair_kit/metal)
+	subclass_stashed_items = list(
+		"Armor Plates" = /obj/item/repair_kit/metal,
+		"Stashed Funds" = /obj/item/roguecoin/silver/pile/wretchpile,
+	)
 
 	tempo_capable = TRUE
 

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/pyromaniac.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/pyromaniac.dm
@@ -30,8 +30,10 @@
 		/datum/skill/labor/farming = SKILL_LEVEL_NOVICE,
 	)
 	subclass_stashed_items = list(
-		"Armor Plates" =	/obj/item/repair_kit/metal,
+		"Armor Plates" = /obj/item/repair_kit/metal,
+		"Stashed Funds" = /obj/item/roguecoin/silver/pile/wretchpile,
 	)
+
 /datum/outfit/job/roguetown/wretch/pyromaniac/pre_equip(mob/living/carbon/human/H)
 	head = /obj/item/clothing/head/roguetown/helmet/heavy/sheriff //wear protection :)
 	mask = /obj/item/clothing/mask/rogue/facemask/

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/roguemage.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/roguemage.dm
@@ -37,6 +37,7 @@
 	)
 	subclass_stashed_items = list(
 		"Sewing Kit" =	/obj/item/repair_kit,
+		"Stashed Funds" = /obj/item/roguecoin/silver/pile/wretchpile,
 	)
 
 /datum/outfit/job/roguetown/wretch/roguemage/pre_equip(mob/living/carbon/human/H)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/slasher.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/slasher.dm
@@ -38,6 +38,7 @@
 	)
 	subclass_stashed_items = list(
 		"Sewing Kit" =	/obj/item/repair_kit,
+		"Stashed Funds" = /obj/item/roguecoin/silver/pile/wretchpile,
 	)
 
 /datum/outfit/job/roguetown/wretch/slasher/pre_equip(mob/living/carbon/human/H)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/vigilante.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/vigilante.dm
@@ -27,6 +27,7 @@
 	)
 	subclass_stashed_items = list(
 		"Sewing Kit" =	/obj/item/repair_kit,
+		"Stashed Funds" = /obj/item/roguecoin/silver/pile/wretchpile,
 	)
 
 /datum/outfit/job/roguetown/wretch/vigilante/pre_equip(mob/living/carbon/human/H)


### PR DESCRIPTION
## About The Pull Request

Gives almost all wretch classes (aside from the Unbound Ancient Death Knight and Unbound Ancient Azurcaephan) a consistent amount of starting cash, stashed to be retrieved at their convenience. The current amount is precisely 10 ziliquae, for a total of 50 mammon; this can be changed.

Unbound Ancients still don't start with any mammons for their class, but do receive more psila than before. Go nuts.

Removes the random treasure pile of money in the wretchbase. This contained anywhere from just _5-10 mammon_ to upwards of 400, and was consistently rushed by every single roundstart wretch that knew what they were doing. It's gone now.

## Testing Evidence

Compiled, tested with several classes. Booted dunworld.dmm ingame and the money in the wretchbase was gone. WOE

(Screenshot outdated, amount was changed to 10 ziliquae)

<img width="443" height="568" alt="image" src="https://github.com/user-attachments/assets/a5b08baa-4a49-430f-ac96-491e8a6d06f3" />

## Why It's Good For The Game

Wretches have some niche uses for money, but don't directly affect the economy too much. However, having _no_ money can be a pretty nasty thing, especially when the wretchbase has access to things like a vomitorium and its own custom (EXPENSIVE) silverface.

Having some starting capital helps you supply your own gimmick, get set up with specific niche things that your class doesn't start with, and even feed it back into the economy indirectly by buying from people outside of town. If you do go into town to spend it, you'd be putting yourself at risk, so it does encourage at least a little interaction that way.

This could lead to unforeseen consequences if wretches find some powergamey way to make use of starting capital, but I wasn't able to come up with any myself. On some rounds this might actually lead to less money circulating.

You can make money as a wretch by selling in town to the NAVIGATOR, which is tedious and risky and annoying, or by selling to the contraband NAVIGATOR, which is even more tedious and annoying. Otherwise there are scant few ways of making money, which is why I don't think wretches should even be trying to bother.

50 can be adjusted to a lower or higher number, but this has been frequently requested and seems like a good thing for the health of the antagonists.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Wretches now start with 50 mammon
add: Unbound Ancient wretches now start with more psila
del: Removed random money in the wretchbase
/:cl:
