### PR TITLE
QOL: Cooling backpack can now be repaired

### DIFF
--- a/code/modules/clothing/rogueclothes/storage/storage.dm
+++ b/code/modules/clothing/rogueclothes/storage/storage.dm
@@ -317,6 +317,7 @@
 	equip_sound = 'sound/blank.ogg'
 	bloody_icon_state = "bodyblood"
 	sewrepair = FALSE
+	anvilrepair = /datum/skill/craft/engineering
 	component_type = /datum/component/storage/concrete/roguetown/backpack
 
 /obj/item/storage/backpack/rogue/backpack/bagpack


### PR DESCRIPTION
## About The Pull Request

Added a way to repair said backpack with hammer and some engineering skills

## Testing Evidence

Праверыў на сваім серверы

## Why It's Good For The Game

You dont need to give all your money to guild again for cool pack, i dont think this will cause some major balance issues

## Changelog
:cl:
qol: Added repairing to cooling backpack via hammer and engineering
/:cl:

