### PR TITLE
[Cooking] map in static smokers

### DIFF
--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -1333,6 +1333,10 @@
 /obj/structure/fluff/railing/border/east,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
+"anz" = (
+/obj/machinery/light/rogue/smoker/wheeled,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "anB" = (
 /obj/structure/fluff/railing/corner/north_east,
 /turf/open/floor/rogue/rooftop/green,
@@ -3769,6 +3773,10 @@
 /obj/effect/decal/cleanable/debris/glassy,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town)
+"aLM" = (
+/obj/machinery/light/rogue/smoker,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/exposed/town/keep)
 "aLN" = (
 /obj/effect/decal/cobbleedge{
 	icon_state = "cobbleedge-sread"
@@ -13039,6 +13047,11 @@
 /obj/structure/closet/crate/chest/neu,
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/physician)
+"cyw" = (
+/obj/structure/flora/roguegrass,
+/obj/machinery/light/rogue/smoker,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "cyy" = (
 /obj/structure/closet/crate/coffin,
 /turf/open/floor/rogue/cobble/mossy,
@@ -73004,6 +73017,7 @@
 	info = "The Inquisition will hardly come search for me here - yet the drow have started to notice my presence in the area. I fear everyday upon which I take breath, risking death by their hand or the Otavans."
 	},
 /obj/structure/table/wood/poor,
+/obj/item/reagent_containers/food/snacks/rogue/meat/steak/smoked_z,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/under/underdark)
 "nDi" = (
@@ -81693,6 +81707,18 @@
 "peO" = (
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/beach/central)
+"peV" = (
+/obj/structure/closet/crate/chest/crate,
+/obj/item/grown/log/tree/small,
+/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
+/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
+/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
+/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
+/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
+/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
+/obj/item/flint,
+/turf/open/floor/rogue/ruinedwood/turned,
+/area/rogue/under/underdark)
 "peW" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
 /obj/structure/bed/rogue/shit,
@@ -124624,7 +124650,7 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/cave)
 "xfI" = (
-/obj/structure/spider/stickyweb,
+/obj/machinery/light/rogue/smoker,
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/underdark)
 "xfO" = (
@@ -270850,7 +270876,7 @@ pMG
 njB
 mQr
 slz
-njB
+cyw
 sns
 uZQ
 trN
@@ -278724,7 +278750,7 @@ gHj
 sPj
 qmZ
 sPj
-qmZ
+peV
 weG
 sPj
 sPj
@@ -315522,7 +315548,7 @@ exD
 exD
 njB
 lkt
-exD
+anz
 wdl
 jZR
 pxc
@@ -315570,7 +315596,7 @@ gfZ
 sPm
 vAw
 vAw
-vAw
+aLM
 hrE
 hrE
 jWw

--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -410,10 +410,6 @@
 /obj/structure/stairs/stone,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/physician)
-"aer" = (
-/obj/machinery/light/rogue/smoker,
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/exposed/town/keep)
 "aes" = (
 /obj/structure/rack/rogue/shelf/biggest,
 /obj/item/ammo_casing/caseless/rogue/sling_bullet/scattershot{
@@ -59049,6 +59045,10 @@
 /obj/structure/ladder,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town)
+"kZe" = (
+/obj/machinery/light/rogue/smoker/wheeled,
+/turf/open/floor/rogue/twig,
+/area/rogue/indoors/town)
 "kZj" = (
 /obj/effect/decal/edge{
 	color = "#3f3f3f";
@@ -67603,6 +67603,7 @@
 	dir = 10
 	},
 /obj/machinery/light/rogue/candle/l,
+/obj/machinery/light/rogue/smoker/wheeled,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "myE" = (
@@ -74790,10 +74791,6 @@
 /obj/effect/spawner/lootdrop/cheap_jewelry_spawner,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cave/scarymaze)
-"nUq" = (
-/obj/machinery/light/rogue/smoker/wheeled,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/town)
 "nUs" = (
 /obj/structure/fluff/railing/border/east,
 /turf/open/floor/rogue/cobble/mossy,
@@ -93128,18 +93125,6 @@
 /obj/machinery/tanningrack,
 /turf/open/floor/rogue/church,
 /area/rogue/under/cave/scarymaze)
-"rlq" = (
-/obj/structure/closet/crate/chest/crate,
-/obj/item/grown/log/tree/small,
-/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
-/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
-/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
-/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
-/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
-/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
-/obj/item/flint,
-/turf/open/floor/rogue/ruinedwood/turned,
-/area/rogue/under/underdark)
 "rlr" = (
 /obj/structure/rack/rogue/shelf/biggest,
 /obj/item/burial_shroud{
@@ -94910,11 +94895,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/shelter/woods)
-"rCw" = (
-/obj/structure/flora/roguegrass,
-/obj/machinery/light/rogue/smoker,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "rCx" = (
 /obj/structure/fluff/walldeco/church/line{
 	dir = 8
@@ -98331,6 +98311,18 @@
 /obj/item/roguestatue/gold/loot,
 /turf/open/floor/rogue/tile/checker,
 /area/rogue/indoors/town/vault)
+"skG" = (
+/obj/structure/closet/crate/chest/crate,
+/obj/item/grown/log/tree/small,
+/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
+/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
+/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
+/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
+/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
+/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
+/obj/item/flint,
+/turf/open/floor/rogue/ruinedwood/turned,
+/area/rogue/under/underdark)
 "skI" = (
 /obj/item/roguecoin/copper,
 /turf/open/floor/rogue/cobble,
@@ -100954,6 +100946,10 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/abandonedhotsprings)
+"sIF" = (
+/obj/machinery/light/rogue/smoker,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/exposed/town/keep)
 "sIG" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10
@@ -114085,6 +114081,11 @@
 /obj/structure/bookcase/random/archive,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"vfu" = (
+/obj/structure/flora/roguegrass,
+/obj/machinery/light/rogue/smoker,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "vfy" = (
 /obj/structure/table/wood/large_table/middle_east,
 /obj/item/reagent_containers/glass/cup/wooden{
@@ -115942,6 +115943,10 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/goblinfort)
+"vxH" = (
+/obj/machinery/light/rogue/smoker/wheeled,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "vxI" = (
 /obj/effect/decal/mossy,
 /obj/structure/flora/roguegrass/bush/wall,
@@ -270876,7 +270881,7 @@ pMG
 njB
 mQr
 slz
-rCw
+vfu
 sns
 uZQ
 trN
@@ -278750,7 +278755,7 @@ gHj
 sPj
 qmZ
 sPj
-rlq
+skG
 weG
 sPj
 sPj
@@ -315548,7 +315553,7 @@ exD
 exD
 njB
 lkt
-nUq
+vxH
 wdl
 jZR
 pxc
@@ -315596,7 +315601,7 @@ gfZ
 sPm
 vAw
 vAw
-aer
+sIF
 hrE
 hrE
 jWw
@@ -420391,7 +420396,7 @@ aBB
 aBB
 xWK
 gKh
-iBM
+kZe
 glU
 iBM
 iBM

--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -410,6 +410,10 @@
 /obj/structure/stairs/stone,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/physician)
+"aer" = (
+/obj/machinery/light/rogue/smoker,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/exposed/town/keep)
 "aes" = (
 /obj/structure/rack/rogue/shelf/biggest,
 /obj/item/ammo_casing/caseless/rogue/sling_bullet/scattershot{
@@ -1333,10 +1337,6 @@
 /obj/structure/fluff/railing/border/east,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
-"anz" = (
-/obj/machinery/light/rogue/smoker/wheeled,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/town)
 "anB" = (
 /obj/structure/fluff/railing/corner/north_east,
 /turf/open/floor/rogue/rooftop/green,
@@ -3773,10 +3773,6 @@
 /obj/effect/decal/cleanable/debris/glassy,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town)
-"aLM" = (
-/obj/machinery/light/rogue/smoker,
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/exposed/town/keep)
 "aLN" = (
 /obj/effect/decal/cobbleedge{
 	icon_state = "cobbleedge-sread"
@@ -13047,11 +13043,6 @@
 /obj/structure/closet/crate/chest/neu,
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/physician)
-"cyw" = (
-/obj/structure/flora/roguegrass,
-/obj/machinery/light/rogue/smoker,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "cyy" = (
 /obj/structure/closet/crate/coffin,
 /turf/open/floor/rogue/cobble/mossy,
@@ -74799,6 +74790,10 @@
 /obj/effect/spawner/lootdrop/cheap_jewelry_spawner,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cave/scarymaze)
+"nUq" = (
+/obj/machinery/light/rogue/smoker/wheeled,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "nUs" = (
 /obj/structure/fluff/railing/border/east,
 /turf/open/floor/rogue/cobble/mossy,
@@ -81707,18 +81702,6 @@
 "peO" = (
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/beach/central)
-"peV" = (
-/obj/structure/closet/crate/chest/crate,
-/obj/item/grown/log/tree/small,
-/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
-/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
-/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
-/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
-/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
-/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
-/obj/item/flint,
-/turf/open/floor/rogue/ruinedwood/turned,
-/area/rogue/under/underdark)
 "peW" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
 /obj/structure/bed/rogue/shit,
@@ -93145,6 +93128,18 @@
 /obj/machinery/tanningrack,
 /turf/open/floor/rogue/church,
 /area/rogue/under/cave/scarymaze)
+"rlq" = (
+/obj/structure/closet/crate/chest/crate,
+/obj/item/grown/log/tree/small,
+/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
+/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
+/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
+/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
+/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
+/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
+/obj/item/flint,
+/turf/open/floor/rogue/ruinedwood/turned,
+/area/rogue/under/underdark)
 "rlr" = (
 /obj/structure/rack/rogue/shelf/biggest,
 /obj/item/burial_shroud{
@@ -94915,6 +94910,11 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/shelter/woods)
+"rCw" = (
+/obj/structure/flora/roguegrass,
+/obj/machinery/light/rogue/smoker,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "rCx" = (
 /obj/structure/fluff/walldeco/church/line{
 	dir = 8
@@ -123850,7 +123850,7 @@
 /obj/effect/decal/mossy{
 	dir = 4
 	},
-/obj/structure/flora/ausbushes/lavendergrass,
+/obj/machinery/light/rogue/smoker,
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/town)
 "wXs" = (
@@ -270876,7 +270876,7 @@ pMG
 njB
 mQr
 slz
-cyw
+rCw
 sns
 uZQ
 trN
@@ -278750,7 +278750,7 @@ gHj
 sPj
 qmZ
 sPj
-peV
+rlq
 weG
 sPj
 sPj
@@ -315548,7 +315548,7 @@ exD
 exD
 njB
 lkt
-anz
+nUq
 wdl
 jZR
 pxc
@@ -315596,7 +315596,7 @@ gfZ
 sPm
 vAw
 vAw
-aLM
+aer
 hrE
 hrE
 jWw


### PR DESCRIPTION
## About The Pull Request
- Adds a smoker to the keep's farming area, the soilson's farming area, the innkeep's farming area.
- Adds a smoker out in the underdark with supplies to use is, interactive tutorializing!
- Adds a wheeled smoker to the small warden's tower for them to take along on adventures. Fun!
- Adds wheeled smokers to hunter houses.

## Testing Evidence
simple ahh mapping change

## Why It's Good For The Game
Maps in the smokers which I kept out of the smoker PR as to avoid conflicts. Given to roles where it makes sense. Hopefully will prevent these from being given to everyone.

## Changelog

:cl:
add: Added smoker structures to following roles - Warden (tower), hunter houses, inn, soilson, keep.
/:cl:
