### PR TITLE
BUGFIX: Psydonic silver-reinforced staff crafting

### DIFF
--- a/code/modules/roguetown/roguecrafting/crafting/weapons_tools.dm
+++ b/code/modules/roguetown/roguecrafting/crafting/weapons_tools.dm
@@ -434,7 +434,7 @@
 	craftdiff = 5
 
 /datum/crafting_recipe/roguetown/survival/quarterstaff_psydonic/bullion
-	name = "psydonic silver-reinforced quarterstaff"
+	name = "psydonic silver-reinforced quarterstaff (bullion)"
 	category = "Tools"
 	result = list(/obj/item/rogueweapon/woodstaff/quarterstaff/psy)
 	reqs = list(


### PR DESCRIPTION
## About The Pull Request

Fixed crafting recipes for silver bar variant

## Testing Evidence

protestil na localke

## Why It's Good For The Game

bugs are bad

## Changelog


:cl:
fix: Added a different name for bullion recipe variant which fixed conflict between two
/:cl:

