### PR TITLE
Un-gatekeeps gatekeeping (Mechanics examines for wrenches, levers, gates, plates, and hatches)

### DIFF
--- a/code/game/objects/items/contraption.dm
+++ b/code/game/objects/items/contraption.dm
@@ -266,12 +266,13 @@
 
 /obj/item/rogueweapon/contraption/linker/get_mechanics_examine(mob/user)
 	. = ..()
+	. += span_info("Wrenches consume gears to perform a variety of artificing functions.")
+	. += span_info("Use of a wrench requires a high Engineering skill, and may befuddle your character otherwise.")
 	. += span_info("Use it like a multitool on compatible machinery to store a target in its buffer, then use it again on another compatible target to link them.")
 	. += span_info("Right click it in-hand to wipe its stored buffer.")
 	. += span_info("Right-click an adjacent rotatable rotational object while holding this to rotate it.")
 	. += span_info("Middle-click an adjacent placed shaft, cogwheel, or gearbox while holding this to disassemble it back into an item pile.")
-	if(user.get_skill_level(/datum/skill/craft/engineering) >= 4)
-		. += span_info("Holding it in your hands grants Tune Up, which spends wrench charge to repair or enhance compatible engineering targets.")
+	. += span_info("Holding it in your hands grants Tune Up, which spends wrench charge to repair or enhance compatible engineering targets.")
 
 /obj/item/rogueweapon/contraption/linker/attack_right(mob/user)
 	. = ..()

--- a/code/game/objects/structures/fluff.dm
+++ b/code/game/objects/structures/fluff.dm
@@ -413,6 +413,13 @@
 	redstone_structure = TRUE
 	broken_icon_state = "passage1b"
 
+/obj/structure/bars/passage/get_mechanics_examine(mob/user)
+	. = ..()
+	. += span_info("Most gates are traditionally linked to a lever or winch. Left-clicking the right lever or winch will open the gate that they're connected to.")
+	. += span_info("A skilled Engineer could use a wrench to link this to a device.")
+	. += span_info("The Master of the Guild of Craft can unlink devices from each other by using their special wrench.")
+	. += span_info("While a length process, gates can also be bypassed through destroying them with enough strikes. Bombs of blastpowder in particular excel at damaging these structures.")
+
 /obj/structure/bars/passage/steel
 	name = "steel bars"
 	max_integrity = 2500

--- a/code/game/objects/structures/roguetown/redstone.dm
+++ b/code/game/objects/structures/roguetown/redstone.dm
@@ -147,6 +147,8 @@ GLOBAL_LIST_EMPTY(redstone_objs)
 /obj/structure/lever/get_mechanics_examine(mob/user)
 	. = ..()
 	. += span_info("Left-click the lever to actuate whatever might be connected to it. The time needed to complete this action scales with your character's Strength.")
+	. += span_info("A skilled Engineer could use a wrench to link this to a device.")
+	. += span_info("The Master of the Guild of Craft can unlink devices from each other by using their special wrench.")
 
 /obj/structure/lever/attack_hand(mob/user)
 	if(isliving(user))
@@ -273,6 +275,11 @@ GLOBAL_LIST_EMPTY(redstone_objs)
 	density = FALSE
 	anchored = TRUE
 	redstone_structure = TRUE
+
+/obj/structure/pressure_plate/get_mechanics_examine(mob/user)
+	. = ..()
+	. += span_info("A skilled Engineer could use a wrench to link this to a device.")
+	. += span_info("The Master of the Guild of Craft can unlink devices from each other by using their special wrench.")
 
 /obj/structure/pressure_plate/Crossed(atom/movable/AM)
 	. = ..()
@@ -780,6 +787,11 @@ GLOBAL_LIST_EMPTY(redstone_objs)
 	AddComponent(/datum/component/squeak, list('sound/foley/footsteps/FTMET_A1.ogg','sound/foley/footsteps/FTMET_A2.ogg','sound/foley/footsteps/FTMET_A3.ogg','sound/foley/footsteps/FTMET_A4.ogg'), 100)
 	return ..()
 */
+/obj/structure/floordoor/get_mechanics_examine(mob/user)
+	. = ..()
+	. += span_info("A skilled Engineer could use a wrench to link this to a device.")
+	. += span_info("The Master of the Guild of Craft can unlink devices from each other by using their special wrench.")
+
 /obj/structure/floordoor/obj_break(damage_flag)
 	set_is_platform(FALSE)
 	obj_flags &= ~BLOCK_Z_IN_UP


### PR DESCRIPTION
## About The Pull Request

Adds mechanical information to assorted Engineering items to better explain how they work. The wrench, especially, previously locked most of its info away unless your character was very high level. Now it simply says you need a high level to use it, rather than confounding players for no good reason.

## Testing Evidence

Went ingame as a character with no Engineering skill and examined the atoms in question.
<img width="587" height="556" alt="image" src="https://github.com/user-attachments/assets/0cc252b4-5844-461e-8fa9-77d17c2c8dc2" />
<img width="582" height="216" alt="image" src="https://github.com/user-attachments/assets/e901aeaa-66f3-44a1-8ed0-0580430bd3f3" />
<img width="581" height="279" alt="image" src="https://github.com/user-attachments/assets/d6d7d758-0cdc-4d8c-bf0a-65da5ff747a5" />
<img width="585" height="181" alt="image" src="https://github.com/user-attachments/assets/af8a350b-281c-4095-9a75-d3b5cea99e02" />
<img width="585" height="194" alt="image" src="https://github.com/user-attachments/assets/a8b2f676-2d5d-478d-ad49-dd8002a4453d" />


## Why It's Good For The Game

While it's definitely good to let players discover some interactions on their own, Engineering is an especially 'gate-kept' skill, being only properly accessible if you start as a Guild artificer, Munitioneer, or skeleton sapper. This PR adds no better way of training it, but it does make it more clear what's actually happening to players. More information ingame is better. Fewer baffled questions in mentorhelp is better.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Added better mechanics help for some Engineering components and items
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
