### PR TITLE
Virtue Sanitization

### DIFF
--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -403,7 +403,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 		var/datum/virtue/V = virtue_type
 		virtue = new V.type
 		if(length(V.picked_choices))
-			virtue.picked_choices = V.picked_choices
+			virtue_choices = V.picked_choices.Copy()
 		qdel(V)
 	else if(ispath(virtue_type, /datum/virtue))
 		virtue = new virtue_type
@@ -415,7 +415,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 		var/datum/virtue/V = virtuetwo_type
 		virtuetwo = new V.type
 		if(length(V.picked_choices))
-			virtuetwo.picked_choices = V.picked_choices
+			virtuetwo_choices = V.picked_choices.Copy()
 		qdel(V)
 	else if(ispath(virtuetwo_type, /datum/virtue))
 		virtuetwo = new virtuetwo_type
@@ -423,10 +423,22 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 		virtuetwo = new /datum/virtue/none
 
 	if(length(virtue_choices))
-		virtue.picked_choices = virtue_choices.Copy()
+		var/error_found = FALSE
+		for(var/choice in virtue_choices)
+			if(!(choice in virtue.extra_choices))
+				error_found = TRUE
+				break
+		if(!error_found)
+			virtue.picked_choices = virtue_choices.Copy()
 
 	if(length(virtuetwo_choices))
-		virtuetwo.picked_choices = virtuetwo_choices.Copy()
+		var/error_found = FALSE
+		for(var/choice in virtuetwo_choices)
+			if(!(choice in virtuetwo.extra_choices))
+				error_found = TRUE
+				break
+		if(!error_found)
+			virtuetwo.picked_choices = virtuetwo_choices.Copy()
 
 	virtue.on_load()
 	virtuetwo.on_load()


### PR DESCRIPTION
## About The Pull Request
Adds fallback cases for when a virtue's additional choices no longer exist, as this error came up in the latest Socialite PR.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
What is saved:
<img width="197" height="110" alt="Un20RWTJ7y" src="https://github.com/user-attachments/assets/a9421d52-14ee-4065-b48a-e962fc954ada" />

--Beauty is removed from Well Off Somewhere Else--

What is loaded afterwards:
<img width="380" height="184" alt="Weswr4fkqJ" src="https://github.com/user-attachments/assets/c941fdc0-98f3-41da-b349-430f1ed92db0" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Non-user facing. Avoids runtimes.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
