### PR TITLE
BUGFIX: Conf. Hood coverage

### DIFF
--- a/code/modules/clothing/rogueclothes/headwear/adjusthoods.dm
+++ b/code/modules/clothing/rogueclothes/headwear/adjusthoods.dm
@@ -467,7 +467,7 @@
 	icon_state = "confessorhood"
 	item_state = "confessorhood"
 	color = null
-	body_parts_covered = NECK | HEAD | HAIR
+	body_parts_covered = NECK | HEAD | HAIR | EARS
 	slot_flags = ITEM_SLOT_HEAD|ITEM_SLOT_MASK
 	flags_inv = HIDEEARS|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
 	armor = ARMOR_LEATHER


### PR DESCRIPTION
## About The Pull Request

Previously hood that covers all your head(except face)  and lowers FOV did not actually cover your ears. 

## Testing Evidence

tested on local server

## Why It's Good For The Game

it's looks dumb without it

## Changelog
added EARS to coverage

:cl:

fix: confessional hood coverage

/:cl:


