### PR TITLE
Opens the floodgates (Wood shafts are now a novice craft)

### DIFF
--- a/code/modules/roguetown/roguecrafting/engineering.dm
+++ b/code/modules/roguetown/roguecrafting/engineering.dm
@@ -742,7 +742,7 @@
 	verbage = "engineers"
 	skillcraft = /datum/skill/craft/engineering
 	tools = list(/obj/item/rogueweapon/huntingknife = 1)
-	craftdiff = 4
+	craftdiff = 1
 
 /datum/crafting_recipe/roguetown/engineering/stickshaft
 	name = "wooden shaft"
@@ -754,7 +754,7 @@
 	verbage = "engineers"
 	skillcraft = /datum/skill/craft/engineering
 	tools = list(/obj/item/rogueweapon/huntingknife = 1)
-	craftdiff = 4
+	craftdiff = 1
 
 /datum/crafting_recipe/roguetown/engineering/cog
 	name = "wooden cogwheel(6x)"


### PR DESCRIPTION
## About The Pull Request

Makes wood shafts (which transfer rotational energy) a novice craft instead of an expert craft.

## Testing Evidence

Compiled, ran, checked crafting menu, crafted shafts.

I worried that they would be a new way to powergame money by selling to the NAVIGATOR, but stacks of shafts sell for approximately jack and shit, so it won't change anything there.

<img width="342" height="432" alt="image" src="https://github.com/user-attachments/assets/7a0c1937-9bc9-4573-b6d8-c19d32fb1dd8" />

## Why It's Good For The Game

Makes an easy-sounding craft into an actually easy craft.

This makes a lot intuitive "realistic" sense but actually has larger-scale consequences--this means that characters with no skill in Engineering could power-train it to at least Apprentice if they spent some time and had enough intelligence. It also means that characters with a higher softcap on Engineering could, over the course of days, slowly grow to become capable of more advanced artifice.

I personally think this is cool, but it certainly proliferates a field of craft that was previously *very* kept to within the Guild. **It's worth noting that you can already power-level Engineering if you have a forge and an anvil, but this makes it doable without doing any smithing directly.**

Probably a "needs approval from multiple collabs" type PR because of these consequences.

## Changelog

:cl:
balance: Wood shafts are now a novice craft
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
