### PR TITLE
BUGFIX: Roundstart mercs link expiration

### DIFF
--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary.dm
@@ -111,8 +111,8 @@
 			to_chat(M, span_boldnotice("I sense a mercenary statue calling out to me..."))
 			to_chat(M, span_notice("<a href='?src=[REF(statue)];register=[REF(H)]'>Touch the statue from afar</a> to register myself as available for contract."))
 
-			// Store the registration request
-			statue.pending_registrations[H.key] = H
+			statue.pending_registrations[M.key] = H
+			addtimer(CALLBACK(statue, TYPE_PROC_REF(/obj/structure/roguemachine/talkstatue/mercenary, expire_registration), M.key), 5 MINUTES)
 
 /datum/advclass/mercenary/post_equip(mob/living/carbon/human/H) // has to be here because this is done AFTER subclass selection
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Right now, if you press ready in lobby as mercenary, when game actually start you will be no longer capable to register yourself at mercenary statue, cause timer starts in lobby. I did fix it and now it starts to count only on spawn

## Testing Evidence

Auf einem lokalen Server getestet

## Why It's Good For The Game

bugs are still bad

## Changelog
:cl:
fix: Fixed a bug that counted readiness in lobby as time on mercenary, so merc statue link was always expired even before server actually started round
/:cl:
