### PR TITLE
fixes socialite providing massages from trees erroneously

### DIFF
--- a/code/modules/virtues/utility.dm
+++ b/code/modules/virtues/utility.dm
@@ -159,7 +159,7 @@
 	for(var/choice in picked_choices)
 		if(choice == "Nutcracker")
 			ADD_TRAIT(recipient, TRAIT_NUTCRACKER, TRAIT_VIRTUE)
-		else if(choice == "Massage")
+		else if(choice == "Massage Ability")
 			if(recipient.mind)
 				recipient.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/massage)
 		else

--- a/code/modules/virtues/utility.dm
+++ b/code/modules/virtues/utility.dm
@@ -123,17 +123,21 @@
 #undef NOTABLE_RESIDENCY
 #undef NOTABLE_SHREWD
 
+#define SOCIALITE_MASSAGE "Massage Ability"
+#define SOCIALITE_NUTCRACKER "Nutcracker Trait"
+#define SOCIALITE_EMPATH "Empath Trait"
+
 /datum/virtue/utility/socialite
 	name = "Socialite"
 	desc = "I thrive in social settings, easily reading the emotions of others and charming those around me. My presence is always felt at any gathering."
 	ui_fa_icon = "people-arrows"
-	added_traits = list(TRAIT_BEAUTIFUL, TRAIT_GOODLOVER, TRAIT_EMPATH)
-	max_choices = 3
-	choice_costs = list(0, 0, 4)
+	added_traits = list(TRAIT_BEAUTIFUL, TRAIT_GOODLOVER)
+	max_choices = 4
+	choice_costs = list(0, 0, 2, 4)
 	extra_choices = list(
-	"Massage Ability",
-	"Hand Mirror" = /obj/item/handmirror,
-	"Nutcracker" = TRAIT_NUTCRACKER,
+	SOCIALITE_MASSAGE,
+	SOCIALITE_NUTCRACKER,
+	SOCIALITE_EMPATH,
 	"Cookies" = /obj/item/reagent_containers/food/snacks/rogue/cookie,
 	"Rosa Bouquet" = /obj/item/bouquet/rosa,
 	"Salvia Bouquet" = /obj/item/bouquet/salvia,
@@ -156,17 +160,25 @@
 
 /datum/virtue/utility/socialite/apply_to_human(mob/living/carbon/human/recipient)
 	..()
+	recipient.mind.special_items["Hand Mirror"] = /obj/item/handmirror
 	for(var/choice in picked_choices)
-		if(choice == "Nutcracker")
-			ADD_TRAIT(recipient, TRAIT_NUTCRACKER, TRAIT_VIRTUE)
-		else if(choice == "Massage Ability")
-			if(recipient.mind)
-				recipient.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/massage)
-		else
-			recipient.mind.special_items[choice] = extra_choices[choice]
+		switch(choice)
+			if(SOCIALITE_MASSAGE)
+				if(recipient.mind)
+					recipient.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/massage)
+			if(SOCIALITE_NUTCRACKER)
+				ADD_TRAIT(recipient, TRAIT_NUTCRACKER, TRAIT_VIRTUE)
+			if(SOCIALITE_EMPATH)
+				ADD_TRAIT(recipient, TRAIT_EMPATH, TRAIT_VIRTUE)
+			else
+				recipient.mind.special_items[choice] = extra_choices[choice]
 	if(isdullahan(recipient))
 		REMOVE_TRAIT(recipient, TRAIT_BEAUTIFUL, TRAIT_VIRTUE)
 		ADD_TRAIT(recipient, TRAIT_BEAUTIFUL_UNCANNY, TRAIT_VIRTUE)
+
+#undef SOCIALITE_MASSAGE
+#undef SOCIALITE_NUTCRACKER
+#undef SOCIALITE_EMPATH
 
 /datum/virtue/utility/failed_squire
 	name = "Failed Squire"


### PR DESCRIPTION
## About The Pull Request
fixes socialite providing massages from trees erroneously
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
fixes socialite providing massages from trees erroneously
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
fixes socialite providing massages from trees erroneously
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix:Fixed Socialite Massage option not working correctly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
