### PR TITLE
Adds Socialite Virtue | Well-Off Tweaks

### DIFF
--- a/code/modules/virtues/utility.dm
+++ b/code/modules/virtues/utility.dm
@@ -74,7 +74,7 @@
 				else
 					if(!SStreasury.has_account(recipient))
 						SStreasury.create_bank_account(recipient)
-					if(SStreasury.generate_money_account(rand(80, 120), H))
+					if(SStreasury.generate_money_account(rand(80, 120), recipient))
 						record_round_statistic(STATS_MAMMONS_DEPOSITED, rand(80, 120))
 			if(NOTABLE_RESIDENCY)
 				ADD_TRAIT(recipient, TRAIT_RESIDENT, TRAIT_VIRTUE)

--- a/code/modules/virtues/utility.dm
+++ b/code/modules/virtues/utility.dm
@@ -57,7 +57,7 @@
 		NOTABLE_RESIDENCY,
 	)
 	choice_tooltips = list(
-		NOTABLE_SHREWD = "I've a hidden coinpurse for a particularly dark dae and have become far more apt at telling prices apart. Grants Secular Appraise -- a spell that allows you to tell how much wealth someone has on them, and in their Meister.",
+		NOTABLE_SHREWD = "I've managed to secure a Meister account and a lump sum within it. Grants Secular Appraise -- a spell that allows you to tell how much wealth someone has on them, and in their Meister.",
 		NOTABLE_RESIDENCY = "I am a Resident of Azure Peak, with access to one of its buildings all to myself.",
 	)
 
@@ -69,7 +69,13 @@
 			if(NOTABLE_SHREWD)
 				ADD_TRAIT(recipient, TRAIT_SEEPRICES, TRAIT_VIRTUE)
 				recipient.mind?.AddSpell(new /obj/effect/proc_holder/spell/invoked/appraise/secular)
-				recipient.mind?.special_items["Weighty Coinpurse"] = /obj/item/storage/belt/rogue/pouch/coins/virtuepouch
+				if(HAS_TRAIT(recipient, TRAIT_OUTLAW))
+					recipient.mind?.special_items["Weighty Coinpurse"] = /obj/item/storage/belt/rogue/pouch/coins/virtuepouch
+				else
+					if(!SStreasury.has_account(recipient))
+						SStreasury.create_bank_account(recipient)
+					if(SStreasury.generate_money_account(rand(80, 120), H))
+						record_round_statistic(STATS_MAMMONS_DEPOSITED, rand(80, 120))
 			if(NOTABLE_RESIDENCY)
 				ADD_TRAIT(recipient, TRAIT_RESIDENT, TRAIT_VIRTUE)
 				if(recipient.mind)

--- a/code/modules/virtues/utility.dm
+++ b/code/modules/virtues/utility.dm
@@ -42,29 +42,23 @@
 	SStreasury.noble_incomes[recipient] = (SStreasury.noble_incomes[recipient] || 0) + 15
 	SStreasury.grant_estate_income(recipient, 15, !already_has_income)
 
-#define NOTABLE_BEAUTY "Beauty"
-#define NOTABLE_STASH "Stashed Riches"
 #define NOTABLE_RESIDENCY "Residency"
-#define NOTABLE_SHREWD "Shrewd Appraisal"
+#define NOTABLE_SHREWD "Shrewd Lyfestyle"
 
 /datum/virtue/utility/notable
 	name = "Well Off"
 	desc = "Fate or effort had blessed my lyfe with spoils, natural or earned."
 	ui_fa_icon = "coins"
-	max_choices = 2	//Tentative. 2 is more interesting than getting all 4 easily.
-	choice_costs = list(0, 0)
-	stackable = TRUE
+	max_choices = 2
+	choice_costs = list(0, 8)
+	stackable = FALSE
 	extra_choices = list(	//These are so individually bespoke it's not even worth assoc listing them, all are snowflaked in the application proc instead.
-		NOTABLE_BEAUTY,
-		NOTABLE_STASH,
+		NOTABLE_SHREWD,
 		NOTABLE_RESIDENCY,
-		NOTABLE_SHREWD
 	)
 	choice_tooltips = list(
-		NOTABLE_BEAUTY = "Just looking at me relieves some of the hardships of the world, and I'm quite good in bed.",
-		NOTABLE_STASH = "I've a hidden coinpurse for a particularly dark dae.",
+		NOTABLE_SHREWD = "I've a hidden coinpurse for a particularly dark dae and have become far more apt at telling prices apart. Grants Secular Appraise -- a spell that allows you to tell how much wealth someone has on them, and in their Meister.",
 		NOTABLE_RESIDENCY = "I am a Resident of Azure Peak, with access to one of its buildings all to myself.",
-		NOTABLE_SHREWD = "Grants Secular Appraise -- a spell that allows you to tell how much wealth someone has on them, and in their Meister."
 	)
 
 /datum/virtue/utility/notable/apply_to_human(mob/living/carbon/human/recipient)
@@ -72,18 +66,10 @@
 		return
 	for(var/choice in picked_choices)
 		switch(choice)
-			if(NOTABLE_BEAUTY)
-				ADD_TRAIT(recipient, TRAIT_BEAUTIFUL, TRAIT_VIRTUE)
-				ADD_TRAIT(recipient, TRAIT_GOODLOVER, TRAIT_VIRTUE)
-				if(isdullahan(recipient))
-					REMOVE_TRAIT(recipient, TRAIT_BEAUTIFUL, TRAIT_VIRTUE)
-					ADD_TRAIT(recipient, TRAIT_BEAUTIFUL_UNCANNY, TRAIT_VIRTUE)
-				recipient.mind?.special_items["Hand Mirror"] = /obj/item/handmirror
-			if(NOTABLE_STASH)
-				recipient.mind?.special_items["Weighty Coinpurse"] = /obj/item/storage/belt/rogue/pouch/coins/virtuepouch
 			if(NOTABLE_SHREWD)
 				ADD_TRAIT(recipient, TRAIT_SEEPRICES, TRAIT_VIRTUE)
 				recipient.mind?.AddSpell(new /obj/effect/proc_holder/spell/invoked/appraise/secular)
+				recipient.mind?.special_items["Weighty Coinpurse"] = /obj/item/storage/belt/rogue/pouch/coins/virtuepouch
 			if(NOTABLE_RESIDENCY)
 				ADD_TRAIT(recipient, TRAIT_RESIDENT, TRAIT_VIRTUE)
 				if(recipient.mind)
@@ -128,10 +114,53 @@
 								recipient.forceMove(spawn_loc)
 								to_chat(recipient, span_notice("As a resident of Azure Peak, you find yourself in the local tavern."))
 
-#undef NOTABLE_BEAUTY
-#undef NOTABLE_STASH
 #undef NOTABLE_RESIDENCY
 #undef NOTABLE_SHREWD
+
+/datum/virtue/utility/socialite
+	name = "Socialite"
+	desc = "I thrive in social settings, easily reading the emotions of others and charming those around me. My presence is always felt at any gathering."
+	ui_fa_icon = "people-arrows"
+	added_traits = list(TRAIT_BEAUTIFUL, TRAIT_GOODLOVER, TRAIT_EMPATH)
+	max_choices = 3
+	choice_costs = list(0, 0, 4)
+	extra_choices = list(
+	"Massage Ability",
+	"Hand Mirror" = /obj/item/handmirror,
+	"Nutcracker" = TRAIT_NUTCRACKER,
+	"Cookies" = /obj/item/reagent_containers/food/snacks/rogue/cookie,
+	"Rosa Bouquet" = /obj/item/bouquet/rosa,
+	"Salvia Bouquet" = /obj/item/bouquet/salvia,
+	"Calendula Bouquet" = /obj/item/bouquet/calendula,
+	"Matricaria Bouquet" = /obj/item/bouquet/matricaria,
+	"Red Lipstick" = /obj/item/lipstick,
+	"Purple Lipstick" = /obj/item/lipstick/purple,
+	"Jade Lipstick" = /obj/item/lipstick/jade,
+	"Black Lipstick" = /obj/item/lipstick/black,
+	"Lavender Perfume" = /obj/item/perfume/lavender,
+	"Cherry Perfume" = /obj/item/perfume/cherry,
+	"Rose Perfume" = /obj/item/perfume/rose,
+	"Jasmine Perfume" = /obj/item/perfume/jasmine,
+	"Mint Perfume" = /obj/item/perfume/mint,
+	"Vanilla Perfume" = /obj/item/perfume/vanilla,
+	"Pear Perfume" = /obj/item/perfume/pear,
+	"Strawberry Perfume" = /obj/item/perfume/strawberry,
+	"Cinnamon Perfume" = /obj/item/perfume/cinnamon,
+	)
+
+/datum/virtue/utility/socialite/apply_to_human(mob/living/carbon/human/recipient)
+	..()
+	for(var/choice in picked_choices)
+		if(choice == "Nutcracker")
+			ADD_TRAIT(recipient, TRAIT_NUTCRACKER, TRAIT_VIRTUE)
+		else if(choice == "Massage")
+			if(recipient.mind)
+				recipient.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/massage)
+		else
+			recipient.mind.special_items[choice] = extra_choices[choice]
+	if(isdullahan(recipient))
+		REMOVE_TRAIT(recipient, TRAIT_BEAUTIFUL, TRAIT_VIRTUE)
+		ADD_TRAIT(recipient, TRAIT_BEAUTIFUL_UNCANNY, TRAIT_VIRTUE)
 
 /datum/virtue/utility/failed_squire
 	name = "Failed Squire"


### PR DESCRIPTION
## About The Pull Request
- Adds Socialite Virtue, Inspired by Ratwood's version.
<img width="250" height="44" alt="VmxmxvP661" src="https://github.com/user-attachments/assets/0015018d-40d0-43a5-85ba-c7902abba6fa" />

It gives Beautiful, Good Lover and Empath:
<img width="503" height="215" alt="ktNMEcNwaV" src="https://github.com/user-attachments/assets/849f26bf-41f8-43a9-a3ef-2f96a08344c0" />

While also giving a set of extra choices for those feeling... romantical, and perhaps seeking to be kissed on their hot mouth:
<img width="194" height="602" alt="UecGjKnQgo" src="https://github.com/user-attachments/assets/aaa79a95-388d-421d-90eb-5685617602a9" />
Up to 3 choices can be made, though the third one will cost more.

- Well-Off tweaks

Removed Beautiful and Stash choices, instead there's now only Residency and 'Shrewd Lyfestyle'. 
Shrewd Lyfestyle combines the stash with the shrewd appraisal.
Shrewd Lyfestyle now adds a meister account and the stash is now deposited into it, if applicable. Outlaws get the same pouch as before.
<img width="166" height="126" alt="y2DbyErmbt" src="https://github.com/user-attachments/assets/e06793c6-d178-4fc3-a0e1-3c47a5c4f471" />

It's also no longer stackable. Both options can be picked, but it'll cost more triumphs.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Above!
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Well-off had an odd place of being picked by both people who wish to dodge the economy and the far more respectable (gooners), adding more of those fluffy goodies felt like inflating an already popular virtue (Well-Off), so it was better off being split.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Added Socialite Virtue.
del: Removed Stash and Beauty options from Well-Off virtue.
balance: Added a new Well-Off option -- Shrewd Lyfestyle.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
