### PR TITLE
[QoL] Implements Wealth Appraisal on Examine

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -9,6 +9,7 @@
 #define TRAIT_NUTCRACKER "Nutcracker"
 #define TRAIT_SEEPRICES "Skilled Appraiser"
 #define TRAIT_SEEPRICES_SHITTY "Appraiser"
+#define TRAIT_SEEWEALTH "Wealth Appraiser"
 #define TRAIT_NOBLE "Noble Blooded"
 #define TRAIT_DEFILED_NOBLE "Drained Noble Blood"
 #define TRAIT_EMPATH "Empath"

--- a/code/datums/gods/patrons/inhumen/matthios.dm
+++ b/code/datums/gods/patrons/inhumen/matthios.dm
@@ -21,6 +21,7 @@
 		"MATTHIOS IS JUSTICE!",
 		"MATTHIOS IS MY LORD!",
 	)
+	traits_tier = list(TRAIT_SEEWEALTH = CLERIC_T2)
 	storyteller = /datum/storyteller/matthios
 
 	titles = list(

--- a/code/modules/jobs/job_types/roguetown/burghers/merchant.dm
+++ b/code/modules/jobs/job_types/roguetown/burghers/merchant.dm
@@ -23,7 +23,7 @@ The priests will whisper that you follow the Sun-Thief. Frown, shake your head, 
 	cmode_music = 'sound/music/combat_noble.ogg'
 	is_quest_giver = TRUE
 
-	job_traits = list(TRAIT_SEEPRICES, TRAIT_CICERONE)
+	job_traits = list(TRAIT_SEEPRICES, TRAIT_SEEWEALTH, TRAIT_CICERONE)
 	virtue_restrictions = list(/datum/virtue/utility/skilled, /datum/virtue/utility/apprentice) //Commerce role, not a craftsman.
 
 	advclass_cat_rolls = list(CTAG_MERCH = 2)
@@ -89,7 +89,6 @@ The priests will whisper that you follow the Sun-Thief. Frown, shake your head, 
 	else if(should_wear_femme_clothes(H))
 		shoes = /obj/item/clothing/shoes/roguetown/gladiator
 	if(H.mind)
-		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/appraise/secular)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/takeapprentice)
 	if(H.mind)
 		SStreasury.grant_savings(ECONOMIC_RICH, H)

--- a/code/modules/jobs/job_types/roguetown/courtier/clerk.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/clerk.dm
@@ -22,7 +22,7 @@
 	round_contrib_points = 2
 	advclass_cat_rolls = list(CTAG_CLERK = 2)
 
-	job_traits = list(TRAIT_SEEPRICES, TRAIT_ROYAL_SUBSIDY)
+	job_traits = list(TRAIT_SEEPRICES, TRAIT_SEEWEALTH, TRAIT_ROYAL_SUBSIDY)
 	virtue_restrictions = list(/datum/virtue/utility/skilled, /datum/virtue/utility/apprentice) //Commerce role, not a craftsman.
 	job_subclasses = list(
 		/datum/advclass/clerk
@@ -56,8 +56,6 @@
 
 /datum/outfit/job/roguetown/clerk/basic/pre_equip(mob/living/carbon/human/H)
 	..()
-	if(H.mind)
-		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/appraise/secular)
 
 	if(should_wear_femme_clothes(H))
 		shirt = /obj/item/clothing/suit/roguetown/shirt/dress/silkdress/green

--- a/code/modules/jobs/job_types/roguetown/courtier/steward.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/steward.dm
@@ -22,7 +22,7 @@
 
 	advclass_cat_rolls = list(CTAG_STEWARD = 2)
 
-	job_traits = list(TRAIT_NOBLE, TRAIT_SEEPRICES, TRAIT_ROYAL_SUBSIDY)
+	job_traits = list(TRAIT_NOBLE, TRAIT_SEEPRICES, TRAIT_SEEWEALTH, TRAIT_ROYAL_SUBSIDY)
 	vice_restrictions = list(/datum/charflaw/mute, /datum/charflaw/unintelligible) //Needs to use the throat - sometimes
 	virtue_restrictions = list(/datum/virtue/utility/skilled, /datum/virtue/utility/apprentice) //Commerce role, not a craftsman.
 	job_subclasses = list(
@@ -77,8 +77,6 @@
 	beltl = /obj/item/storage/belt/rogue/pouch/merchant/coins
 	backr = /obj/item/storage/backpack/rogue/satchel
 	id = /obj/item/scomstone
-	if(H.mind)
-		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/appraise/secular)
 	add_verb(H, /mob/living/carbon/human/proc/adjust_taxes)
 	if(H.mind)
 		SStreasury.grant_savings(ECONOMIC_RICH, H)

--- a/code/modules/jobs/job_types/roguetown/nobility/lord.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/lord.dm
@@ -241,7 +241,7 @@ GLOBAL_LIST_EMPTY(lord_titles)
 	outfit = /datum/outfit/job/roguetown/lord/merchant
 	category_tags = list(CTAG_LORD)
 	noble_income = 275 // Decently high but shouldn't remove any need for economic management
-	traits_applied = list(TRAIT_NOBLE, TRAIT_SEEPRICES, TRAIT_CICERONE, TRAIT_KEENEARS, TRAIT_MEDIUMARMOR, TRAIT_DNR)
+	traits_applied = list(TRAIT_NOBLE, TRAIT_SEEPRICES, TRAIT_CICERONE, TRAIT_KEENEARS, TRAIT_MEDIUMARMOR, TRAIT_SEEWEALTH, TRAIT_DNR)
 	subclass_stats = list(
 		STATKEY_LCK = 5,
 		STATKEY_INT = 5,
@@ -275,8 +275,6 @@ GLOBAL_LIST_EMPTY(lord_titles)
 /datum/outfit/job/roguetown/lord/merchant/pre_equip(mob/living/carbon/human/H)
 	..()
 	l_hand = /obj/item/rogueweapon/lordscepter
-	if(H.mind)
-		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/appraise/secular)
 
 /**
 	Mage Lord subclass. Prince mage is a thing.

--- a/code/modules/jobs/job_types/roguetown/peasants/shophand.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/shophand.dm
@@ -22,7 +22,7 @@
 	round_contrib_points = 2
 	cmode_music = 'sound/music/cmode/towner/combat_towner.ogg'
 
-	job_traits = list(TRAIT_SEEPRICES)
+	job_traits = list(TRAIT_SEEPRICES, TRAIT_SEEWEALTH)
 	virtue_restrictions = list(/datum/virtue/utility/skilled, /datum/virtue/utility/apprentice) //Commerce role, not a craftsman.
 
 	advclass_cat_rolls = list(CTAG_SHOPHAND = 2)
@@ -39,10 +39,10 @@
 	subclass_stats = list(
 		STATKEY_SPD = 1,
 		STATKEY_INT = 1,
+		STATKEY_STR = 1,
 		STATKEY_LCK = 1
 	)
 	subclass_skills = list(
-		//worse skills than a normal peasant, generally, with random bad combat skill
 		/datum/skill/misc/stealing = SKILL_LEVEL_EXPERT,
 		/datum/skill/misc/sneaking = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/climbing = SKILL_LEVEL_JOURNEYMAN,
@@ -53,6 +53,8 @@
 		/datum/skill/combat/wrestling = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/athletics = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/lockpicking = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/combat/swords = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/combat/maces = SKILL_LEVEL_APPRENTICE,
 	)
 
 /datum/outfit/job/roguetown/shophand/basic/pre_equip(mob/living/carbon/human/H)
@@ -74,16 +76,6 @@
 		beltr = /obj/item/storage/belt/rogue/pouch/coins/poor
 		beltl = /obj/item/storage/keyring/merchant
 		backr = /obj/item/storage/backpack/rogue/satchel
-	if(H.mind)
-		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/appraise/secular)
-	if(prob(33))
-		H.adjust_skillrank(/datum/skill/combat/crossbows, 1, TRUE)
-	else if(prob(33))
-		H.adjust_skillrank(/datum/skill/combat/bows, 1, TRUE)
-	else //the legendary shopARM
-		H.adjust_skillrank(/datum/skill/combat/swords, 1, TRUE)
-		H.adjust_skillrank(/datum/skill/combat/maces, 1, TRUE)
-		H.change_stat(STATKEY_STR, 1)
 	if(H.mind)
 		SStreasury.grant_savings(ECONOMIC_UPPER_MIDDLE_CLASS, H)
 	backpack_contents = list(

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -1076,6 +1076,15 @@
 				carbs.Jitter(10)
 				carbs.stuttering += 25
 
+		if (HAS_TRAIT(user, TRAIT_SEEWEALTH))
+			if(HAS_TRAIT(src, TRAIT_DECEIVING_MEEKNESS) && src != user)
+				. +=span_notice("I cannot tell how much wealth they have.")
+			else
+				var/mammonsonperson = get_mammons_in_atom(src)
+				var/mammonsinbank = SStreasury.get_balance(src)
+				var/totalvalue = mammonsinbank + mammonsonperson
+				. +=span_notice("[src] has [mammonsonperson] mammons on them, [mammonsinbank] in their meister, for a total of [totalvalue] mammons.")
+
 		// Shouldn't be able to tell they are unrevivable through a mask as a Necran
 		if(HAS_TRAIT(src, TRAIT_DNR) && src != user)
 			if(HAS_TRAIT(user, TRAIT_DEATHSIGHT) || stat == DEAD)

--- a/code/modules/spells/pantheon/inhumen/matthios.dm
+++ b/code/modules/spells/pantheon/inhumen/matthios.dm
@@ -924,53 +924,6 @@
 				target.death()
 		return TRUE
 
-///////////////////
-// T? - Appraise //
-///////////////////
-//Unused besides the secular part
-
-/obj/effect/proc_holder/spell/invoked/appraise
-	name = "Appraise"
-	desc = "Tells you how many mammons someone has on them and in the meister."
-	action_icon = 'icons/mob/actions/matthiosmiracles.dmi'
-	overlay_icon = 'icons/mob/actions/matthiosmiracles.dmi'
-	overlay_state = "appraise"
-	miracle = TRUE
-	devotion_cost = 5
-	releasedrain = 10
-	chargedrain = 0
-	chargetime = 0
-	range = 4
-	warnie = "sydwarning"
-	movement_interrupt = FALSE
-	invocation_type = "none"
-	associated_skill = /datum/skill/magic/holy
-	antimagic_allowed = TRUE
-	recharge_time = 5 SECONDS
-
-/obj/effect/proc_holder/spell/invoked/appraise/secular
-	name = "Secular Appraise"
-	range = 2
-	associated_skill = /datum/skill/misc/reading
-	action_icon = 'icons/mob/actions/matthiosmiracles.dmi'
-	overlay_icon = 'icons/mob/actions/matthiosmiracles.dmi'
-	miracle = FALSE
-	devotion_cost = 0 //Merchants are not clerics
-
-/obj/effect/proc_holder/spell/invoked/appraise/cast(list/targets, mob/living/user)
-	if(ishuman(targets[1]))
-		var/mob/living/carbon/human/target = targets[1]
-		if(HAS_TRAIT(target, TRAIT_DECEIVING_MEEKNESS) && target != user)
-			to_chat(user, "<font color='yellow'>I cannot tell...</font>")
-			if(prob(50 + ((target.STAPER - 10) * 10)))
-				to_chat(target, span_warning("A pair of prying eyes were laid on me..."))
-			return
-		var/mammonsonperson = get_mammons_in_atom(target)
-		var/mammonsinbank = SStreasury.get_balance(target)
-		var/totalvalue = mammonsinbank + mammonsonperson
-		to_chat(user, ("<font color='yellow'>[target] has [mammonsonperson] mammons on them, [mammonsinbank] in their meister, for a total of [totalvalue] mammons.</font>"))
-
-
 ///////////////
 // T? - Raze //
 ///////////////

--- a/code/modules/virtues/utility.dm
+++ b/code/modules/virtues/utility.dm
@@ -68,7 +68,7 @@
 		switch(choice)
 			if(NOTABLE_SHREWD)
 				ADD_TRAIT(recipient, TRAIT_SEEPRICES, TRAIT_VIRTUE)
-				recipient.mind?.AddSpell(new /obj/effect/proc_holder/spell/invoked/appraise/secular)
+				ADD_TRAIT(recipient, TRAIT_SEEWEALTH, TRAIT_VIRTUE)
 				if(HAS_TRAIT(recipient, TRAIT_OUTLAW))
 					recipient.mind?.special_items["Weighty Coinpurse"] = /obj/item/storage/belt/rogue/pouch/coins/virtuepouch
 				else

--- a/code/modules/virtues/utility.dm
+++ b/code/modules/virtues/utility.dm
@@ -57,7 +57,7 @@
 		NOTABLE_RESIDENCY,
 	)
 	choice_tooltips = list(
-		NOTABLE_SHREWD = "I've managed to secure a Meister account and a lump sum within it. Grants Secular Appraise -- a spell that allows you to tell how much wealth someone has on them, and in their Meister.",
+		NOTABLE_SHREWD = "I've managed to secure a Meister account and a lump sum within it. I also know enough to determinate people's wealth at a glance, as well as the accurate price of items.",
 		NOTABLE_RESIDENCY = "I am a Resident of Azure Peak, with access to one of its buildings all to myself.",
 	)
 


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

Removes the spell Secular Appraise. Gives to all those that got it before the ability to see wealth in others as good as you did with Secular appraisal, the trait being called See Wealth. It doesnt work if the target its using a mask.

Mattios t2 casters get the See Wealth perk for free.

Shop hands always get 1 point of str and sword/maces on apprentice now, instead of it being 1/3 of a chance.

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

no spell and examine working:

<img width="2084" height="1145" alt="image" src="https://github.com/user-attachments/assets/46001f6b-6cf8-45eb-bae1-452a47e616c5" />

doesnt work with mask:

<img width="1444" height="751" alt="image" src="https://github.com/user-attachments/assets/48292499-092a-4383-8a7a-33aa56851683" />

<img width="618" height="633" alt="image" src="https://github.com/user-attachments/assets/7fb8c4f2-9a5c-4acb-9524-e7417748b7ea" />


Free Man getting the perk:

<img width="633" height="693" alt="image" src="https://github.com/user-attachments/assets/ff6ce20b-2cf5-4a43-a0e9-c5b5aed7fc03" />


## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

I am tired of having a spell as a mage main if I pick anything that gives me appraise, besides every other use works with examine, is silly that the person one doesnt. This makes the system more intuitive to use. It's a bit weird the bath master doesnt have it, but as it didnt have it originally, didnt add it now.

Regarding the shop hand, unless its the jester, on which I have my own commentary and goes out of scope, its bad design for a class so weak to have a chance of 2/5 of their stats not to exist and get a novice level skill on top of that. The class itself does need a review, as many many other classes, but this is just a flagrant thing that could be fixed with two lines and not much though.

And Matthios getting it at T2 made sense since the spell was orriginally a matthios thing.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
qol: Removes the spell Secular Appraise. Gives to all those that got it before the ability to see wealth in others as good as you did with Secular appraisal, the trait being called See Wealth. It doesnt work if the target its using a mask.
add: Mattios t2 casters get the See Wealth perk for free.
balance: Shop hands always get 1 point of str and sword/maces on apprentice now, instead of it being 1/3 of a chance.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
