### PR TITLE
Fix chat hanging

### DIFF
--- a/tgui/packages/common/storage.ts
+++ b/tgui/packages/common/storage.ts
@@ -114,8 +114,14 @@ class IFrameIndexedDbBackend implements StorageBackend {
   async get(key: string): Promise<any> {
     return new Promise((resolve) => {
       const handler = (message: MessageEvent) => {
-        if (message.source === this.iframeWindow && message.data?.key === key) {
-          window.removeEventListener('message', handler);
+        if (message.source !== this.iframeWindow) {
+          return;
+        }
+
+        if (message.data?.error) {
+          console.error(message.data.error);
+          resolve(undefined);
+        } else if (message.data?.key === key) {
           resolve(message.data.value);
         }
       };

--- a/tgui/public/iframe.html
+++ b/tgui/public/iframe.html
@@ -56,6 +56,8 @@
                 { key: messageEvent.data.key, value: value },
                 '*',
               );
+            }, (error) => {
+              messageEvent.source.postMessage({ error }, '*');
             });
             break;
           case 'set':


### PR DESCRIPTION
## About The Pull Request
Port of VOREStation/VOREStation#19687

Basically, iframe storage would just hang forever if it encountered an error- and whatever Edge/WV2 does to clean up old DBs, causes [this error](https://chromestatus.com/feature/5140210640486400): `Data lost due to missing file. Affected record should be considered irrecoverable`

Now it'll report the error and resolve(undefined).

This means the chat won't just get stuck in a half-initialized state that can only be fixed with a full cache clear, it'll just fall back to defaults.

This doesn't fix the underlying issue of our persistent storage getting removed, but that's a Lummox issue, see [here](https://www.byond.com/forum/post/2989980).

Note: The fixes here will not work until Virgo's byond-client-storage repo is updated after the mentioned PR is merged. They won't cause any harm either though.

## Testing Evidence
No good way to test because there's no good way to cause the error.

## Why It's Good For The Game
No more chat getting stuck blank

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Chat will no longer hang and show a blank screen when storage is lost.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
