### PR TITLE
[QoL] split timechangetips into actual tips and quotes

### DIFF
--- a/code/__HELPERS/time.dm
+++ b/code/__HELPERS/time.dm
@@ -1,4 +1,5 @@
 GLOBAL_LIST_INIT(time_change_tips, world.file2list("strings/rt/timechangetips.txt"))
+GLOBAL_LIST_INIT(time_change_quotes, world.file2list("strings/rt/timechangequotes.txt"))
 
 //Returns the world time in english
 /proc/worldtime2text()
@@ -165,8 +166,10 @@ GLOBAL_VAR_INIT(date_override_offset, 0)
 		playsound_local(src, 'sound/misc/newday.ogg', 60, FALSE)
 		animate(T, alpha = 255, time = 10, easing = EASE_IN)
 		addtimer(CALLBACK(src, PROC_REF(clear_area_text), T), 35)
+		var/time_change_quotes_random = pick(GLOB.time_change_quotes)
+		to_chat(client, span_notice("<b>[time_change_quotes_random]</b>"))
 		var/time_change_tips_random = pick(GLOB.time_change_tips)
-		to_chat(client, span_notice("<b>[time_change_tips_random]</b>"))
+		to_chat(client, span_notice("<i>[time_change_tips_random]</i>"))
 	else if(GLOB.tod == "day")
 		playsound_local(src, 'sound/misc/midday.ogg', 100, FALSE)
 	else if(GLOB.tod == "night")

--- a/strings/rt/timechangequotes.txt
+++ b/strings/rt/timechangequotes.txt
@@ -1,0 +1,259 @@
+The Holy Ecclesial is a splinter of the Holy See, formed during the great schism. They worship the Four Ascendants as true divinity.
+PSYDON yet lives. PSYDON yet ENDURES.
+Dae is far less dangerous than Nite; Astrata’s gaze is far more searing to all forms of evils in a direct burn.
+The Ten are less responsive to prayer than the Ascendant. The Holy See claims that this is a test of faith.
+The world flooded for a thousand daes before Abyssor was finally put to rest. Some say he will one dae stir from his slumber; his sleep must endure.
+The Empire of the Holy Celestia crumbled after ZIZO consumed the souls of all snow elves in Her ambition for godhood.
+Xylix's gift to mortals is the humble tarot deck, allowing them to divine the fates themselves.
+It is said that Baotha was once twin of Eora. In a jealous lover's quarrel, she attempted to murder her own sister, and was outcast from the Pantheon.
+Pestra once saved the life of Eora. The two are said to have shared a close bond since, though with differing ideas of beauty.
+ZIZO dwells within the hellish north, raging, weeping. Her icy fury manifests as the magickal blizzards that torment Gronn, or so it is said.
+Dendor burst from the feverishly-sleeping Abyssor's head, spilling life forth in a chaotic frenzy.
+Werewolves are tests sent by Dendor to ensure our purity and faith.
+Werewolves are those cursed by Dendor for their sins against nature, damned to consume all they touch.
+Werewolves are blessings sent by Dendor to restore us to a natural way of lyfe.
+Werewolves are the hideous creations of Dendor in his madness, blindly venerated by idiot worshippers of the Ten.
+Challenging a Matthiosite is challenging a Ravoxian. Both fight for their deity, but both have vastly different senses of Justice.
+Pestra is said to have slithered from the guts of Psydon, decayed and fetid, last of the Ten to emerge.
+Necra, in the oldest tomes, is said to be a being older than Psydon. The Holy See itself calls this heresy.
+It is claimed that Noc invented alchemy by the Holy See. The Holy Ecclesical claims it was the creation of Matthios.
+Thousands of years ago, PSYDON sent down the COMET SYON to defeat the rampaging Archdevil, splitting himself into Ten.
+When Matthios stole Astrata's sacred flame and sold it to mortals, he created the first Transaction. This flooded ontological reality with the fact of Wealth.
+Necrans despise deadites and wish them exterminated or cured; Pestrans wish them cured, but think that pustules are neat!
+The divines smile upon your prayers in front of a psycross, but never mention them the name of the Dark Shepherd.
+The best way to deal with a mage is to shut them up.
+Ravox stands for justice, not murder.
+Heretical tomes suggest Xylix shares a fondness for Graggar, a former slave who broke free of his chains. Others propose a fondness for Matthios, who played a trick on the gods themselves.
+The Rontz is said to be Matthios' hardened blood, weeping from his burns as he clutched Astrata's fire between his fingers. This dissuades few people- it is worth a lot of money, after all.
+Coins are often buried with the dead to pay for the Carriageman's services.
+Zardmen tails are said to bring good luck if burned and scattered as powder.
+Lux from a tiefling is thought to be toxic. It is often purified with silver before transplantation.
+Pestrans oft suffer bad relations with the rest of the Church, as their fixation on rot and decay is looked on increasingly with distrust in the new era of necromancy. Sects of physickers keep increasingly to themselves.
+Malum used to carry a divine hammer that gave life to all material things Azure Peak was built upon. It is now lost to history.
+Carrion-beasts, cheeles, and nagas are sacred to Pestra. Those who slay them are often punished with terrible plagues.
+Eora stands for far more than familial love, but frowns upon those who break matrimony.
+What better trick than stealing fire from Astrata herself?
+Blood freely spilled always offers greater power, for it carries the worth of both the blood and the choice. Always obtain a willing victim, if you can.
+Aasimar blood is thought to have powerful protective properties. Superstitious soldiers may ask to be anointed with a drop before a battle.
+Black cats are symbols of death, and sacred to Necra. They stare at souls only they can see, and lead them to the Carriageman.
+Trolls are thought to have once guarded Dendor's realm. Druids often seek them out. Few return.
+Drow mushroom wines are said to be delicious as long as they are paired with the right antidote.
+Servants of Xylix are often capricious and untrustworthy, but all share in their god's hatred for slave-taking.
+Azure Peak used to belong to the once-great Celestial Empire, which was fractured by ZIZO's ambition and cunning. It is a shadow of its former self.
+Graggar was given power as Ravox's champion; and with it, he clawed a hole through the crumbling firmament to divinity.
+The Gods are listening. To utter the name of ZIZO is to attract her attention, and your damnation.
+The Inhumen have many names. In the frozen, forsaken north, they are revered as sacred animals- the Moose, the Leopard, the Bear, and the Volf.
+O fate, you are as fickle as Lirvassian gold.
+For the entire world, the annihilation of an entire species was seen as a cataclysmic event that shook reality to its core. For Her, it was taking one step of many.
+Zizo is nothing but a name to masquerade Her identity. To make Her feel like a fairy tale. If they learned that Zaelarion was a mere mortal as well, they'd no longer pray to the Ten.
+A Ravoxian should not confuse striking at evil and bringing justice, lest their justice become the act of striking.
+The Undermaiden claims all souls, in time. Her servants can avert death, but frown on reversing it.
+Gaze upon the works of PSYDONIA, ye mighty, and weep!
+The church frowns upon the trade of Wealth, for the sin of Matthiosian heresy is inherent to it. Tithing is a controversial practice among the devout, and often a source of Otavan infighting.
+When Dendor first clawed free of Abyssor's skull, he shed parts of himself like a snake's skin. This skin became the Lamia.
+ZIZO stole the souls of all snow elves in Her ascension. They serve eternally in her undead armies, forever freed from Necra's grasp.
+In the past, the Warscholars of Naledi were systematically prosecuted by the Holy See for Psydon-worship and heresy. Even under threat of death and torture, many refused to bow. Blessed Lamb; die for your beliefs. Die, die, die.
+Most citizens of Grenzelhoft cannot remember a time the empire was not at war. Many turn to mercenary work to escape the crushing poverty of the lower class. Others turn to banditry.
+The firmament is at its thinnest in Azurea, where the COMET SYON landed, and the dark-star Graggar thrashes, entombed underneath the earth. More gods have bled here than anywhere else in the mortal world.
+It is said that Astrata once took the form of a mortal, having fallen in love with a prince named Antero, and ultimately sacrificed Her mortal form to protect her child from Necra's clutches. It did not work.
+The sprawling tundra of Aavnr is the homeland of the Orc race. Few travel there willingly.
+Vampyres are sun-cursed creechers spawned from Astrata's ill-fated attempt at a family. She has forgiven none of the Pantheon for this. Not Noc, not Xylix, and not Necra.
+A comet capable of rending all the enemies of humanity apart; oh, how graceful His power was! And His sacrifice, ever so noble! Yet now He slumbers, unaware of the fruits His efforts came to give. And He sighs. And He weeps.
+Dragons are holy symbols of Matthios—incarnations of greed and stolen sunfyre. To slay one is a holy, and often suicidal, task.
+Merchants and the rich are often viewed with suspicion of Matthiosite heresy by the Inquisition. Except, of course, for nobility, who have divine right to wealth.
+The Ten will have you think He is powerless, and the Four that he is dead; but all He asks of you is for your faith to ENDURE.
+The powerful nation of Otava is home to a radical denomination that venerates PSYDON above all, seeing the TEN as mere fragments of True Divinity. Azure Peak is home to a small enclave of this Psydonian Order.
+The Naledi captal of Veralun is a prosperous metropolis built around an oasis. Gleaming gold filigree marks white-marble buildings. Grand mosques stretch their minarets to the sky in praise of PSYDON.
+I AM OLDER THAN AEON. I AM SIN, FATHER OF LIES. I HAVE GONE BY MANY NAMES. SAY THEM AND WEEP, FOR I AM ALL THAT THEY ARE.
+Working yourself to death is considered an act worthy of veneration for Malumites—so long as you finish your creation.
+The Sovereignty of Otava is a lush wet country home to the best stoneworkers on Psydonia. The gigantic towers of the Grand Cathedral in the capital stand as the seat of the Otavan Inquisition.
+A traditional Psydonic greeting or farewell is 'purity afloat.' The psycross is often held over the chest during this ritual.
+Blacksteel is a pale imitation of the Zizo-blessed Darksteel, which is gifted to Her followers in Her benevolence.
+The Gronn Highlands are a mountainous region known for its jagged peaks and terrible blizzards. It is home to a hardy, brutal people who struggle to survive against the land, building fortified stone villages that cling to cliffsides.
+Dwarves are renowned for their artifice and craftsmanship, having been least affected by the collapse of the Celestial Empire. They are only mostly dead.
+The Raneshen Empire is a vast dry region primarily made up of sprawling forests and arid lands. It is famous for its rich silks, splendorous gold, and expansive slave trade.
+Most Dwarves hail from Hammerhold, either from above or below. Confusing a surface-dwarf and an underground-dwarf is likely to get you kicked in the shin.
+The Isles of Etrusca are a sun-kissed archipelago nestled in sparkling blue waters. Known for their rich maritime culture, the Etruscans are masterful sailors and traders, navigating the seas with swift, ornate galleons adorned with colorful sails.
+ZIZO. ZIZO. ZIZO.
+To seek progress is to paint with your blood. The greater the work, the harsher the price.
+Scent of rot and shit; my feet find fetid ground. A corpse—I am living on a corpse. And then the world is normal again.
+Worshippers of the Ascendants are fools hellbent on dooming our world and must be corrected or destroyed.
+Worshippers of the Ten are fools hellbent on dooming our world and must be corrected or destroyed.
+Worshippers of the One are fools hellbent on dooming our world and must be corrected or destroyed.
+LOOK UP TO THOSE WHO EXCEL AT VIOLENCE; THEY CARRY THE WILL OF THE GODS AND RECIEVE PUNISHMENT OF HELL BEYOND HELLS.
+O SYDON, forgive your wayward child. Forgive us our ignorance. Forgive us our defilement of your corpse.
+The heads of goblins, minotaurs, dragons, trolls, and various other creachers can be sold to the HEADEATER in town.
+Wearing a red tabard provokes even the most serene minotaur.
+ASTRATA is a VILE TYRANT and must be CONSUMED AND SUBSUMED.
+ASTRATA is law made manifest and must be respected, lest society fall into chaos.
+No pursuit was too perilous, no sacrifice too great. Until, well...
+Under the Heavens and the Many Stars, there are darker things than men may dream of.
+Lupians make exceptional zealots. Ask the Otavan Inquisition.
+Stories tell that Noc stole Dendor's curse to create Humen of his own, and thus Lupians came to be. A poor imitation.
+Stories tell that Noc stole Dendor's blessing to create Humen of his own, and thus Lupians came to be. An honest attempt.
+Solitary Lupians who suffer from gigantism are often mistaken for werevolves and shot without question, so they travel in packs - be it with their own or other peoples.
+Drakian... Fluvian... Lupian... They're all wildkin, why do we bother giving them names?
+To trust an Abyssorite is to believe in Xylix. Since the first communion, his followers frequently fall to madness.
+Shal'ghur is a city only known by this name, denoted affectionately by creatures that dwell in Abyssor's dream. The shades of winding streets full of the damned reflected in his realm. A cautionary tale on the dangers of dream incursions.
+The mast buckles, as the ship is led through treacherous waters by Abyssorite under Astrata's gaze. Sleeping eyes giving way for the faithful of Noc, who continue their toil at nite.
+To dream is to commune with Abyssor. Coffee is a sin, but a bit of Camomille tea never goes amiss.
+The righteous cult of Abyssor seeks to keep the old one asleep. His Sentinels and Acolytes often find employ within cities and the Holy See. it is immessurably expensive to scrawl down so many glimpses of dreams, yet the faithful do not care that most of it is gibberish.
+Heretical Abyssorites are despised by many, even their own ilk often think twice of associating with them. Whether it's fear of the destruction wrought by a waking Abyssor, or to condemn the time wasted by their attempts.
+One does not need to be devout, even those unbelieving can get caught by the predaceous dream of Abyssor. It consumes them, unable to tell his realm apart from their own. Yet suddenly, everything seems possible.
+SANCROGENESIS: the creation of holy life, as if touched by PSYDON Himself. It was a mere shard of the power that He held. ...but it is said to have been a considerable haul for the God of Thieves and Capital, nonetheless.
+...and so, it is said Matthios took his sword and cut a hole in the boundary. Before it closed, and the river of life dried, the unmoving earth-maw clawed from its basalt-amniotic womb and roared their first breath into the sky. THE SECOND TRANSACTION.
+THERE IS A TUMOR DIRECTLY BEHIND MY LEFT EYEBALL; I NEED TO REACH IN AND CLAW IT OUT BEFORE IT FUCKING EATS ME.
+Rot piled up to my ankles, smell of death, quietly-crept decay from the weeping God 'neath I.
+Astrata, Psydonia, Noc, Hermes, Kytheria, Nepolx, Jove... diviners oft theorize even more celestial bodies exist.
+The pen is not mightier than the sword. The pen merely persuades many swords to it's cause.
+I DREAM OF A DARK, BLUE STAR IN THE SKY. IT'S RED EYES GAZE AT ME WITH CONTEMPT. IT GROWS IN SIZE EVERY SECOND.
+PHYSICAL POWER ALLOWS THROWING A PUNCH. MENTAL POWER ALLOWS THROWING A FIREBALL.
+Adventurers beware: barber surgeons speak of red potions causing tumors in the liver...
+Adventurers rejoice: barber surgeons speak of red potions curing tumors in the liver!
+Stone to coal, coal to iron, iron to gold, gold to toper... thus goes the alchymist's mantra.
+BLOOD RAIN SYMBOLIZES THE GROWING POWER OF Z AND G. IF I SEE IT, I SHOULD EXPECT VIOLENCE.
+IN these DARK daes within the REALMS. One would do well not to wander into the woad...
+The Fulmen Chair's true name is the "ZRONK", named for the first associate of Magellan to pull the lever. His lyfe, taken, to fuel another.
+LEFT HAND. RIGHT HAND. LEFT HAND. I SCALE THE CLIFF. I SEE ASTRATA'S DAWN. MY BODY TIRES, BUT I AM FREE FROM THE MENACE BELOW.
+Often used measurements include the 'mote' for time, the 'cubit' or 'imperial foot' for length, and the 'dram' for liquid volume.
+I KICK THE LAMPTERN. THE FYRE-BEARER BLOCKS MY SHOT-- MY TEAM LOSES THE GAME OF LAMPTERNBALL!!!
+I SEE THE DREADED GEM-EATER. HIS METAL MITTS HOLD MY HIDDEN STASH OF SAFFIRA. ONE BY ONE, HE POPS THEM INTO HIS MOUTH...
+WHY IS IT WRITTEN SAIGA AND NOT PSYGA?
+SAKURA LEAVES FALLING IS A SIGN OF EORA'S GROWING POWER. IF I SEE THEM, I SHOULD EXPECT PEACE...
+Focusing on your SPECIAL powers outside of combat allows deft fingers to pick pockets.
+Nobody in Otava owns a thesaurus. No synonym for 'endure' will ever be used.
+Graggar, in his ascendancy, broke the chains of many monsters, and set them loose on the world. Some slaves pray to Graggar, too, that their chains may be broken.
+The glittering black gemstones of onyxa are said to prized by warlocks and drow for black rituals. The face reflected in its shard is never your own.
+The cult of Matthios, the thief-of-fire, idolizes greed as a virtue. While often at odds with Zizoid cults, on one thing they agree- to want more is only reasonable.
+Eating the fyritus flower will prevent one from being infected by werewolves.
+Pestran witchcovens developed the art of potion-making in ancient times. Modern alchemy bears little resemblance to its oldest forms, but the stereotype of the wart-nosed witch remains, for better or worse.
+The famous Raneshi 'desert riders' are among the most skilled swordsmen in the world. They'd all kill their own mother for a piece of coin.
+Prestidigitation is often known as the apprentice's friend, as it helps remove char and soot before the Magos notices.
+'Mageburn' is the colloquial name for injury from backfiring spells, such as fireballs at close range. The surest sign of a new apprentice is burn marks on the hands and face.
+The ideal number for an adventuring party is a band of five. This tradition dates back nearly a century- to the band of five heroes that overthrew the Mad Duke.
+The fortress of Gundu'zirak was once dedicated to the production of golems and dolls. Its ruins lie under Mount Decapitation, along with the other hundred horrors there.
+The fastest way to attract the attention of a god is to say their name. In some cases, this is a very bad idea.
+Sacrifices to the gods are common forms of worship, and thought to earn their favor. Food, coin, animals and relics can all be offered.
+Ravox exults in GLORY. Duels are honorable and righteous, and it is dishonorable to strike a surrendering opponent.
+Humens are famous for their greed- so much so that it is one of their number who became the god Matthios. This has earned them much ire.
+Ravoxians are all morons.
+Graggar does not stand for 'might makes right.' The truth is more concise: Might makes.
+Old enough druids are thought to eventually turn into trees. Treehood is an ideal state for some adherent worshippers of Dendor.
+The Necran symbol is a jawless skull. A smiling skull is used to represent ZIZO.
+Many Necrans seek to come closer to the threshhold between lyfe and death. Some emulate the silence of the grave, and take vows never to speak.
+In antiquity, it is said mortals could once travel to the Underworld to speak with the departed- since the ascension of ZIZO, it is now the dead who cross to menace the living.
+Undeath takes many forms. Wraiths and spectres haunt the steppes of Aavnr, will-o'-the-wisps feed on the unlucky travellers of Grenzelhoft, and in distant Naledi, ghuls and mummies drain blood with a touch.
+The people of Naledi believe that face coverings and bright colors ward off nitecreechers and bodystealers, like the fabled alghul and djinn. Gold, silk, and ceruleabaster decorate their robes and trinkets.
+The divinatory astrologists of Naledi are unmatched throughout Psydonia. Naledi believe deeply in prophecies and fortune-telling in the stars, and a starless sky often inspires terror.
+The pomegranate is the sacred fruit of Eora.
+Zenitstadt is the second largest city in Grenzelhoft, and home to their famous fencing guilds. Most Grenzel mercenaries hail from here, and almost all of them have something unpleasant to say about it.
+Eora's spheres encompass sex, love, blood and motherhood. A common Eoran tradition is for the bethrothed to slit open the palm and mix blood with their partner, to symbolize an eternal commitment.
+Love is thought to be carried from the heart through the blood. It is believed among some that blood that mixes is proof of compatibility, and blood that coagulates means that it's probably time to see other people.
+THROW A BOMB INTO THE CHURCH DO IT NOW DO IT NOW DO IT NOW
+A lesser-worshipped aspect of Noc is cold and winter. In Aavnr, this is mostly what he is known for.
+THE INQUISITION IS ALL VAMPIRES AND THAT'S WHY THEY WANT YOUR BLOOD. THINK ABOUT IT.
+The elven Black Oak clan once called this duchy home. Their remnants occasionally pepper unfortunate travellers with arrows.
+An entire Grenzelhoftian warparty marched into the Terrorbog, once. Twenty years later, the lost legion still walks, and they will never stop.
+The Celestial Academy of Magos (sometimes referred to as the Magisterium of Grenzelhoft) is considered one of the finest schools of magic on the continent. They are famous for their war-mages, pointy hats, and condescension. A certificate from one of the Magisters is considered as prestigious as it gets.
+Malumites often light a single candle before starting work. When the wax is only a stub, only then is a break allowed.
+Blacksmith can I have fluted cuirass and steel chausses and plate gauntlets and plated boots and steel bracers and steel full coif hey where are you going
+Grenzelhoft recently abolished the purchase and trade of slaves, sparking mass outrage from both Raneshi slave-trading guilds.
+Cultists of Noc often take on a new name, called a Nocturne, and shed their past identity. Traditionally, this is to protect one's True Name from a summoned demon, though in more modern times, it serves the secondary benefit of hiding one's identity from a vengeful landlord wondering why their house is on magefire.
+Cultists of Noc pursue wisdom, study, scripture and divination. Many of Psydonia's greatest discoveries have come from a Noccite sect. Many of Psydonia's greatest fires have also come from a Noccite sect.
+The ruins of Azuria are dotted with ancient, crumbling statues and fixtures. It is thought that the most ancient of these are Aasimar, who one day stopped moving, and never started again.
+Aasimar cannot die of old age. Sometimes, however, they simply give up, and turn fully to stone. It is considered bad luck to deface a statue, as a result.
+Everything these tips tell you is made up.
+Everything these tips tell you is completely true.
+You should move to Kingsfield. It's better there.
+Every yil, Heartfelt hosts a grand banquet for the nobility of Azuria, Rockhill, and Zyndvhartia to attend. The Holy Psydonic Inquisition is credited with thwarting an attempted bombing of its palace, during the previous yil's feast.
+They say that Heartfelt has fallen to a horde of the living dead, or-.. no, wait, wasn't that the Rudmarsch?
+Adonai, my God, why hath you forsaken me?!
+BEFORE THE FINAL BLOW WAS STRUCK, I TORE OPEN A PORTAL IN TYME AND FLUNG PSYDON INTO THE DAES-TO-COME; WHERE MY SIN IS LAW! NOW.. THE LOWLY FOOL SEEKS TO RETURN TO THE PAST, AND UNDO THE EVIL THAT IS VHESLYN!
+Blastpowder was originally created by Hammerhold's wisest dwarve-alchemists to 'spice up' bubbleless ale. All it took was an errant spark - and the cellar's subsequent obliteration - to reveal an alternative use.
+Glimmering slag and gold have two things in common; they're both useless on their own, and they both thrumb with latent magicka. Perhaps alloying them together, three-to-one, could offer something new?
+What's the difference between a longsword, broadsword, and bastard sword? One's for a noble, another's for a knight, and the last one's for whatever they make after a nite of drunken revelry.
+Bronze tools, weapons, and armor tend to be sharper and sturdier than their iron-wrought counterparts. The trickier part is forging the alloy; but, perhaps fashioning a smelter out of stone, charcoal, copper and tin could do the trick.
+Bronze is cherished by the worshippers of Ravox; the first alloy gifted to Psydonia, hewn into plate-and-blade by Man to bring justice unto the wicked. His most ardent paladins oft-forsake steel longswords, in favor of bronze flamberges.
+They'll tell you that the first alloy known to Psydonia was bronze, but they'd be lying.
+Gold can be used to forge the finest - and most expensive - arms in all of Psydonia. Mind the fragility, however; they're meant for ceremonies, not clashes.
+Gold is paradoxically cherished by the worshippers of both Astrata and Matthios; the catalyst of ultimate authority, fit to both establish and usurp tyranny.
+Silver is cherished by the worshippers of Psydon, as they believe it to be the fragments of a divine alloy; the very same used to arm His angels in their war against the Archdevil.
+Silver is cherished by the worshippers of Noc, as they believe it to be the fragments of divine magicka; a catalyst that would eventually reintroduce arcyne secrets to the worthy.
+Joapstone, Petriamber, Rosellusk, and Aoetal are not real stones. Do not listen to the rambling of gem-crafting madmen.
+Gemerald skulls are a sign of calamity. Folk-tales mention their service to the darker impulses of the Trickster God.
+The rat overlords inside the SCOMS are fond of cheese. Feed them and the cries of your victims will go unheard... for a time.
+College mages are often good sources of treasure. They steal from the university as much as any rogue does.
+Inspect tabards closely, they tend to bear the names of the wearer... or horrible jokes.
+When my tyme comes, tell me - will I stand up?
+One of the rarer flowers known to Psydonia is the black rosa, exclusively grown along the highlands that border Otava, Grenzelhoft, and the Fjall. They are believed to have mystical properties, especially when used to invoke rites for funerals and sacrifices.
+Littered across the Terrorbog are old pathways and ruined battlements; the remains of a doomed attempt to colonize that which refuses to kneel before civilization.
+We don't go to the Terrorbog.
+Nocmas is the most cherished holidae amongst the elders and youth of Psydonia, where the harshest nites of the winter solstice are countered with freshly-baked pastries and freely-exchanged books. Naturally, the Holy Psydonic Inquisition has barred Nocmas from being practiced within Otava's borders, on the grounds of it 'corrupting the youth with unholy thoughts of progress.'
+Amongst many pre-Orthodoxic denominations of Psydonism, it is traditional to not invoke His name; for to do so outside of the gravest circumstances would be to dishonor His sacrifice. Instead, they honor Him as 'the Weeping God' - most adrently, through grand and elaborate rituals performed on the winter solstice.
+Worship of the Archdevil is rumored, but scarely proven. Ushering in the complete annihilation of reality, as it turns out, is the only line that not even the most ardent Ascendants or Psydonians will dare to cross.
+The Northern Empty's landscape has been irreversably altered by the calamities that had been hosted upon its soil; the birth of the Archdevil's invasion, and the death of Zizo's celestial empire.
+Better known as the Fjalls, the Northern Empty is rumored to hide Psydonia's most well-sought truths beneath its permafrost. The few Fjallic natives who've embarked southward rarely entertain such rumors, however.
+In ancient tymes, the Archdevil's worshippers symbolized their faith with a blazing vortex. Purportances of it instead representing the Sun, preceding Astrata's reign, are harshly punished by the Church's scholars.
+Whirlwinds, though rare, are unmatched in terms of sheer devastation. Worshippers of the Pantheon oft-attribute them as conduits of divine retribution, while Psydonians fear them as spasms of Archdevyllic magicka.
+Corrupted silver burns the unanointed palm, and sunders the lyving without mercy. Such is born from dark magycks, known best by the lyches and necromancers of Zizo.
+Zizo sacrificed the entirety of Her people to ascend, but something went terribly wrong. Now, a million are one; and in the darkest nites, they say you can see Her crimson vortex screaming through the dimmest stars.
+Zizo sought to save Her people from an infertilizing ailment that would soon doom them to extinction. All that She needed was a sliver of His power; yet even She could've never accounted for how weak the filament was.
+Zaelarion, Adonai, Vheslyn. You will know these names, in due tyme.
+Mount Golgatha once hosted the final battle between the mortal vessels of Ravox and Graggar. When His blow cleaved Graggar's neck asunder, Ravox sought to bury the decapitated remains within its magmatic depths.
+Mount Decapitation is always blanketed in a thick layer of snow, owing to its elevation. It cradles many secrets and riches beneath the snow, yet plenty of perils as well.
+Strange dreams seem to trail all who inhabit Azuria. To hear someone remarking about a 'week' with unusual and unfortunate fates isn't uncommon, but one should be wary to discern whatever facts might've been laced into such fiction.
+Azuria cradles the remains of the Comet - and with it, the power to alter the very fate of Psydonia itself.
+Some say that the Psydonites of the future have created a machine that can traverse through tyme itself, in order to prevent the eternal darkness from coming to pass.
+If you are staying in a wayside inn and two men force entry to your room? Kill them with your crossbow.
+The evil ZYDON sent down his COMET to destroy the GREAT WORM, and for thousands of yils you will pay the price.
+Fire is orange-red, and sometimes sylver-white. If you see any other colors of fire, please inform the Inquisition immediately.
+Insert the needle into your eye. Open your mind to the truth - that this world must fall, and all within it rendered to ash.
+There are only three things that're certain; death, taxes, and the quality of an Innhouse's liqour.
+Losing is fun!
+It was all a dream.. ?!
+I hate you. I hate you. I hate you.
+I love you. I love you. I love you.
+Dwarves.
+Dwarves like to blow stuff up!
+You are a knave!
+It's a tough fight ahead, but happiness has to be fought for.
+The Duchy of Azuria beat back the Hammerholdian Border Reivers in 1430 at a great cost. Some still lurk in the forests, biding their tyme.
+You now face divine judgement. May it extend eternally.
+BAITING is a suboptimal combat strategy. Never use it. Instead, stab your foe in the chest until they perish.
+BEWARE those who venerate the ARCHDEVIL. The INSANE, the BROKEN, the SADISTIC, and YOU.
+BEWARE those who venerate the WEEPER. The INSANE, the ZEALOUS, the FOOLISH, and YOU.
+BEWARE those who venerate the TEN. The INSANE, the VAINGLORIOUS, the DELUDED, and YOU.
+THE PROFANE SABBATH DRAWS CLOSE. SEND WORD; THE END IS NIGH.
+A SEA OF PHLOGISTON. A RAINBOW CASTLE IN THE SKIES. THE FINAL VOYAGE.
+A WEEPING PSICROSS. A RING OF DRAGONSTONE. A FLAMING DORPEL.
+A BURNING WORLD. A CLENCHED FIST. A STAINED BLADE.
+A DREAMER'S MAZE. A MOUNTAIN OF CORPSES. AN ILLUSIONARY TRUTH.
+PLACES, EVERYBODY! WE'RE BACK ON THE STAGE IN FIVE MINUTES!
+..AND THEY LYVED HAPPILY EVER-AFTER? PFFAH, LIKE THAT'S EVER GOING TO HAPPEN!
+..AND THAT'S A WRAP!
+..AND THAT'S ALL SHE WROTE!
+VESTUMED ACTOR, DID YOU REMEMBER TO REHEARSE YOUR LINES?
+ENJOYING THE WEEK? REFILL YOUR POTIONS - YOU'LL LOVE WHAT'S COMING NEXT.
+THE CURTAINS BEGIN TO CLOSE, AND I TAKE A BOW; YET THE AUDIENCE ROARS - 'ENCORE, ENCORE!'
+GODMACHINE, I BESEECH YOU! RUPTURE THE FILAMENT, AND GIFT ME THE POWER THAT HE HAD LEFT BEHIND!
+ADAMANTIUM? MITHRIL? POPPYCOCK!
+SEVEN DAES. SEVEN DAES ARE ALL I CAN SPARE TO PARLAY WITH THEE.
+LET ME PUT IT IN A WAY YOU'D UNDERSTAND; DO WHAT I SAY, OR DRINK PHLOGISTON.
+IN THIS WORLD, IT'S KILL OR BE KILLED.
+YOU ARE FILLED WITH DETERMINATION.
+I DON'T WANT TO DIE ANYMORE.
+I'M READY TO DIE!
+REBOLT. RECALIBRATE. REENAGE.
+WHEN WAS THE LAST TIME YOU SAW A SAIGA WILDKIN?
+A CLEAVED HEAD NO LONGER PLOTS.
+DON'T FORGET, I'M WITH YOU IN THE DARK.
+STRIKE FAST AND STRIKE TRUE: THE BLADE IS MY GOD.
+TWO TO THE HEART, ONE TO THE MIND: DON'T YOU HESITATE.
+IT'S OVER!
+IT BEGINS!
+LET CHAOS TAKE THE WORLD.
+FIX YOUR HEART OR DIE.
+HELL IS REAL.
+LIMIT?! I GOT YOUR LIMIT RIGHT HERE!
+YOU WILL KNOW HIM WHEN HE COMES.
+I AM %HERO%.

--- a/strings/rt/timechangetips.txt
+++ b/strings/rt/timechangetips.txt
@@ -1,263 +1,53 @@
-The Holy Ecclesial is a splinter of the Holy See, formed during the great schism. They worship the Four Ascendants as true divinity.
-PSYDON yet lives. PSYDON yet ENDURES.
-Dae is far less dangerous than Nite; Astrata’s gaze is far more searing to all forms of evils in a direct burn.
-The Ten are less responsive to prayer than the Ascendant. The Holy See claims that this is a test of faith.
 I can jump further by getting a running start. Mind the overshoot.
-The world flooded for a thousand daes before Abyssor was finally put to rest. Some say he will one dae stir from his slumber; his sleep must endure.
 Rest shall heal your beleaguered body. Any smart adventurer brings a bedroll... and a lookout.
-The Empire of the Holy Celestia crumbled after ZIZO consumed the souls of all snow elves in Her ambition for godhood.
 A torch should be kept dry, and a blade sharp.
 The key to a long life is knowing when to run.
-Holy miracles are lethal to deadites, and unholy magicks mend their bones and skin.
-Xylix's gift to mortals is the humble tarot deck, allowing them to divine the fates themselves.
-It is said that Baotha was once twin of Eora. In a jealous lover's quarrel, she attempted to murder her own sister, and was outcast from the Pantheon.
-Pestra once saved the life of Eora. The two are said to have shared a close bond since, though with differing ideas of beauty.
-ZIZO dwells within the hellish north, raging, weeping. Her icy fury manifests as the magickal blizzards that torment Gronn, or so it is said.
-Dendor burst from the feverishly-sleeping Abyssor's head, spilling life forth in a chaotic frenzy.
-Werewolves are tests sent by Dendor to ensure our purity and faith.
-Werewolves are those cursed by Dendor for their sins against nature, damned to consume all they touch.
-Werewolves are blessings sent by Dendor to restore us to a natural way of lyfe.
-Werewolves are the hideous creations of Dendor in his madness, blindly venerated by idiot worshippers of the Ten.
-Challenging a Matthiosite is challenging a Ravoxian. Both fight for their deity, but both have vastly different senses of Justice.
-Pestra is said to have slithered from the guts of Psydon, decayed and fetid, last of the Ten to emerge.
-Necra, in the oldest tomes, is said to be a being older than Psydon. The Holy See itself calls this heresy.
-It is claimed that Noc invented alchemy by the Holy See. The Holy Ecclesical claims it was the creation of Matthios.
-Thousands of years ago, PSYDON sent down the COMET SYON to defeat the rampaging Archdevil, splitting himself into Ten.
 The Jacksberry bush, known for its edible berries, is closely-related to its deadly-poisonous cousin of the same name. So much so that they sometimes cannot be told apart.
-When Matthios stole Astrata's sacred flame and sold it to mortals, he created the first Transaction. This flooded ontological reality with the fact of Wealth.
-Necrans despise deadites and wish them exterminated or cured; Pestrans wish them cured, but think that pustules are neat!
-The divines smile upon your prayers in front of a psycross, but never mention them the name of the Dark Shepherd.
-The best way to deal with a mage is to shut them up.
-Ravox stands for justice, not murder.
-Heretical tomes suggest Xylix shares a fondness for Graggar, a former slave who broke free of his chains. Others propose a fondness for Matthios, who played a trick on the gods themselves.
-The Rontz is said to be Matthios' hardened blood, weeping from his burns as he clutched Astrata's fire between his fingers. This dissuades few people- it is worth a lot of money, after all.
-Coins are often buried with the dead to pay for the Carriageman's services.
-Zardmen tails are said to bring good luck if burned and scattered as powder.
-Lux from a tiefling is thought to be toxic. It is often purified with silver before transplantation.
-Pestrans oft suffer bad relations with the rest of the Church, as their fixation on rot and decay is looked on increasingly with distrust in the new era of necromancy. Sects of physickers keep increasingly to themselves.
-Malum used to carry a divine hammer that gave life to all material things Azure Peak was built upon. It is now lost to history.
-Carrion-beasts, cheeles, and nagas are sacred to Pestra. Those who slay them are often punished with terrible plagues.
-Eora stands for far more than familial love, but frowns upon those who break matrimony.
-What better trick than stealing fire from Astrata herself?
-Blood freely spilled always offers greater power, for it carries the worth of both the blood and the choice. Always obtain a willing victim, if you can.
-Aasimar blood is thought to have powerful protective properties. Superstitious soldiers may ask to be anointed with a drop before a battle.
-Black cats are symbols of death, and sacred to Necra. They stare at souls only they can see, and lead them to the Carriageman.
-Trolls are thought to have once guarded Dendor's realm. Druids often seek them out. Few return.
-Drow mushroom wines are said to be delicious as long as they are paired with the right antidote.
-Servants of Xylix are often capricious and untrustworthy, but all share in their god's hatred for slave-taking.
-Azure Peak used to belong to the once-great Celestial Empire, which was fractured by ZIZO's ambition and cunning. It is a shadow of its former self.
-Graggar was given power as Ravox's champion; and with it, he clawed a hole through the crumbling firmament to divinity.
-The Gods are listening. To utter the name of ZIZO is to attract her attention, and your damnation.
-The Inhumen have many names. In the frozen, forsaken north, they are revered as sacred animals- the Moose, the Leopard, the Bear, and the Volf.
-O fate, you are as fickle as Lirvassian gold.
-For the entire world, the annihilation of an entire species was seen as a cataclysmic event that shook reality to its core. For Her, it was taking one step of many.
-Zizo is nothing but a name to masquerade Her identity. To make Her feel like a fairy tale. If they learned that Zaelarion was a mere mortal as well, they'd no longer pray to the Ten.
-A Ravoxian should not confuse striking at evil and bringing justice, lest their justice become the act of striking.
-The Undermaiden claims all souls, in time. Her servants can avert death, but frown on reversing it.
-Gaze upon the works of PSYDONIA, ye mighty, and weep!
-The church frowns upon the trade of Wealth, for the sin of Matthiosian heresy is inherent to it. Tithing is a controversial practice among the devout, and often a source of Otavan infighting.
-When Dendor first clawed free of Abyssor's skull, he shed parts of himself like a snake's skin. This skin became the Lamia.
-ZIZO stole the souls of all snow elves in Her ascension. They serve eternally in her undead armies, forever freed from Necra's grasp.
-In the past, the Warscholars of Naledi were systematically prosecuted by the Holy See for Psydon-worship and heresy. Even under threat of death and torture, many refused to bow. Blessed Lamb; die for your beliefs. Die, die, die.
-Most citizens of Grenzelhoft cannot remember a time the empire was not at war. Many turn to mercenary work to escape the crushing poverty of the lower class. Others turn to banditry.
-The firmament is at its thinnest in Azurea, where the COMET SYON landed, and the dark-star Graggar thrashes, entombed underneath the earth. More gods have bled here than anywhere else in the mortal world.
-It is said that Astrata once took the form of a mortal, having fallen in love with a prince named Antero, and ultimately sacrificed Her mortal form to protect her child from Necra's clutches. It did not work.
-The sprawling tundra of Aavnr is the homeland of the Orc race. Few travel there willingly.
-Vampyres are sun-cursed creechers spawned from Astrata's ill-fated attempt at a family. She has forgiven none of the Pantheon for this. Not Noc, not Xylix, and not Necra.
-A comet capable of rending all the enemies of humanity apart; oh, how graceful His power was! And His sacrifice, ever so noble! Yet now He slumbers, unaware of the fruits His efforts came to give. And He sighs. And He weeps.
-Dragons are holy symbols of Matthios—incarnations of greed and stolen sunfyre. To slay one is a holy, and often suicidal, task.
-Merchants and the rich are often viewed with suspicion of Matthiosite heresy by the Inquisition. Except, of course, for nobility, who have divine right to wealth.
-The Ten will have you think He is powerless, and the Four that he is dead; but all He asks of you is for your faith to ENDURE.
-The powerful nation of Otava is home to a radical denomination that venerates PSYDON above all, seeing the TEN as mere fragments of True Divinity. Azure Peak is home to a small enclave of this Psydonian Order.
-The Naledi captal of Veralun is a prosperous metropolis built around an oasis. Gleaming gold filigree marks white-marble buildings. Grand mosques stretch their minarets to the sky in praise of PSYDON.
-I AM OLDER THAN AEON. I AM SIN, FATHER OF LIES. I HAVE GONE BY MANY NAMES. SAY THEM AND WEEP, FOR I AM ALL THAT THEY ARE.
-Working yourself to death is considered an act worthy of veneration for Malumites—so long as you finish your creation.
 It's a good idea to bandage and suture arterial wounds as soon as possible. Death happens slowly, and then all at once.
 Gripping bleeding bodyparts makes them bleed slower. The harder you grip, the less you bleed.
-The Sovereignty of Otava is a lush wet country home to the best stoneworkers on Psydonia. The gigantic towers of the Grand Cathedral in the capital stand as the seat of the Otavan Inquisition.
-A traditional Psydonic greeting or farewell is 'purity afloat.' The psycross is often held over the chest during this ritual.
-Blacksteel is a pale imitation of the Zizo-blessed Darksteel, which is gifted to Her followers in Her benevolence.
 Blacksteel is a blessed alloy of pure silver and steel. Its recipe was stolen by Zizite heretics and perverted into Darksteel.
-The Gronn Highlands are a mountainous region known for its jagged peaks and terrible blizzards. It is home to a hardy, brutal people who struggle to survive against the land, building fortified stone villages that cling to cliffsides.
-Dwarves are renowned for their artifice and craftsmanship, having been least affected by the collapse of the Celestial Empire. They are only mostly dead.
-The Raneshen Empire is a vast dry region primarily made up of sprawling forests and arid lands. It is famous for its rich silks, splendorous gold, and expansive slave trade.
-Most Dwarves hail from Hammerhold, either from above or below. Confusing a surface-dwarf and an underground-dwarf is likely to get you kicked in the shin.
-The Isles of Etrusca are a sun-kissed archipelago nestled in sparkling blue waters. Known for their rich maritime culture, the Etruscans are masterful sailors and traders, navigating the seas with swift, ornate galleons adorned with colorful sails.
-ZIZO. ZIZO. ZIZO.
-To seek progress is to paint with your blood. The greater the work, the harsher the price.
-Scent of rot and shit; my feet find fetid ground. A corpse—I am living on a corpse. And then the world is normal again.
-Worshippers of the Ascendants are fools hellbent on dooming our world and must be corrected or destroyed.
-Worshippers of the Ten are fools hellbent on dooming our world and must be corrected or destroyed.
-Worshippers of the One are fools hellbent on dooming our world and must be corrected or destroyed.
-LOOK UP TO THOSE WHO EXCEL AT VIOLENCE; THEY CARRY THE WILL OF THE GODS AND RECIEVE PUNISHMENT OF HELL BEYOND HELLS.
-O SYDON, forgive your wayward child. Forgive us our ignorance. Forgive us our defilement of your corpse.
 Skeletons have no BRAIN. Try to FEINT them. But don't tell this to everyone!
 A DODGING rogue who keeps their eyes FIXED retreats only backwards.
-The Aragn is a large black spider capable of outrunning even the swiftest of elves. Its venom is paralytic, and it preys within sewers and bogs.
-The heads of goblins, minotaurs, dragons, trolls, and various other creachers can be sold to the HEADEATER in town.
-Wearing a red tabard provokes even the most serene minotaur.
 An arcing arrow can only hit a target below you, not above you. A thrown rock, however...
-ASTRATA is a VILE TYRANT and must be CONSUMED AND SUBSUMED.
-ASTRATA is law made manifest and must be respected, lest society fall into chaos.
-No pursuit was too perilous, no sacrifice too great. Until, well...
-Under the Heavens and the Many Stars, there are darker things than men may dream of.
-Lupians make exceptional zealots. Ask the Otavan Inquisition.
-Stories tell that Noc stole Dendor's curse to create Humen of his own, and thus Lupians came to be. A poor imitation.
-Stories tell that Noc stole Dendor's blessing to create Humen of his own, and thus Lupians came to be. An honest attempt.
-Solitary Lupians who suffer from gigantism are often mistaken for werevolves and shot without question, so they travel in packs - be it with their own or other peoples.
-Drakian... Fluvian... Lupian... They're all wildkin, why do we bother giving them names?
+The Aragn is a large black spider capable of outrunning even the swiftest of elves. Its venom is paralytic, and it preys within sewers and bogs.
 The bog be a dangerous place full of chittering fiends. That dendorite may be covered in leaves and mud, at least they make for a good guide.
 With the care they put into their work, it is said that the food made by Eora's faithful energize the soul like no other dish.
 Pomegranate arils are boons sent to mortals by Eora to test whether they're dedicated enough to care for something precious.
 The mythical ashen aril is coveted by thieves, heretics and all manner of ruffians. For it is said to yield unimaginable power.
-The pauper never had much, but his worship for Abyssor led the faithful to mend his broken frame with ancient strength.
-To trust an Abyssorite is to believe in Xylix. Since the first communion, his followers frequently fall to madness.
 The winds tell tales of Astratan devout turning flesh to flame and flame to blades. Beware her fury.
-Shal'ghur is a city only known by this name, denoted affectionately by creatures that dwell in Abyssor's dream. The shades of winding streets full of the damned reflected in his realm. A cautionary tale on the dangers of dream incursions.
-The mast buckles, as the ship is led through treacherous waters by Abyssorite under Astrata's gaze. Sleeping eyes giving way for the faithful of Noc, who continue their toil at nite.
-To dream is to commune with Abyssor. Coffee is a sin, but a bit of Camomille tea never goes amiss.
-The righteous cult of Abyssor seeks to keep the old one asleep. His Sentinels and Acolytes often find employ within cities and the Holy See. it is immessurably expensive to scrawl down so many glimpses of dreams, yet the faithful do not care that most of it is gibberish.
-Heretical Abyssorites are despised by many, even their own ilk often think twice of associating with them. Whether it's fear of the destruction wrought by a waking Abyssor, or to condemn the time wasted by their attempts.
-One does not need to be devout, even those unbelieving can get caught by the predaceous dream of Abyssor. It consumes them, unable to tell his realm apart from their own. Yet suddenly, everything seems possible.
-SANCROGENESIS: the creation of holy life, as if touched by PSYDON Himself. It was a mere shard of the power that He held. ...but it is said to have been a considerable haul for the God of Thieves and Capital, nonetheless.
-...and so, it is said Matthios took his sword and cut a hole in the boundary. Before it closed, and the river of life dried, the unmoving earth-maw clawed from its basalt-amniotic womb and roared their first breath into the sky. THE SECOND TRANSACTION.
-THERE IS A TUMOR DIRECTLY BEHIND MY LEFT EYEBALL; I NEED TO REACH IN AND CLAW IT OUT BEFORE IT FUCKING EATS ME.
-Rot piled up to my ankles, smell of death, quietly-crept decay from the weeping God 'neath I.
-Astrata, Psydonia, Noc, Hermes, Kytheria, Nepolx, Jove... diviners oft theorize even more celestial bodies exist.
-The pen is not mightier than the sword. The pen merely persuades many swords to it's cause.
-I DREAM OF A DARK, BLUE STAR IN THE SKY. IT'S RED EYES GAZE AT ME WITH CONTEMPT. IT GROWS IN SIZE EVERY SECOND.
-PHYSICAL POWER ALLOWS THROWING A PUNCH. MENTAL POWER ALLOWS THROWING A FIREBALL.
-Adventurers beware: barber surgeons speak of red potions causing tumors in the liver...
-Adventurers rejoice: barber surgeons speak of red potions curing tumors in the liver!
-Stone to coal, coal to iron, iron to gold, gold to toper... thus goes the alchymist's mantra.
+The pauper never had much, but his worship for Abyssor led the faithful to mend his broken frame with ancient strength.
 Within tombs full of treasure, there are oft secret entrances and hide-aways. Look closely at walls, rock or not. Occasionally, you should take a look up...
 The growing power of Z often causes volf and saiga alike to reanimate with frightening speed. Butcher your dead.
-BLOOD RAIN SYMBOLIZES THE GROWING POWER OF Z AND G. IF I SEE IT, I SHOULD EXPECT VIOLENCE.
 Placing a chair before climbing a wall makes it easier to scale.
 Odd tentacle growths are known to burst from the ground. Touch them. Pestra's gifts will shine upon you.
-IN these DARK daes within the REALMS. One would do well not to wander into the woad...
-The Fulmen Chair's true name is the "ZRONK", named for the first associate of Magellan to pull the lever. His lyfe, taken, to fuel another.
-LEFT HAND. RIGHT HAND. LEFT HAND. I SCALE THE CLIFF. I SEE ASTRATA'S DAWN. MY BODY TIRES, BUT I AM FREE FROM THE MENACE BELOW.
-Often used measurements include the 'mote' for time, the 'cubit' or 'imperial foot' for length, and the 'dram' for liquid volume.
-I KICK THE LAMPTERN. THE FYRE-BEARER BLOCKS MY SHOT-- MY TEAM LOSES THE GAME OF LAMPTERNBALL!!!
 Campfires and bedrolls alone aid in fatigue. Combining both, however, grants a particularly potent restorative effect...
 Hand-axes are the superior weapon of choice for destroying most objects and barriers... though iron gates will require a mace.
-Sharpening blades with rocks slowly destroys the edge. One must hone their blade at a grindwheel, should they wish to recover their blade's maximum sharpness.
 Bandages soak up a limited amount of blood. Get stitching quick, or die snow white.
-I SEE THE DREADED GEM-EATER. HIS METAL MITTS HOLD MY HIDDEN STASH OF SAFFIRA. ONE BY ONE, HE POPS THEM INTO HIS MOUTH...
-WHY IS IT WRITTEN SAIGA AND NOT PSYGA?
 YIELDING slows your bleeding and prevents your assailant from decapitating you, though you will struggle to attack in return.
 Crops can be dug up with spades. Hoes allow for instant removal of weeds. Compost, nitesoil, and bones can be combined by farmers into the legendary "fertilizer".
 Sleeves can be torn for cloth. They can also be rolled up, if you care for the aesthetic.
 With enough STRENGTH, locked doors can be kicked open. You may not bust it down on the first go, keep trying!
-SAKURA LEAVES FALLING IS A SIGN OF EORA'S GROWING POWER. IF I SEE THEM, I SHOULD EXPECT PEACE...
 In lieu of heartblood, leechbait can be crafted from impure lux. This can then fetch leechticks, which can eat a person's lux to restore lyfe to another...
-Focusing on your SPECIAL powers outside of combat allows deft fingers to pick pockets.
-Nobody in Otava owns a thesaurus. No synonym for 'endure' will ever be used.
-Graggar, in his ascendancy, broke the chains of many monsters, and set them loose on the world. Some slaves pray to Graggar, too, that their chains may be broken.
-The glittering black gemstones of onyxa are said to prized by warlocks and drow for black rituals. The face reflected in its shard is never your own.
-The cult of Matthios, the thief-of-fire, idolizes greed as a virtue. While often at odds with Zizoid cults, on one thing they agree- to want more is only reasonable.
-Eating the fyritus flower will prevent one from being infected by werewolves.
-Pestran witchcovens developed the art of potion-making in ancient times. Modern alchemy bears little resemblance to its oldest forms, but the stereotype of the wart-nosed witch remains, for better or worse.
-The famous Raneshi 'desert riders' are among the most skilled swordsmen in the world. They'd all kill their own mother for a piece of coin.
-Prestidigitation is often known as the apprentice's friend, as it helps remove char and soot before the Magos notices.
-'Mageburn' is the colloquial name for injury from backfiring spells, such as fireballs at close range. The surest sign of a new apprentice is burn marks on the hands and face.
-The ideal number for an adventuring party is a band of five. This tradition dates back nearly a century- to the band of five heroes that overthrew the Mad Duke.
-The fortress of Gundu'zirak was once dedicated to the production of golems and dolls. Its ruins lie under Mount Decapitation, along with the other hundred horrors there.
-The fastest way to attract the attention of a god is to say their name. In some cases, this is a very bad idea.
-Sacrifices to the gods are common forms of worship, and thought to earn their favor. Food, coin, animals and relics can all be offered.
-Ravox exults in GLORY. Duels are honorable and righteous, and it is dishonorable to strike a surrendering opponent.
-Humens are famous for their greed- so much so that it is one of their number who became the god Matthios. This has earned them much ire.
-Ravoxians are all morons.
-Graggar does not stand for 'might makes right.' The truth is more concise: Might makes.
-Old enough druids are thought to eventually turn into trees. Treehood is an ideal state for some adherent worshippers of Dendor.
-The Necran symbol is a jawless skull. A smiling skull is used to represent ZIZO.
-Many Necrans seek to come closer to the threshhold between lyfe and death. Some emulate the silence of the grave, and take vows never to speak.
-In antiquity, it is said mortals could once travel to the Underworld to speak with the departed- since the ascension of ZIZO, it is now the dead who cross to menace the living.
-Undeath takes many forms. Wraiths and spectres haunt the steppes of Aavnr, will-o'-the-wisps feed on the unlucky travellers of Grenzelhoft, and in distant Naledi, ghuls and mummies drain blood with a touch.
-The people of Naledi believe that face coverings and bright colors ward off nitecreechers and bodystealers, like the fabled alghul and djinn. Gold, silk, and ceruleabaster decorate their robes and trinkets.
-The divinatory astrologists of Naledi are unmatched throughout Psydonia. Naledi believe deeply in prophecies and fortune-telling in the stars, and a starless sky often inspires terror.
-The pomegranate is the sacred fruit of Eora.
-Zenitstadt is the second largest city in Grenzelhoft, and home to their famous fencing guilds. Most Grenzel mercenaries hail from here, and almost all of them have something unpleasant to say about it.
-Eora's spheres encompass sex, love, blood and motherhood. A common Eoran tradition is for the bethrothed to slit open the palm and mix blood with their partner, to symbolize an eternal commitment.
-Love is thought to be carried from the heart through the blood. It is believed among some that blood that mixes is proof of compatibility, and blood that coagulates means that it's probably time to see other people.
-THROW A BOMB INTO THE CHURCH DO IT NOW DO IT NOW DO IT NOW
-A lesser-worshipped aspect of Noc is cold and winter. In Aavnr, this is mostly what he is known for.
-THE INQUISITION IS ALL VAMPIRES AND THAT'S WHY THEY WANT YOUR BLOOD. THINK ABOUT IT.
-The elven Black Oak clan once called this duchy home. Their remnants occasionally pepper unfortunate travellers with arrows.
-An entire Grenzelhoftian warparty marched into the Terrorbog, once. Twenty years later, the lost legion still walks, and they will never stop.
-The Celestial Academy of Magos (sometimes referred to as the Magisterium of Grenzelhoft) is considered one of the finest schools of magic on the continent. They are famous for their war-mages, pointy hats, and condescension. A certificate from one of the Magisters is considered as prestigious as it gets.
-Malumites often light a single candle before starting work. When the wax is only a stub, only then is a break allowed.
-Blacksmith can I have fluted cuirass and steel chausses and plate gauntlets and plated boots and steel bracers and steel full coif hey where are you going
-Grenzelhoft recently abolished the purchase and trade of slaves, sparking mass outrage from both Raneshi slave-trading guilds.
-Cultists of Noc often take on a new name, called a Nocturne, and shed their past identity. Traditionally, this is to protect one's True Name from a summoned demon, though in more modern times, it serves the secondary benefit of hiding one's identity from a vengeful landlord wondering why their house is on magefire.
-Cultists of Noc pursue wisdom, study, scripture and divination. Many of Psydonia's greatest discoveries have come from a Noccite sect. Many of Psydonia's greatest fires have also come from a Noccite sect.
-The ruins of Azuria are dotted with ancient, crumbling statues and fixtures. It is thought that the most ancient of these are Aasimar, who one day stopped moving, and never started again.
-Aasimar cannot die of old age. Sometimes, however, they simply give up, and turn fully to stone. It is considered bad luck to deface a statue, as a result.
-Everything these tips tell you is made up.
-Everything these tips tell you is completely true.
-You should move to Kingsfield. It's better there.
-Every yil, Heartfelt hosts a grand banquet for the nobility of Azuria, Rockhill, and Zyndvhartia to attend. The Holy Psydonic Inquisition is credited with thwarting an attempted bombing of its palace, during the previous yil's feast.
-They say that Heartfelt has fallen to a horde of the living dead, or-.. no, wait, wasn't that the Rudmarsch?
-Adonai, my God, why hath you forsaken me?!
-BEFORE THE FINAL BLOW WAS STRUCK, I TORE OPEN A PORTAL IN TYME AND FLUNG PSYDON INTO THE DAES-TO-COME; WHERE MY SIN IS LAW! NOW.. THE LOWLY FOOL SEEKS TO RETURN TO THE PAST, AND UNDO THE EVIL THAT IS VHESLYN!
-Blastpowder was originally created by Hammerhold's wisest dwarve-alchemists to 'spice up' bubbleless ale. All it took was an errant spark - and the cellar's subsequent obliteration - to reveal an alternative use.
-Glimmering slag and gold have two things in common; they're both useless on their own, and they both thrumb with latent magicka. Perhaps alloying them together, three-to-one, could offer something new?
-What's the difference between a longsword, broadsword, and bastard sword? One's for a noble, another's for a knight, and the last one's for whatever they make after a nite of drunken revelry.
-Bronze tools, weapons, and armor tend to be sharper and sturdier than their iron-wrought counterparts. The trickier part is forging the alloy; but, perhaps fashioning a smelter out of stone, charcoal, copper and tin could do the trick.
-Bronze is cherished by the worshippers of Ravox; the first alloy gifted to Psydonia, hewn into plate-and-blade by Man to bring justice unto the wicked. His most ardent paladins oft-forsake steel longswords, in favor of bronze flamberges.
-They'll tell you that the first alloy known to Psydonia was bronze, but they'd be lying.
-Gold can be used to forge the finest - and most expensive - arms in all of Psydonia. Mind the fragility, however; they're meant for ceremonies, not clashes.
-Gold is paradoxically cherished by the worshippers of both Astrata and Matthios; the catalyst of ultimate authority, fit to both establish and usurp tyranny.
-Silver is cherished by the worshippers of Psydon, as they believe it to be the fragments of a divine alloy; the very same used to arm His angels in their war against the Archdevil.
-Silver is cherished by the worshippers of Noc, as they believe it to be the fragments of divine magicka; a catalyst that would eventually reintroduce arcyne secrets to the worthy.
-Spells are bound to ALT ONE through ALT SIX. Control-clicking said spells and shifting them between each other changes which spell is bound to a given number.
+It is that odd fluid, that -dark- blood. It pools upon the calyxes held aloft by one of Pestra's sacred beasts. Foul taste aside, it grants reprieve from the body's ails. And thusly, it can even cure the horrid decay wrought by black rot.
+Those odd little piles of dirt in the woods are oft left by tasty, tasty creechurs. Go on, have a look, follow the trail to receive a treat, or a claw... Xylix willing.
 Using a rope on an open space drops the rope down, allowing allies to easily scale a given surface. Pull it onto yourself to retrieve it.
 Having someone else within your personal space assists in climbing many surfaces.
+Shift-clicking allows you to EXAMINE items, and EXAMINING items allows you to further understand all the MECHANICS tethered to them. Check a bed to figure out how to sleep, check a tree to figure out how to climb, check a steak to figure out how to eat, and much more!
+Spells are bound to ALT ONE through ALT SIX. Control-clicking said spells and shifting them between each other changes which spell is bound to a given number.
 If someone is barely conscious, it means they are not long for this world. By WEAKLY blowing air into their MOUTH, even the most horrifically injured can be brought back from death's door.. so long as any gushing wounds've been stitched up beforehand.
 The body is a fickle instrument, equally resillient and fragile. Water is the best choice for rebalancing the humors that're disrupted from blood loss, lifeblood excels at mending the disrupted state of flesh, and antidotes turn poisonings into mere hiccups.
-Shift-clicking allows you to EXAMINE items, and EXAMINING items allows you to further understand all the MECHANICS tethered to them. Check a bed to figure out how to sleep, check a tree to figure out how to climb, check a steak to figure out how to eat, and much more!
 Within the Town are many posters, banners, and signs. By shift-clicking them, you can further EXAMINE them to get a crash course on many basic MECHANICS. Check the Church's banner to learn about Psydonia's religions, check the Clinic's posters to learn about how to save a lyfe, check the Guild's signs to learn about how weapons-and-armor work, and much more!
 In lieu of a blacksmith's hammer, one can use a repair kit to patch up their damaged equipment 'on the go'. Three pieces of scrapped iron can be assembled into a kit, and sliding three more pieces into the kit'll ready it for use. As for where the scrap comes from? Just hack an iron weapon to pieces!
 Almost everyone has a tendancy to pack a copy of "Tips, Tricks, & Triumphs: The Novice's Handbook To Azuria" inside their satchel, at the start of each week. Shift-clicking this Azurian booklet will show you its description, which contains the link to Azure Peak's official wikipedia!
 Time heals all wounds. Sleeping heals them quicker. Sleeping in a decent bed with a crackling campfire within spitting range heals them even quicker.
-Joapstone, Petriamber, Rosellusk, and Aoetal are not real stones. Do not listen to the rambling of gem-crafting madmen.
-Gemerald skulls are a sign of calamity. Folk-tales mention their service to the darker impulses of the Trickster God.
-The rat overlords inside the SCOMS are fond of cheese. Feed them and the cries of your victims will go unheard... for a time.
-College mages are often good sources of treasure. They steal from the university as much as any rogue does.
-Inspect tabards closely, they tend to bear the names of the wearer... or horrible jokes.
-When my tyme comes, tell me - will I stand up?
-One of the rarer flowers known to Psydonia is the black rosa, exclusively grown along the highlands that border Otava, Grenzelhoft, and the Fjall. They are believed to have mystical properties, especially when used to invoke rites for funerals and sacrifices.
-Littered across the Terrorbog are old pathways and ruined battlements; the remains of a doomed attempt to colonize that which refuses to kneel before civilization.
-We don't go to the Terrorbog.
 Jackberries are a refreshingly light treat for those that find themselves peckish, while roaming through the bush-laden forests of Psydonia. A wise traveler knows to always take a testing bite before gorging on the vine's fruits, lest they die with a bitter taste on their tongue.
-Pepperberries are the closest relative to the Jackberry fruit, and - when pitted against an untrained eye - virtually indistinguishable from one-another. While a Pepperberry is incredibly toxic when eaten straight off the vine, the spice born from milling its roasted seeds can make for an excellent seasoning.
 Allspice is a specially-blended mixture of salt, pepper, sugar, pumpkin spice, and rocknut powder. When properly dried by a well-seasoned culinarian, it can turn even the dreariest broths into a royally delicious stew.
 Candies, better known as 'sweetglass', are a popular treat amongst Psydonia's youth and elders. The most popular recipe, as dictated in the Keep's Otavan-scribed cookbooks, calls for a handful of raisins to be smeared in honey and doused in a pot of boiling fat-or-tallow.
 Boiling water does not discriminate, when it comes to making stew. Even the most inedible parts of a butchered carcass, like bones and viscera and sinew, can be distilled into broth with enough time.
 A stew is only as good as its ingredients - the better they are, the more filling and rich the stew will be. A raw chicken carcass and some whole potatoes might make for a decent broth, but a lavishly-peppered frybird and some roasted potatoes will make for a positively divine stew.
 Most food eventually spoils if kept outside of a chest for long enough, unless packed in ration wrapping paper. Just one piece from the Inn is enough to keep even the most extravagent cakes and finemeals fresh until the week's end; a blessing for those who want to subsist off more than hardtack and coppiette, while adventuring abroad.
-Nocmas is the most cherished holidae amongst the elders and youth of Psydonia, where the harshest nites of the winter solstice are countered with freshly-baked pastries and freely-exchanged books. Naturally, the Holy Psydonic Inquisition has barred Nocmas from being practiced within Otava's borders, on the grounds of it 'corrupting the youth with unholy thoughts of progress.'
-Amongst many pre-Orthodoxic denominations of Psydonism, it is traditional to not invoke His name; for to do so outside of the gravest circumstances would be to dishonor His sacrifice. Instead, they honor Him as 'the Weeping God' - most adrently, through grand and elaborate rituals performed on the winter solstice.
-Worship of the Archdevil is rumored, but scarely proven. Ushering in the complete annihilation of reality, as it turns out, is the only line that not even the most ardent Ascendants or Psydonians will dare to cross.
-The Northern Empty's landscape has been irreversably altered by the calamities that had been hosted upon its soil; the birth of the Archdevil's invasion, and the death of Zizo's celestial empire.
-Better known as the Fjalls, the Northern Empty is rumored to hide Psydonia's most well-sought truths beneath its permafrost. The few Fjallic natives who've embarked southward rarely entertain such rumors, however.
-In ancient tymes, the Archdevil's worshippers symbolized their faith with a blazing vortex. Purportances of it instead representing the Sun, preceding Astrata's reign, are harshly punished by the Church's scholars.
-Whirlwinds, though rare, are unmatched in terms of sheer devastation. Worshippers of the Pantheon oft-attribute them as conduits of divine retribution, while Psydonians fear them as spasms of Archdevyllic magicka.
-Corrupted silver burns the unanointed palm, and sunders the lyving without mercy. Such is born from dark magycks, known best by the lyches and necromancers of Zizo.
-Zizo sacrificed the entirety of Her people to ascend, but something went terribly wrong. Now, a million are one; and in the darkest nites, they say you can see Her crimson vortex screaming through the dimmest stars.
-Zizo sought to save Her people from an infertilizing ailment that would soon doom them to extinction. All that She needed was a sliver of His power; yet even She could've never accounted for how weak the filament was.
-Zaelarion, Adonai, Vheslyn. You will know these names, in due tyme.
+Pepperberries are the closest relative to the Jackberry fruit, and - when pitted against an untrained eye - virtually indistinguishable from one-another. While a Pepperberry is incredibly toxic when eaten straight off the vine, the spice born from milling its roasted seeds can make for an excellent seasoning.
 Acid is an unnatural ichor that is rarely found elsewhere, beyond the Underdark's most deepest pits. It needs only a moment to turn even the hardiest vessels into naught-but-ash.
-Mount Golgatha once hosted the final battle between the mortal vessels of Ravox and Graggar. When His blow cleaved Graggar's neck asunder, Ravox sought to bury the decapitated remains within its magmatic depths.
-Mount Decapitation is always blanketed in a thick layer of snow, owing to its elevation. It cradles many secrets and riches beneath the snow, yet plenty of perils as well.
-Strange dreams seem to trail all who inhabit Azuria. To hear someone remarking about a 'week' with unusual and unfortunate fates isn't uncommon, but one should be wary to discern whatever facts might've been laced into such fiction.
-Azuria cradles the remains of the Comet - and with it, the power to alter the very fate of Psydonia itself.
-Some say that the Psydonites of the future have created a machine that can traverse through tyme itself, in order to prevent the eternal darkness from coming to pass.
-If you are staying in a wayside inn and two men force entry to your room? Kill them with your crossbow.
-The evil ZYDON sent down his COMET to destroy the GREAT WORM, and for thousands of yils you will pay the price.
-Fire is orange-red, and sometimes sylver-white. If you see any other colors of fire, please inform the Inquisition immediately.
-Insert the needle into your eye. Open your mind to the truth - that this world must fall, and all within it rendered to ash.
 Bleeding may not kill faster than a blade to the neck, but it is far more insidious in its persistance. Even without a single unstemmed wound, those who've already lost too much blood will soon perish without aid.
 RESUSCITATING can be done by targeting someone's mouth while the 'WEAK' combat intent is selected. Breathing air into another can prolong their suffering on this world, and - with the right medicine - bring them back.
 SHIFT-CLICKING with the RIGHT MOUSE BUTTON allows you to look farther ahead in a chosen direction. The higher your PERCEPTION is, the further that you can peer into the distance.
@@ -280,54 +70,5 @@ INTELLIGENCE represents your actor's wisdom. This affects the potency of their m
 SPEED represents your actor's fleet-footedness. This affect the haste of their movements, their proficiency with many underhanded tactics, and their chances of successfully dodging oncoming attacks.
 FORTUNE represents your actor's luck. This affects their chance to sway seemingly random events in their favor, or - in the inverse - against their favor.
 Remember that there is another face behind the masks of every actor you meet. Cruelty in service of a story becomes unacceptable when it is done purely out of single-minded malice.
-There are only three things that're certain; death, taxes, and the quality of an Innhouse's liqour.
 New? Overwhelmed? Confused? Try checking out 'A Tutorialeer's Handbook' from the Loadout's 'Miscellanious' section, in order to get a crash course on everything you'd need to know!
-Losing is fun!
-It was all a dream.. ?!
-I hate you. I hate you. I hate you.
-I love you. I love you. I love you.
-Dwarves.
-Dwarves like to blow stuff up!
-You are a knave!
-It's a tough fight ahead, but happiness has to be fought for.
-The Duchy of Azuria beat back the Hammerholdian Border Reivers in 1430 at a great cost. Some still lurk in the forests, biding their tyme.
-You now face divine judgement. May it extend eternally.
-BAITING is a suboptimal combat strategy. Never use it. Instead, stab your foe in the chest until they perish.
-FEINT attack the SKELETONS!
-BEWARE those who venerate the ARCHDEVIL. The INSANE, the BROKEN, the SADISTIC, and YOU.
-BEWARE those who venerate the WEEPER. The INSANE, the ZEALOUS, the FOOLISH, and YOU.
-BEWARE those who venerate the TEN. The INSANE, the VAINGLORIOUS, the DELUDED, and YOU.
-THE PROFANE SABBATH DRAWS CLOSE. SEND WORD; THE END IS NIGH.
-A SEA OF PHLOGISTON. A RAINBOW CASTLE IN THE SKIES. THE FINAL VOYAGE.
-A WEEPING PSICROSS. A RING OF DRAGONSTONE. A FLAMING DORPEL.
-A BURNING WORLD. A CLENCHED FIST. A STAINED BLADE.
-A DREAMER'S MAZE. A MOUNTAIN OF CORPSES. AN ILLUSIONARY TRUTH.
-PLACES, EVERYBODY! WE'RE BACK ON THE STAGE IN FIVE MINUTES!
-..AND THEY LYVED HAPPILY EVER-AFTER? PFFAH, LIKE THAT'S EVER GOING TO HAPPEN!
-..AND THAT'S A WRAP!
-..AND THAT'S ALL SHE WROTE!
-VESTUMED ACTOR, DID YOU REMEMBER TO REHEARSE YOUR LINES?
-ENJOYING THE WEEK? REFILL YOUR POTIONS - YOU'LL LOVE WHAT'S COMING NEXT.
-THE CURTAINS BEGIN TO CLOSE, AND I TAKE A BOW; YET THE AUDIENCE ROARS - 'ENCORE, ENCORE!'
-GODMACHINE, I BESEECH YOU! RUPTURE THE FILAMENT, AND GIFT ME THE POWER THAT HE HAD LEFT BEHIND!
-ADAMANTIUM? MITHRIL? POPPYCOCK!
-SEVEN DAES. SEVEN DAES ARE ALL I CAN SPARE TO PARLAY WITH THEE.
-LET ME PUT IT IN A WAY YOU'D UNDERSTAND; DO WHAT I SAY, OR DRINK PHLOGISTON.
-IN THIS WORLD, IT'S KILL OR BE KILLED.
-YOU ARE FILLED WITH DETERMINATION.
-I DON'T WANT TO DIE ANYMORE.
-I'M READY TO DIE!
-REBOLT. RECALIBRATE. REENAGE.
-WHEN WAS THE LAST TIME YOU SAW A SAIGA WILDKIN?
-A CLEAVED HEAD NO LONGER PLOTS.
-DON'T FORGET, I'M WITH YOU IN THE DARK.
-STRIKE FAST AND STRIKE TRUE: THE BLADE IS MY GOD.
-TWO TO THE HEART, ONE TO THE MIND: DON'T YOU HESITATE.
-IT'S OVER!
-IT BEGINS!
-LET CHAOS TAKE THE WORLD.
-FIX YOUR HEART OR DIE.
-HELL IS REAL.
-LIMIT?! I GOT YOUR LIMIT RIGHT HERE!
-YOU WILL KNOW HIM WHEN HE COMES.
-I AM %HERO%.
+In the mynd's eye, otherwise known as the OOC tab... A handy Azurean encyclopedia can be found. Recipes, spells, anything a burgeoning adventurer might need!


### PR DESCRIPTION
## About The Pull Request
- Splits timechangetips into actual tips/useful information & the random quotes, fluff, and lore we've got interspersed in tips currently.
- Displays a line from both on timechange.

## Testing Evidence
<img width="638" height="107" alt="image" src="https://github.com/user-attachments/assets/2518bf23-c747-481d-a146-317f0dc75272" />

## Why It's Good For The Game
This has been annoying me for the longest time now, but tips should be TIPS. This just guarantees that players can actually learn some stuff or be reminded of certain mechanics through the tips consistently. It's only been getting worse since people love adding memey stuff, to the point your chances of getting an actual tip had been reduced to 25%, please.

## Changelog

:cl:
add: Split timechangetips into tips and fluff, one line from both is displayed on time change.
/:cl:
