### PR TITLE
adds susiedeltarune

### DIFF
--- a/code/game/objects/items/rogueitems/magic/mageitems.dm
+++ b/code/game/objects/items/rogueitems/magic/mageitems.dm
@@ -56,6 +56,18 @@
 	var/obj/effect/decal/cleanable/roguerune/rune_to_scribe = null
 	var/chosen_keyword
 
+/obj/item/chalk/attack(mob/living/target, mob/living/user)
+
+	user.visible_message(span_notice("[user] begins nibbling on [src]."), span_notice("I begin nibbling on [src]."))
+	if(!do_after(user, 2 SECONDS, target = src))
+		return
+	playsound(user.loc, 'sound/misc/eat.ogg', rand(30,60), TRUE)
+	user.visible_message(span_notice("[user] finishes eating [src]."), span_notice("I finish eating [src]. Yum!"))
+	user.reagents.add_reagent(/datum/reagent/medicine/manapot, 15)
+	qdel(src)
+
+
+
 /obj/item/chalk/attack_self(mob/living/carbon/human/user)
 	if(!HAS_TRAIT(user, TRAIT_LEYLINE_ATTUNEMENT))
 		to_chat(user, span_cult("Nothing comes in mind to draw with the chalk."))


### PR DESCRIPTION
## About The Pull Request

lets you eat chalk

## Testing Evidence

<img width="1035" height="540" alt="image" src="https://github.com/user-attachments/assets/fcff767b-a6d9-46f9-97b1-7a092077447f" />

## Why It's Good For The Game

<img width="382" height="34" alt="image" src="https://github.com/user-attachments/assets/38c441fe-6808-4231-8d03-259f734282ab" />

<img width="761" height="95" alt="image" src="https://github.com/user-attachments/assets/c51cf925-2721-404c-b9b4-873ac53348b4" />
<img width="299" height="105" alt="image" src="https://github.com/user-attachments/assets/221f1c53-e530-4f89-ba7d-f80bbd332192" />

<img width="231" height="175" alt="image" src="https://github.com/user-attachments/assets/b5099a47-39cf-4023-872c-09fcc3db6d11" />



## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: you can eat chalk now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
