### PR TITLE
reverts divine/unholy blast to previous behavior AND changes god effects

### DIFF
--- a/code/modules/spells/spell_types/divine/projectiles_single/divine_blast.dm
+++ b/code/modules/spells/spell_types/divine/projectiles_single/divine_blast.dm
@@ -15,7 +15,7 @@
 	charge_required = TRUE
 	charge_time = 0
 	hold_drain = 1
-	cooldown_time = 5 SECONDS
+	cooldown_time = 8 SECONDS
 	invocations = list("Sakral Strahl!")
 	invocation_type = INVOCATION_SHOUT
 	spell_color = GLOW_COLOR_LIGHTNING
@@ -30,7 +30,7 @@
 /obj/projectile/energy/divineblast
 	name = "Divine Blast"
 	icon_state = "divine_blast"
-	damage = 20 // wont do much to a divine worshipper
+	damage = 30 // wont do much to a divine worshipper
 	woundclass = BCLASS_STAB // divine blade!
 	nodamage = FALSE
 	npc_simple_damage_mult = 2 // The Simple Skele Gibber
@@ -39,7 +39,7 @@
 
 /obj/projectile/energy/divineblast/arc
 	name = "Arced Divine Blast"
-	damage = 15 // Slightly lower base damage and barely matter due to low to hit but not a problem on acolyte / cleric.
+	damage = 25 // Slightly lower base damage and barely matter due to low to hit but not a problem on acolyte / cleric.
 	arcshot = TRUE
 
 /obj/projectile/energy/divineblast/on_hit(target)
@@ -76,21 +76,26 @@
 		if (ishuman(firer))
 			caster = firer
 			switch(caster.patron.type)
-				if(/datum/patron/divine/undivided)
-					damage += 15 // just more raw damage. As mentioned in UNDIVIDED. Our generics are better as a trade off of not having higher tier uniques.
+				if(/datum/patron/divine/undivided) //more raw dmg
+					damage += 10
 					H.visible_message(span_warning("Holy light slams into [H] with force!"), span_warning("Holy light slams into me with force!"))
-				if(/datum/patron/divine/astrata)
+				if(/datum/patron/divine/astrata) //1 extra burn stack to matthiosans so we're not applying an insane amt of soft stun. Astrata is NOT letting you FF nobles.
+					if(HAS_TRAIT(H, TRAIT_NOBLE))
+						visible_message(span_warning("Astrata refuses her power! [src] fizzles on contact with [H]!"))
+						playsound(get_turf(H), 'sound/magic/magic_nulled.ogg', 100)
+						qdel(src)
+						return BULLET_ACT_BLOCK
 					if(istype(H.patron, /datum/patron/inhumen/matthios))
 						H.visible_message(span_warning("[H] is engulfed in flames!"), span_warning("Astrata's <b>hatred</b> sets me aflame!"))
-						H.adjust_fire_stacks(3) //ANCIENT ENEMY I DO NOT FEAR YOU
+						H.adjust_fire_stacks(3)
 						H.ignite_mob()
 					else
 						H.visible_message(span_warning("[H] is engulfed in flames!"), span_warning("Astrata's fury sets me aflame!"))
 						H.adjust_fire_stacks(2) //Remains regular, setting everyone on fire is funnier
 						H.ignite_mob()
-				if(/datum/patron/divine/abyssor)
+				if(/datum/patron/divine/abyssor) //sovl oxyloss
 					H.visible_message(span_warning("Water seeps from [H]'s lips!"), span_warning("Choking water in my lungs!"))
-					H.Dizzy(5)
+					H.adjustOxyLoss(10)
 					H.emote("drown")
 				if(/datum/patron/divine/dendor)
 					H.Slowdown(2) // Shared with Ravox cuz immobilize + offbal is 2 strong

--- a/code/modules/spells/spell_types/divine/projectiles_single/divine_blast.dm
+++ b/code/modules/spells/spell_types/divine/projectiles_single/divine_blast.dm
@@ -2,7 +2,7 @@
 	name = "Divine Blast"
 	desc = "Concentrate my belief. Deals more damage to heretics and deadites. \n\
 	Damage is increased by 100% versus simple-minded creechurs.\n\
-	Toggle arc mode (Shift+G) while the spell is active to fire it over intervening mobs. Arced attacks deal 25% less damage."
+	Toggle arc mode (Shift+G) while the spell is active to fire it over intervening mobs. Arced attacks deal less damage."
 	button_icon_state = "divine_blast"
 	cast_range = 12
 	projectile_type = /obj/projectile/energy/divineblast
@@ -30,7 +30,7 @@
 /obj/projectile/energy/divineblast
 	name = "Divine Blast"
 	icon_state = "divine_blast"
-	damage = 30 // wont do much to a divine worshipper
+	damage = 30
 	woundclass = BCLASS_STAB // divine blade!
 	nodamage = FALSE
 	npc_simple_damage_mult = 2 // The Simple Skele Gibber
@@ -39,7 +39,7 @@
 
 /obj/projectile/energy/divineblast/arc
 	name = "Arced Divine Blast"
-	damage = 25 // Slightly lower base damage and barely matter due to low to hit but not a problem on acolyte / cleric.
+	damage = 26 // Slightly lower base damage and barely matter due to low to hit but not a problem on acolyte / cleric.
 	arcshot = TRUE
 
 /obj/projectile/energy/divineblast/on_hit(target)
@@ -59,11 +59,11 @@
 		var/mob/living/carbon/human/H = target
 		if(istype(H.patron, /datum/patron/divine))
 			if(H in GLOB.excommunicated_players)
-				damage += 20
+				damage += 10
 		if(istype(H.patron, /datum/patron/inhumen))
-			damage += 20
+			damage += 10
 		if(istype(H.patron, /datum/patron/old_god))
-			damage += 20
+			damage += 10
 		if(HAS_TRAIT(H, TRAIT_SILVER_WEAK) && !H.has_status_effect(STATUS_EFFECT_ANTIMAGIC))
 			H.visible_message("<font color='white'>Divine power rebukes [H]!</font>")
 			to_chat(H, span_userdanger("Divine fury rebukes my presence! My body catches aflame!")) //Its NOT a Silver sunder, for balance reasons w/ the buffs. Change this back to sunders when clergy isn't absolutely fucked to fight.

--- a/code/modules/spells/spell_types/divine/projectiles_single/divine_blast.dm
+++ b/code/modules/spells/spell_types/divine/projectiles_single/divine_blast.dm
@@ -1,36 +1,30 @@
-/obj/effect/proc_holder/spell/invoked/projectile/divineblast
+/datum/action/cooldown/spell/projectile/divine_blast
 	name = "Divine Blast"
-	desc = "Shoot out a blast of divine power! Deals more damage to heretics(Psydonians/Inhumen) and Undead! \n\
+	desc = "Concentrate my belief. Deals more damage to heretics and deadites. \n\
 	Damage is increased by 100% versus simple-minded creechurs.\n\
 	Toggle arc mode (Shift+G) while the spell is active to fire it over intervening mobs. Arced attacks deal 25% less damage."
-	clothes_req = FALSE
-	range = 12
+	button_icon_state = "divine_blast"
+	cast_range = 12
 	projectile_type = /obj/projectile/energy/divineblast
 	projectile_type_arc = /obj/projectile/energy/divineblast/arc
-	overlay_state = "divine_blast"
-	sound = list('sound/magic/vlightning.ogg')
-	active = FALSE
-	releasedrain = 20
-	chargedrain = 1
-	chargetime = 0
-	recharge_time = 5 SECONDS
-	warnie = "spellwarning"
-	no_early_release = TRUE
-	movement_interrupt = FALSE
-	invocations = list("Göttliche Macht")
-	invocation_type = "shout"
-	glow_color = GLOW_COLOR_LIGHTNING
+	sound = 'sound/magic/vlightning.ogg'
+	primary_resource_type = SPELL_COST_DEVOTION
+	primary_resource_cost = 25
+	secondary_resource_type = SPELL_COST_STAMINA
+	secondary_resource_cost = 20
+	charge_required = TRUE
+	charge_time = 0
+	hold_drain = 1
+	cooldown_time = 5 SECONDS
+	invocations = list("Sakral Strahl!")
+	invocation_type = INVOCATION_SHOUT
+	spell_color = GLOW_COLOR_LIGHTNING
 	glow_intensity = GLOW_INTENSITY_LOW
-	charging_slowdown = 3
-	chargedloop = /datum/looping_sound/invokegen
+	charge_slowdown = 3
 	associated_skill = /datum/skill/magic/holy
-	miracle = TRUE
+	primary_resource_type = SPELL_COST_DEVOTION
 	devotion_cost = 25
-	human_req = TRUE
-
-/obj/effect/proc_holder/spell/invoked/projectile/divineblast/cast(list/targets, mob/user = user)
-	projectile_type = arc_mode ? projectile_type_arc : initial(projectile_type)
-	. = ..()
+	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC | SPELL_REQUIRES_HUMAN
 
 
 /obj/projectile/energy/divineblast

--- a/code/modules/spells/spell_types/divine/projectiles_single/divine_blast.dm
+++ b/code/modules/spells/spell_types/divine/projectiles_single/divine_blast.dm
@@ -1,191 +1,131 @@
-/datum/action/cooldown/spell/projectile/divine_blast
-	background_icon = 'icons/mob/actions/genericmiracles.dmi'
-	button_icon = 'icons/mob/actions/genericmiracles.dmi'
-	button_icon_state = "dblast"
+/obj/effect/proc_holder/spell/invoked/projectile/divineblast
 	name = "Divine Blast"
-	desc = "Release a blast of sheer divine energy at your enemies. Deals more damage to apostates, undead, and simple-minded creatures. Toggle firing mode (Shift+G): Focus or Arc."
-	fluff_desc = "Among the first miracles bestowed upon the faithful is the ability to channel their patron's essence into a focused blast of divine power. Though simple in execution, it is a versatile expression of a deity's will, carrying forth a fragment of the patron's true nature."
-	sound = 'sound/magic/vlightning.ogg'
-	spell_color = GLOW_COLOR_LIGHTNING
-	glow_intensity = GLOW_INTENSITY_LOW
+	desc = "Shoot out a blast of divine power! Deals more damage to heretics(Psydonians/Inhumen) and Undead! \n\
+	Damage is increased by 100% versus simple-minded creechurs.\n\
+	Toggle arc mode (Shift+G) while the spell is active to fire it over intervening mobs. Arced attacks deal 25% less damage."
+	clothes_req = FALSE
+	range = 12
 	projectile_type = /obj/projectile/energy/divineblast
-	cast_range = SPELL_RANGE_PROJECTILE
-
-	primary_resource_type = SPELL_COST_DEVOTION
-	primary_resource_cost = 25
-	invocation_type = INVOCATION_SHOUT
-	charge_required = TRUE
-	charge_time = CHARGETIME_MAJOR
-	hold_drain = 1
-	charge_slowdown = CHARGING_SLOWDOWN_SMALL
-	charge_swingdelay_type = SWINGDELAY_PENALTY
-	charge_sound = 'sound/magic/charging.ogg'
-
-	cooldown_time = 10 SECONDS
+	projectile_type_arc = /obj/projectile/energy/divineblast/arc
+	overlay_state = "divine_blast"
+	sound = list('sound/magic/vlightning.ogg')
+	active = FALSE
+	releasedrain = 20
+	chargedrain = 1
+	chargetime = 0
+	recharge_time = 5 SECONDS
+	warnie = "spellwarning"
+	no_early_release = TRUE
+	movement_interrupt = FALSE
+	invocations = list("Göttliche Macht")
+	invocation_type = "shout"
+	glow_color = GLOW_COLOR_LIGHTNING
+	glow_intensity = GLOW_INTENSITY_LOW
+	charging_slowdown = 3
+	chargedloop = /datum/looping_sound/invokegen
 	associated_skill = /datum/skill/magic/holy
-	spell_impact_intensity = SPELL_IMPACT_LOW
-	spell_requirements = SPELL_REQUIRES_HUMAN
-	var/next_bonus_time = 0
-	var/current_mode = 1
-	var/list/modes = list(
-		list("name" = "Focus", "tag" = "FOCUS", "proj" = /obj/projectile/energy/divineblast, "invocation" = "Sakral Strahl!"),
-		list("name" = "Arc", "tag" = "ARC", "proj" = /obj/projectile/energy/divineblast/arc, "invocation" = "Sakral Strahl!"),
-	)
+	miracle = TRUE
+	devotion_cost = 25
+	human_req = TRUE
+
+/obj/effect/proc_holder/spell/invoked/projectile/divineblast/cast(list/targets, mob/user = user)
+	projectile_type = arc_mode ? projectile_type_arc : initial(projectile_type)
+	. = ..()
+
 
 /obj/projectile/energy/divineblast
-	name = "divine blast"
-	tracer_type = /obj/effect/projectile/tracer/wormhole
-	muzzle_type = null
-	impact_type = null
-	hitscan = TRUE
-	movement_type = UNSTOPPABLE
-	light_color = LIGHT_COLOR_WHITE
-	damage = 52
-	max_range = MAGE_LONG_PROJ_RANGE
-	damage_type = BURN
-	guard_deflectable = TRUE
-	expose_caster_on_deflect = TRUE
-	speed = 0.3
-	flag = "fire"
-	light_outer_range = 4
-	color = "#00a3d4"
+	name = "Divine Blast"
+	icon_state = "divine_blast"
+	damage = 20 // wont do much to a divine worshipper
+	woundclass = BCLASS_STAB // divine blade!
+	nodamage = FALSE
+	npc_simple_damage_mult = 2 // The Simple Skele Gibber
+	hitsound = 'sound/magic/churn.ogg'
+	speed = 1
 
 /obj/projectile/energy/divineblast/arc
-	name = "arced divine blast"
-	damage = 32
+	name = "Arced Divine Blast"
+	damage = 15 // Slightly lower base damage and barely matter due to low to hit but not a problem on acolyte / cleric.
 	arcshot = TRUE
 
-/obj/projectile/energy/divineblast/on_hit(target, blocked = FALSE)
+/obj/projectile/energy/divineblast/on_hit(target)
 	. = ..()
-	if(ismob(target))
-		var/mob/M = target
-		if(M.anti_magic_check())
-			visible_message(span_warning("[src] dissipates harmlessly against [target]!"))
-			playsound(get_turf(target), 'sound/magic/magic_nulled.ogg', 100)
+	if(isliving(target))
+		var/mob/living/H = target
+		if(H.job in GLOB.church_positions) // TRAIT_CLERGY could work here but is unmaintained and druids, sextons, etc. all lack it.
+			visible_message(span_warning("The divine blast bounces off [H] harmlessly!"))
+			playsound(get_turf(H), 'sound/magic/magic_nulled.ogg', 100)
 			qdel(src)
 			return BULLET_ACT_BLOCK
-		if(isliving(M))
-			var/mob/living/L = M
-			if(out_of_effective_range())
-				qdel(src)
-				return
-			if(blocked < 100)
-				if(HAS_TRAIT(L, TRAIT_SILVER_WEAK) && !L.has_status_effect(STATUS_EFFECT_ANTIMAGIC))
-					L.visible_message("<font color='white'>Divine power rebukes [L]!</font>")
-					L.adjust_fire_stacks(2, /datum/status_effect/fire_handler/fire_stacks/divine)
-					L.ignite_mob()
-				apply_divine_damage(L)
-				var/datum/action/cooldown/spell/projectile/divine_blast/S = source_spell
-				if(S && S.can_apply_god_bonus())
-					apply_god_bonus(L)
-					S.consume_god_bonus()
-	qdel(src)
-
-/datum/action/cooldown/spell/projectile/divine_blast/proc/can_apply_god_bonus()
-	return world.time >= next_bonus_time
-
-/datum/action/cooldown/spell/projectile/divine_blast/proc/consume_god_bonus()
-	next_bonus_time = world.time + 30 SECONDS
-
-/obj/projectile/energy/divineblast/proc/apply_divine_damage(mob/living/L)
-	var/damage_to_do = damage
-	if(L.patron?.type in ALL_INHUMEN_PATRONS)
-		damage_to_do += 30
-	if(L.patron?.type in OLD_GOD_PATRON)
-		damage_to_do += 25
-	if(L.mob_biotypes & MOB_UNDEAD)
-		damage_to_do += 50
-	if(!L.mind)
-		damage_to_do += 50
-	var/mob/living/carbon/human/caster = firer
-	if(L.guard_deflect_spell("Divine Blast", TRUE, caster))
-		return
-	if(istype(caster) && ishuman(L))
-		if(arcyne_strike(caster, L, null, damage_to_do, def_zone, BCLASS_BURN, PEN_MEDIUM, spell_name = "Divine Blast", damage_type = BURN, skip_animation = TRUE) == ARCYNE_STRIKE_WARDED)
+		if(out_of_effective_range())
 			return
+		if(H.mob_biotypes & MOB_UNDEAD)
+			damage += 10
+	if(ishuman(target))
+		var/mob/living/carbon/human/H = target
+		if(istype(H.patron, /datum/patron/divine))
+			if(H in GLOB.excommunicated_players)
+				damage += 20
+		if(istype(H.patron, /datum/patron/inhumen))
+			damage += 20
+		if(istype(H.patron, /datum/patron/old_god))
+			damage += 20
+		if(HAS_TRAIT(H, TRAIT_SILVER_WEAK) && !H.has_status_effect(STATUS_EFFECT_ANTIMAGIC))
+			H.visible_message("<font color='white'>Divine power rebukes [H]!</font>")
+			to_chat(H, span_userdanger("Divine fury rebukes my presence! My body catches aflame!")) //Its NOT a Silver sunder, for balance reasons w/ the buffs. Change this back to sunders when clergy isn't absolutely fucked to fight.
+			H.adjust_fire_stacks(2, /datum/status_effect/fire_handler/fire_stacks/divine)
+			H.ignite_mob()
+		if(H.has_status_effect(/datum/status_effect/debuff/necran_cross))
+			// Undead weakened by a blessed necran cross are more fragile to divine magycks
+			damage += 30
+		var/mob/living/carbon/human/caster
+		if (ishuman(firer))
+			caster = firer
+			switch(caster.patron.type)
+				if(/datum/patron/divine/undivided)
+					damage += 15 // just more raw damage. As mentioned in UNDIVIDED. Our generics are better as a trade off of not having higher tier uniques.
+					H.visible_message(span_warning("Holy light slams into [H] with force!"), span_warning("Holy light slams into me with force!"))
+				if(/datum/patron/divine/astrata)
+					if(istype(H.patron, /datum/patron/inhumen/matthios))
+						H.visible_message(span_warning("[H] is engulfed in flames!"), span_warning("Astrata's <b>hatred</b> sets me aflame!"))
+						H.adjust_fire_stacks(3) //ANCIENT ENEMY I DO NOT FEAR YOU
+						H.ignite_mob()
+					else
+						H.visible_message(span_warning("[H] is engulfed in flames!"), span_warning("Astrata's fury sets me aflame!"))
+						H.adjust_fire_stacks(2) //Remains regular, setting everyone on fire is funnier
+						H.ignite_mob()
+				if(/datum/patron/divine/abyssor)
+					H.visible_message(span_warning("Water seeps from [H]'s lips!"), span_warning("Choking water in my lungs!"))
+					H.Dizzy(5)
+					H.emote("drown")
+				if(/datum/patron/divine/dendor)
+					H.Slowdown(2) // Shared with Ravox cuz immobilize + offbal is 2 strong
+					H.visible_message(span_warning("Roots coil around [H]'s legs!"), span_warning("Roots tangle around my legs!"))
+				if(/datum/patron/divine/necra)
+					if((H.mob_biotypes & MOB_UNDEAD) || HAS_TRAIT(H, TRAIT_DEATHLESS)) //DEATH TO THE DEATHLESS, NECRA HATES YOU.
+						H.adjust_fire_stacks(4, /datum/status_effect/fire_handler/fire_stacks/divine)
+						H.ignite_mob()
+						H.visible_message(span_warning("[H] is rebuked by Divine Scorn!"), span_warning("The Undermaiden's <b>scornful</b> gaze rebukes me!"))
+				if(/datum/patron/divine/pestra)
+					H.vomit(stun = 0)
+					H.adjustToxLoss(10)
+					H.visible_message(span_warning("[H] expels some leeches out of them!"), span_warning("Something roils within me!"))
+					new /obj/item/natural/worms/leech(get_turf(H))
+				if(/datum/patron/divine/eora)
+					H.blur_eyes(10)
+				if(/datum/patron/divine/noc)
+					H.visible_message(span_warning("Moonlight engulfs [H]"), span_warning("Moonlight engulfs me!"))
+					for(var/obj/O in range(0, H))
+						O.extinguish()
+					for(var/mob/M in range(0, H)) // extinguish lights of target(zizo snuff pretty much but range 0 always)
+						for(var/obj/O in M.contents)
+							O.extinguish()
+				if(/datum/patron/divine/ravox)
+					H.Slowdown(2)
+					H.visible_message(span_warning("Divine chains briefly coil around [H]'s legs!"), span_warning("Divine chains briefly shackle around my legs!"))
+				if(/datum/patron/divine/malum)
+					H.adjustBruteLoss(10) //Think of it like hammering into you, it was straight direct armor-peircing burn damage before and could crit you insanely fast
+					H.visible_message(span_warning("[H] is hammered with divine force!"), span_warning("Malum's disappointment hammers into me!"))
+					//He's not mad, he's not proud, he's not hateful, he's as neutrally disappointed in you as one can be. (Its also funnier this way)
 	else
-		L.apply_damage(damage_to_do, BURN)
-
-/obj/projectile/energy/divineblast/proc/apply_god_bonus(mob/living/L)
-	var/mob/living/carbon/human/caster = firer
-	if(!istype(caster))
 		return
-
-	switch(caster.patron?.type)
-		if(/datum/patron/divine/undivided)
-			L.adjust_fire_stacks(4, /datum/status_effect/fire_handler/fire_stacks/divine)
-			L.ignite_mob()
-			L.apply_status_effect(/datum/status_effect/debuff/exposed, 3 SECONDS)
-		if(/datum/patron/divine/astrata)
-			L.adjust_fire_stacks(4, /datum/status_effect/fire_handler/fire_stacks/divine)
-			L.ignite_mob()
-			L.apply_status_effect(/datum/status_effect/debuff/exposed, 3 SECONDS)
-		if(/datum/patron/divine/noc)
-			L.adjust_fire_stacks(4, /datum/status_effect/fire_handler/fire_stacks/divine)
-			L.ignite_mob()
-			L.apply_status_effect(/datum/status_effect/debuff/exposed, 3 SECONDS)
-		if(/datum/patron/divine/dendor)
-			L.adjust_fire_stacks(4, /datum/status_effect/fire_handler/fire_stacks/divine)
-			L.ignite_mob()
-			L.apply_status_effect(/datum/status_effect/debuff/exposed, 3 SECONDS)
-		if(/datum/patron/divine/abyssor)
-			L.adjust_fire_stacks(4, /datum/status_effect/fire_handler/fire_stacks/divine)
-			L.ignite_mob()
-			L.apply_status_effect(/datum/status_effect/debuff/exposed, 3 SECONDS)
-		if(/datum/patron/divine/ravox)
-			L.adjust_fire_stacks(4, /datum/status_effect/fire_handler/fire_stacks/divine)
-			L.ignite_mob()
-			L.apply_status_effect(/datum/status_effect/debuff/exposed, 3 SECONDS)
-		if(/datum/patron/divine/necra)
-			L.adjust_fire_stacks(4, /datum/status_effect/fire_handler/fire_stacks/divine)
-			L.ignite_mob()
-			L.apply_status_effect(/datum/status_effect/debuff/exposed, 3 SECONDS)
-		if(/datum/patron/divine/xylix)
-			L.adjust_fire_stacks(4, /datum/status_effect/fire_handler/fire_stacks/divine)
-			L.ignite_mob()
-			L.apply_status_effect(/datum/status_effect/debuff/exposed, 3 SECONDS)
-		if(/datum/patron/divine/pestra)
-			L.adjust_fire_stacks(4, /datum/status_effect/fire_handler/fire_stacks/divine)
-			L.ignite_mob()
-			L.apply_status_effect(/datum/status_effect/debuff/exposed, 3 SECONDS)
-		if(/datum/patron/divine/malum)
-			L.adjust_fire_stacks(4, /datum/status_effect/fire_handler/fire_stacks/divine)
-			L.ignite_mob()
-			L.apply_status_effect(/datum/status_effect/debuff/exposed, 3 SECONDS)
-		if(/datum/patron/divine/eora)
-			L.adjust_fire_stacks(4, /datum/status_effect/fire_handler/fire_stacks/divine)
-			L.ignite_mob()
-			L.apply_status_effect(/datum/status_effect/debuff/exposed, 3 SECONDS)
-
-/datum/action/cooldown/spell/projectile/divine_blast/Grant(mob/grant_to)
-	. = ..()
-	apply_mode(current_mode)
-
-/datum/action/cooldown/spell/projectile/divine_blast/proc/apply_mode(index)
-	var/list/mode = modes[index]
-	projectile_type = mode["proj"]
-	invocations = list(mode["invocation"])
-	update_mode_maptext(mode["tag"])
-
-/datum/action/cooldown/spell/projectile/divine_blast/toggle_arc_mode(mob/user)
-	current_mode = (current_mode % length(modes)) + 1
-	apply_mode(current_mode)
-	to_chat(user, span_notice("[name]: [modes[current_mode]["name"]] mode."))
-
-/datum/action/cooldown/spell/projectile/divine_blast/proc/update_mode_maptext(tag)
-	for(var/datum/hud/hud as anything in viewers)
-		var/atom/movable/screen/movable/action_button/B = viewers[hud]
-		var/atom/movable/screen/arc_maptext_holder/holder
-		for(var/atom/movable/screen/arc_maptext_holder/existing in B.vis_contents)
-			holder = existing
-			break
-		if(!holder)
-			holder = new(B)
-			B.vis_contents.Add(holder)
-		holder.maptext = MAPTEXT(tag)
-		holder.color = "#00ccff"
-
-/datum/action/cooldown/spell/projectile/divine_blast/get_spell_statistics(mob/living/user)
-	var/list/stats = ..()
-	stats += span_info("Firing mode (Shift+G): Focus (standard blast) / Arc (lobs over obstacles with reduced damage).")
-	return stats

--- a/code/modules/spells/spell_types/divine/projectiles_single/unholy_blast.dm
+++ b/code/modules/spells/spell_types/divine/projectiles_single/unholy_blast.dm
@@ -1,163 +1,122 @@
-/datum/action/cooldown/spell/projectile/unholy_blast
-	background_icon = 'icons/mob/actions/genericmiracles.dmi'
-	button_icon = 'icons/mob/actions/genericmiracles.dmi'
-	button_icon_state = "ublast"
-	name = "Profane Blast"
-	desc = "Release a blast of sheer divine energy at your enemies. Deals more damage to conformists, undead, and simple-minded creatures. Toggle firing mode (Shift+G): Focus or Arc."
-	fluff_desc = "Among the first miracles bestowed upon the faithful is the ability to channel their patron's essence into a focused blast of divine power. Though simple in execution, it is a versatile expression of a deity's will, carrying forth a fragment of the patron's true nature."
-	sound = 'sound/magic/vlightning.ogg'
-	spell_color = GLOW_COLOR_LIGHTNING
-	glow_intensity = GLOW_INTENSITY_LOW
+/obj/effect/proc_holder/spell/invoked/projectile/unholyblast // this CANNOT be a child of divine_blast bc you have to call parent on cast.
+	name = "Unholy Blast"
+	desc = "Channel unholy power and sunder the unbelievers. Deals additional damage to wretched conformists and Psydonites! \n\
+	Damage is increased by 100% versus simple-minded creechurs.\n\
+	Toggle arc mode (Shift+G) while the spell is active to fire it over intervening mobs. Arced attacks deal 25% less damage."
+	clothes_req = FALSE
+	range = 12
+	overlay_state = "unholy_blast"
 	projectile_type = /obj/projectile/energy/unholyblast
-	cast_range = SPELL_RANGE_PROJECTILE
-
-	primary_resource_type = SPELL_COST_DEVOTION
-	primary_resource_cost = 25
-	invocation_type = INVOCATION_SHOUT
-	charge_required = TRUE
-	charge_time = CHARGETIME_MAJOR
-	hold_drain = 1
-	charge_slowdown = CHARGING_SLOWDOWN_SMALL
-	charge_swingdelay_type = SWINGDELAY_PENALTY
-	charge_sound = 'sound/magic/charging.ogg'
-
-	cooldown_time = 10 SECONDS
+	projectile_type_arc = /obj/projectile/energy/unholyblast/arc
+	sound = list('sound/magic/vlightning.ogg')
+	active = FALSE
+	releasedrain = 20
+	chargedrain = 1
+	chargetime = 0
+	recharge_time = 5 SECONDS
+	warnie = "spellwarning"
+	no_early_release = TRUE
+	movement_interrupt = FALSE
+	invocations = list("Dunkle macht")
+	invocation_type = "shout"
+	glow_color = GLOW_COLOR_LIGHTNING
+	glow_intensity = GLOW_INTENSITY_LOW
+	charging_slowdown = 3
+	chargedloop = /datum/looping_sound/invokegen
 	associated_skill = /datum/skill/magic/holy
-	spell_impact_intensity = SPELL_IMPACT_LOW
-	spell_requirements = SPELL_REQUIRES_HUMAN
-	var/next_bonus_time = 0
-	var/current_mode = 1
-	var/list/modes = list(
-		list("name" = "Focus", "tag" = "FOCUS", "proj" = /obj/projectile/energy/unholyblast, "invocation" = "Larkas Strahl!"),
-		list("name" = "Arc", "tag" = "ARC", "proj" = /obj/projectile/energy/unholyblast/arc, "invocation" = "Larkas Strahl!"),
-	)
+	miracle = TRUE
+	devotion_cost = 25
+	human_req = TRUE
+
 
 /obj/projectile/energy/unholyblast
-	name = "unholy blast"
-	tracer_type = /obj/effect/projectile/tracer/wormhole
-	muzzle_type = null
-	impact_type = null
-	hitscan = TRUE
-	movement_type = UNSTOPPABLE
-	light_color = LIGHT_COLOR_WHITE
-	damage = 52
-	max_range = MAGE_LONG_PROJ_RANGE
-	damage_type = BURN
-	guard_deflectable = TRUE
-	expose_caster_on_deflect = TRUE
-	speed = 0.3
-	flag = "fire"
-	light_outer_range = 4
-	color = "#810000"
+	name = "Unholy Blast"
+	icon_state = "unholy_blast"
+	damage = 20 // wont do much to a heretical worshipper
+	woundclass = BCLASS_CUT // I REALLY wanted to do cut
+	nodamage = FALSE
+	npc_simple_damage_mult = 2 // The Simple Skele Gibber
+	hitsound = 'sound/magic/soulsteal.ogg' // its kinda quiet BUT its cool
+	speed = 1
 
 /obj/projectile/energy/unholyblast/arc
-	name = "arced unholy blast"
-	damage = 32
+	name = "Arced Unholy Blast"
+	damage = 15 // Slightly lower base damage
 	arcshot = TRUE
 
-/obj/projectile/energy/unholyblast/on_hit(target, blocked = FALSE)
+/obj/effect/proc_holder/spell/invoked/projectile/unholyblast/cast(list/targets, mob/user = user)
+	projectile_type = arc_mode ? projectile_type_arc : initial(projectile_type)
 	. = ..()
-	if(ismob(target))
-		var/mob/M = target
-		if(M.anti_magic_check())
-			visible_message(span_warning("[src] dissipates harmlessly against [target]!"))
-			playsound(get_turf(target), 'sound/magic/magic_nulled.ogg', 100)
-			qdel(src)
-			return BULLET_ACT_BLOCK
-		if(isliving(M))
-			var/mob/living/L = M
-			if(out_of_effective_range())
-				qdel(src)
-				return
-			if(blocked < 100)
-				if(HAS_TRAIT(L, TRAIT_SILVER_WEAK) && !L.has_status_effect(STATUS_EFFECT_ANTIMAGIC))
-					L.visible_message("<font color='white'>Divine power staggers [L]!</font>")
-					L.Immobilize(3 SECONDS)
-					L.apply_status_effect(/datum/status_effect/debuff/clickcd, 3 SECONDS)
-				apply_divine_damage(L)
-				var/datum/action/cooldown/spell/projectile/unholy_blast/S = source_spell
-				if(S && S.can_apply_god_bonus())
-					apply_god_bonus(L)
-					S.consume_god_bonus()
-	qdel(src)
 
-/datum/action/cooldown/spell/projectile/unholy_blast/proc/can_apply_god_bonus()
-	return world.time >= next_bonus_time
 
-/datum/action/cooldown/spell/projectile/unholy_blast/proc/consume_god_bonus()
-	next_bonus_time = world.time + 30 SECONDS
-
-/obj/projectile/energy/unholyblast/proc/apply_divine_damage(mob/living/L)
-	var/damage_to_do = damage
-	if(L.patron?.type in ALL_DIVINE_PATRONS)
-		damage_to_do += 30
-	if(L.patron?.type in OLD_GOD_PATRON)
-		damage_to_do += 25
-	if(L.mob_biotypes & MOB_UNDEAD)
-		damage_to_do += 50
-	if(!L.mind)
-		damage_to_do += 50
-	var/mob/living/carbon/human/caster = firer
-	if(L.guard_deflect_spell("Unholy Blast", TRUE, caster))
-		return
-	if(istype(caster) && ishuman(L))
-		if(arcyne_strike(caster, L, null, damage_to_do, def_zone, BCLASS_BURN, PEN_MEDIUM, spell_name = "Divine Blast", damage_type = BURN, skip_animation = TRUE) == ARCYNE_STRIKE_WARDED)
+/obj/projectile/energy/unholyblast/on_hit(target)
+	if(isliving(target))
+		var/mob/living/H = target
+		if(out_of_effective_range())
 			return
+		if(H.mob_biotypes & MOB_UNDEAD)
+			damage += 20
+	if(ishuman(target))
+		var/mob/living/carbon/human/H = target
+		if(istype(H.patron, /datum/patron/divine))
+			damage += 20
+		if(istype(H.patron, /datum/patron/old_god))
+			damage += 20
+		var/mob/living/carbon/human/caster
+		if (ishuman(firer))
+			caster = firer
+			switch(caster.patron.type)
+				if(/datum/patron/inhumen/baotha)
+					H.adjustToxLoss(10)
+					H.Dizzy(5)
+					H.visible_message(span_warning("[H] looks unwell..."), span_warning("I feel dizzy... and I've been poisoned!"))
+					if(HAS_TRAIT(H, TRAIT_SILVER_WEAK) && !H.has_status_effect(STATUS_EFFECT_ANTIMAGIC))
+						H.visible_message("<font color='white'>Unholy power rebukes [H]!</font>")
+						to_chat(H, span_userdanger("Unholy wrath rebukes my presence! My body catches aflame!"))
+						H.adjust_fire_stacks(2, /datum/status_effect/fire_handler/fire_stacks/divine)
+						H.ignite_mob()
+				if(/datum/patron/inhumen/matthios)
+					if(HAS_TRAIT(H, TRAIT_NOBLE))
+						damage += 10
+						H.adjust_fire_stacks(4) //ditto to Astrata
+						H.visible_message(span_warning("[H]'s blue blood burns bright!"), span_warning("My body burns-- my blood is being transacted into fire!"))
+					else
+						H.visible_message(span_warning("[H] is set aflame with gilded flames!"), span_warning("Gilded flame engulfs me!"))
+					H.adjust_fire_stacks(2)
+					H.ignite_mob()
+					if(HAS_TRAIT(H, TRAIT_SILVER_WEAK) && !H.has_status_effect(STATUS_EFFECT_ANTIMAGIC))
+						H.visible_message("<font color='white'>Unholy power rebukes [H]!</font>")
+						to_chat(H, span_userdanger("Unholy wrath rebukes my presence! My body catches aflame!"))
+						H.adjust_fire_stacks(2, /datum/status_effect/fire_handler/fire_stacks/divine)
+						H.ignite_mob()
+				if(/datum/patron/inhumen/graggar)
+					H.visible_message(span_warning("A splatter of blood covers [H]'s face!"), span_warning("A glob of blood splatters my vision!"))
+					H.Dizzy(5)
+					H.blur_eyes(5)
+					if(HAS_TRAIT(H, TRAIT_SILVER_WEAK) && !H.has_status_effect(STATUS_EFFECT_ANTIMAGIC))
+						H.visible_message("<font color='white'>Unholy power rebukes [H]!</font>")
+						to_chat(H, span_userdanger("Unholy wrath rebukes my presence! My body catches aflame!"))
+						H.adjust_fire_stacks(2, /datum/status_effect/fire_handler/fire_stacks/divine)
+						H.ignite_mob()
+						H.Slowdown(4) //Suffer
+				if(/datum/patron/inhumen/zizo)
+					if(istype(H.patron, /datum/patron/divine/necra)) //Hilarious, always hit with full regardless of silver weak
+						H.adjust_fire_stacks(6, /datum/status_effect/fire_handler/fire_stacks/divine)
+						H.ignite_mob()
+						H.visible_message(span_warning("[H] is smited by unholy spite!"), span_warning("Zizo's seething <b>hatred</b> smites me!"))
+						H.Slowdown(3)
+					if(!HAS_TRAIT(H, TRAIT_SILVER_WEAK) && !HAS_TRAIT(H, TRAIT_LYCANRESILENCE) && !istype(H.patron, /datum/patron/divine/necra)) //We churn you for NOT being silver weak. ZIZO. ZIZO. ZIZO.
+						H.adjust_fire_stacks(3, /datum/status_effect/fire_handler/fire_stacks/divine)
+						H.ignite_mob()
+						H.visible_message(span_warning("Seething ambition sears [H]'s flesh aflame!"), span_warning("Visions of progress and ambition sears my flesh, mynd and sets me aflame!"))
+						H.Slowdown(3)
+					if(HAS_TRAIT(H, TRAIT_LYCANRESILENCE) && !istype(H.patron, /datum/patron/divine/necra)) //EXCEPT WEREWOLVES... Fuck Dendor. Specifically within werebeast form, hense the trait, not the antag check.
+						H.adjust_fire_stacks(4, /datum/status_effect/fire_handler/fire_stacks/divine) //Less cause this is an actual antag, UNLESS they worship Necra in which case you kind of deserve this.
+						H.ignite_mob()
+						H.visible_message(span_warning("[H] is churned by unholy spite!"), span_warning("Zizo's seething <b>hatred</b> rebukes me!"))
+						H.Slowdown(3)
+					if(HAS_TRAIT(H, TRAIT_SILVER_WEAK) && !HAS_TRAIT(H, TRAIT_LYCANRESILENCE) && !istype(H.patron, /datum/patron/divine/necra))
+						H.visible_message(span_warning("Unholy spite slams into [H]!"), span_warning("Unholy spite slams into me!"))
+						H.Slowdown(2) //Less severe slowdown
 	else
-		L.apply_damage(damage_to_do, BURN)
-
-/obj/projectile/energy/unholyblast/proc/apply_god_bonus(mob/living/L)
-	var/mob/living/carbon/human/caster = firer
-	if(!istype(caster))
 		return
-
-	switch(caster.patron?.type)
-		if(/datum/patron/inhumen/zizo)
-			L.adjust_fire_stacks(4, /datum/status_effect/fire_handler/fire_stacks/divine)
-			L.ignite_mob()
-			L.apply_status_effect(/datum/status_effect/debuff/exposed, 3 SECONDS)
-		if(/datum/patron/inhumen/graggar)
-			L.adjust_fire_stacks(4, /datum/status_effect/fire_handler/fire_stacks/divine)
-			L.ignite_mob()
-			L.apply_status_effect(/datum/status_effect/debuff/exposed, 3 SECONDS)
-		if(/datum/patron/inhumen/matthios)
-			L.adjust_fire_stacks(4, /datum/status_effect/fire_handler/fire_stacks/divine)
-			L.ignite_mob()
-			L.apply_status_effect(/datum/status_effect/debuff/exposed, 3 SECONDS)
-		if(/datum/patron/inhumen/baotha)
-			L.adjust_fire_stacks(4, /datum/status_effect/fire_handler/fire_stacks/divine)
-			L.ignite_mob()
-			L.apply_status_effect(/datum/status_effect/debuff/exposed, 3 SECONDS)
-
-/datum/action/cooldown/spell/projectile/unholy_blast/Grant(mob/grant_to)
-	. = ..()
-	apply_mode(current_mode)
-
-/datum/action/cooldown/spell/projectile/unholy_blast/proc/apply_mode(index)
-	var/list/mode = modes[index]
-	projectile_type = mode["proj"]
-	invocations = list(mode["invocation"])
-	update_mode_maptext(mode["tag"])
-
-/datum/action/cooldown/spell/projectile/unholy_blast/toggle_arc_mode(mob/user)
-	current_mode = (current_mode % length(modes)) + 1
-	apply_mode(current_mode)
-	to_chat(user, span_notice("[name]: [modes[current_mode]["name"]] mode."))
-
-/datum/action/cooldown/spell/projectile/unholy_blast/proc/update_mode_maptext(tag)
-	for(var/datum/hud/hud as anything in viewers)
-		var/atom/movable/screen/movable/action_button/B = viewers[hud]
-		var/atom/movable/screen/arc_maptext_holder/holder
-		for(var/atom/movable/screen/arc_maptext_holder/existing in B.vis_contents)
-			holder = existing
-			break
-		if(!holder)
-			holder = new(B)
-			B.vis_contents.Add(holder)
-		holder.maptext = MAPTEXT(tag)
-		holder.color = "#00ccff"
-
-/datum/action/cooldown/spell/projectile/unholy_blast/get_spell_statistics(mob/living/user)
-	var/list/stats = ..()
-	stats += span_info("Firing mode (Shift+G): Focus (standard blast) / Arc (lobs over obstacles with reduced damage).")
-	return stats

--- a/code/modules/spells/spell_types/divine/projectiles_single/unholy_blast.dm
+++ b/code/modules/spells/spell_types/divine/projectiles_single/unholy_blast.dm
@@ -15,7 +15,7 @@
 	charge_required = TRUE
 	charge_time = 0
 	hold_drain = 1
-	cooldown_time = 5 SECONDS
+	cooldown_time = 8 SECONDS
 	invocations = list("Larkas Strahl!")
 	invocation_type = INVOCATION_SHOUT
 	spell_color = GLOW_COLOR_LIGHTNING
@@ -30,7 +30,7 @@
 /obj/projectile/energy/unholyblast
 	name = "Unholy Blast"
 	icon_state = "unholy_blast"
-	damage = 20 // wont do much to a heretical worshipper
+	damage = 30 // wont do much to a heretical worshipper
 	woundclass = BCLASS_CUT // I REALLY wanted to do cut
 	nodamage = FALSE
 	npc_simple_damage_mult = 2 // The Simple Skele Gibber
@@ -39,7 +39,7 @@
 
 /obj/projectile/energy/unholyblast/arc
 	name = "Arced Unholy Blast"
-	damage = 15 // Slightly lower base damage
+	damage = 25 // Slightly lower base damage
 	arcshot = TRUE
 
 /obj/projectile/energy/unholyblast/on_hit(target)
@@ -59,29 +59,28 @@
 		if (ishuman(firer))
 			caster = firer
 			switch(caster.patron.type)
-				if(/datum/patron/inhumen/baotha)
-					H.adjustToxLoss(10)
-					H.Dizzy(5)
-					H.visible_message(span_warning("[H] looks unwell..."), span_warning("I feel dizzy... and I've been poisoned!"))
+				if(/datum/patron/inhumen/baotha) //increased dmg based off of how stressed the enemy gamer is
+					damage += max(H.get_stress_amount(), 0) * 3
+					H.visible_message(span_warning("[H] looks numb..."), span_warning("My heart aches with melancholy."))
 					if(HAS_TRAIT(H, TRAIT_SILVER_WEAK) && !H.has_status_effect(STATUS_EFFECT_ANTIMAGIC))
 						H.visible_message("<font color='white'>Unholy power rebukes [H]!</font>")
 						to_chat(H, span_userdanger("Unholy wrath rebukes my presence! My body catches aflame!"))
 						H.adjust_fire_stacks(2, /datum/status_effect/fire_handler/fire_stacks/divine)
 						H.ignite_mob()
-				if(/datum/patron/inhumen/matthios) //pseudo-churn - +10 dmg and +2 fire stacks per every 100 gold the person is carrying
+				if(/datum/patron/inhumen/matthios) //pseudo-churn - +5 dmg and +1 fire stacks per every 100 gold the person is carrying
 					var/mammons = get_mammons_in_atom(H)
-					damage += round(mammons / 10)
+					damage += round(mammons / 20)
 					H.visible_message(span_warning("[H] is set aflame with gilded flames!"), span_warning("Gilded flame engulfs me!"))
-					H.adjust_fire_stacks(2 + (floor(mammons / 100) * 2))
+					H.adjust_fire_stacks(2 + (floor(mammons / 100) * 1))
 					H.ignite_mob()
 					if(HAS_TRAIT(H, TRAIT_SILVER_WEAK) && !H.has_status_effect(STATUS_EFFECT_ANTIMAGIC))
 						H.visible_message("<font color='white'>Unholy power rebukes [H]!</font>")
 						to_chat(H, span_userdanger("Unholy wrath rebukes my presence! My body catches aflame!"))
 						H.adjust_fire_stacks(2, /datum/status_effect/fire_handler/fire_stacks/divine)
 						H.ignite_mob()
-				if(/datum/patron/inhumen/graggar)
+				if(/datum/patron/inhumen/graggar) //flat extra dmg, blurry vision
+					damage += 10
 					H.visible_message(span_warning("A splatter of blood covers [H]'s face!"), span_warning("A glob of blood splatters my vision!"))
-					H.Dizzy(5)
 					H.blur_eyes(5)
 					if(HAS_TRAIT(H, TRAIT_SILVER_WEAK) && !H.has_status_effect(STATUS_EFFECT_ANTIMAGIC))
 						H.visible_message("<font color='white'>Unholy power rebukes [H]!</font>")
@@ -89,7 +88,7 @@
 						H.adjust_fire_stacks(2, /datum/status_effect/fire_handler/fire_stacks/divine)
 						H.ignite_mob()
 						H.Slowdown(4) //Suffer
-				if(/datum/patron/inhumen/zizo)
+				if(/datum/patron/inhumen/zizo) //not really sure what the thematic here
 					if(istype(H.patron, /datum/patron/divine/necra)) //Hilarious, always hit with full regardless of silver weak
 						H.adjust_fire_stacks(6, /datum/status_effect/fire_handler/fire_stacks/divine)
 						H.ignite_mob()

--- a/code/modules/spells/spell_types/divine/projectiles_single/unholy_blast.dm
+++ b/code/modules/spells/spell_types/divine/projectiles_single/unholy_blast.dm
@@ -2,7 +2,7 @@
 	name = "Unholy Blast"
 	desc = "Channel unholy power and sunder the unbelievers. Deals additional damage to wretched conformists and Psydonites. \n\
 	Damage is increased by 100% versus simple-minded creechurs.\n\
-	Toggle arc mode (Shift+G) while the spell is active to fire it over intervening mobs. Arced attacks deal 25% less damage."
+	Toggle arc mode (Shift+G) while the spell is active to fire it over intervening mobs. Arced attacks deal less damage."
 	button_icon_state = "unholy_blast"
 	cast_range = 12
 	projectile_type = /obj/projectile/energy/unholyblast
@@ -30,7 +30,7 @@
 /obj/projectile/energy/unholyblast
 	name = "Unholy Blast"
 	icon_state = "unholy_blast"
-	damage = 30 // wont do much to a heretical worshipper
+	damage = 30
 	woundclass = BCLASS_CUT // I REALLY wanted to do cut
 	nodamage = FALSE
 	npc_simple_damage_mult = 2 // The Simple Skele Gibber
@@ -39,7 +39,7 @@
 
 /obj/projectile/energy/unholyblast/arc
 	name = "Arced Unholy Blast"
-	damage = 25 // Slightly lower base damage
+	damage = 26 // Slightly lower base damage
 	arcshot = TRUE
 
 /obj/projectile/energy/unholyblast/on_hit(target)
@@ -48,13 +48,13 @@
 		if(out_of_effective_range())
 			return
 		if(H.mob_biotypes & MOB_UNDEAD)
-			damage += 20
+			damage += 10
 	if(ishuman(target))
 		var/mob/living/carbon/human/H = target
 		if(istype(H.patron, /datum/patron/divine))
-			damage += 20
+			damage += 10
 		if(istype(H.patron, /datum/patron/old_god))
-			damage += 20
+			damage += 10
 		var/mob/living/carbon/human/caster
 		if (ishuman(firer))
 			caster = firer

--- a/code/modules/spells/spell_types/divine/projectiles_single/unholy_blast.dm
+++ b/code/modules/spells/spell_types/divine/projectiles_single/unholy_blast.dm
@@ -1,32 +1,29 @@
-/obj/effect/proc_holder/spell/invoked/projectile/unholyblast // this CANNOT be a child of divine_blast bc you have to call parent on cast.
+/datum/action/cooldown/spell/projectile/unholy_blast
 	name = "Unholy Blast"
-	desc = "Channel unholy power and sunder the unbelievers. Deals additional damage to wretched conformists and Psydonites! \n\
+	desc = "Channel unholy power and sunder the unbelievers. Deals additional damage to wretched conformists and Psydonites. \n\
 	Damage is increased by 100% versus simple-minded creechurs.\n\
 	Toggle arc mode (Shift+G) while the spell is active to fire it over intervening mobs. Arced attacks deal 25% less damage."
-	clothes_req = FALSE
-	range = 12
-	overlay_state = "unholy_blast"
+	button_icon_state = "unholy_blast"
+	cast_range = 12
 	projectile_type = /obj/projectile/energy/unholyblast
 	projectile_type_arc = /obj/projectile/energy/unholyblast/arc
-	sound = list('sound/magic/vlightning.ogg')
-	active = FALSE
-	releasedrain = 20
-	chargedrain = 1
-	chargetime = 0
-	recharge_time = 5 SECONDS
-	warnie = "spellwarning"
-	no_early_release = TRUE
-	movement_interrupt = FALSE
-	invocations = list("Dunkle macht")
-	invocation_type = "shout"
-	glow_color = GLOW_COLOR_LIGHTNING
+	sound = 'sound/magic/vlightning.ogg'
+	primary_resource_type = SPELL_COST_DEVOTION
+	primary_resource_cost = 25
+	secondary_resource_type = SPELL_COST_STAMINA
+	secondary_resource_cost = 20
+	charge_required = TRUE
+	charge_time = 0
+	hold_drain = 1
+	cooldown_time = 5 SECONDS
+	invocations = list("Larkas Strahl!")
+	invocation_type = INVOCATION_SHOUT
+	spell_color = GLOW_COLOR_LIGHTNING
 	glow_intensity = GLOW_INTENSITY_LOW
-	charging_slowdown = 3
-	chargedloop = /datum/looping_sound/invokegen
+	charge_slowdown = 3
 	associated_skill = /datum/skill/magic/holy
-	miracle = TRUE
 	devotion_cost = 25
-	human_req = TRUE
+	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC | SPELL_REQUIRES_HUMAN
 
 
 /obj/projectile/energy/unholyblast
@@ -43,11 +40,6 @@
 	name = "Arced Unholy Blast"
 	damage = 15 // Slightly lower base damage
 	arcshot = TRUE
-
-/obj/effect/proc_holder/spell/invoked/projectile/unholyblast/cast(list/targets, mob/user = user)
-	projectile_type = arc_mode ? projectile_type_arc : initial(projectile_type)
-	. = ..()
-
 
 /obj/projectile/energy/unholyblast/on_hit(target)
 	if(isliving(target))

--- a/code/modules/spells/spell_types/divine/projectiles_single/unholy_blast.dm
+++ b/code/modules/spells/spell_types/divine/projectiles_single/unholy_blast.dm
@@ -22,6 +22,7 @@
 	glow_intensity = GLOW_INTENSITY_LOW
 	charge_slowdown = 3
 	associated_skill = /datum/skill/magic/holy
+	primary_resource_type = SPELL_COST_DEVOTION
 	devotion_cost = 25
 	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC | SPELL_REQUIRES_HUMAN
 
@@ -67,14 +68,11 @@
 						to_chat(H, span_userdanger("Unholy wrath rebukes my presence! My body catches aflame!"))
 						H.adjust_fire_stacks(2, /datum/status_effect/fire_handler/fire_stacks/divine)
 						H.ignite_mob()
-				if(/datum/patron/inhumen/matthios)
-					if(HAS_TRAIT(H, TRAIT_NOBLE))
-						damage += 10
-						H.adjust_fire_stacks(4) //ditto to Astrata
-						H.visible_message(span_warning("[H]'s blue blood burns bright!"), span_warning("My body burns-- my blood is being transacted into fire!"))
-					else
-						H.visible_message(span_warning("[H] is set aflame with gilded flames!"), span_warning("Gilded flame engulfs me!"))
-					H.adjust_fire_stacks(2)
+				if(/datum/patron/inhumen/matthios) //pseudo-churn - +10 dmg and +2 fire stacks per every 100 gold the person is carrying
+					var/mammons = get_mammons_in_atom(H)
+					damage += round(mammons / 10)
+					H.visible_message(span_warning("[H] is set aflame with gilded flames!"), span_warning("Gilded flame engulfs me!"))
+					H.adjust_fire_stacks(2 + (floor(mammons / 100) * 2))
 					H.ignite_mob()
 					if(HAS_TRAIT(H, TRAIT_SILVER_WEAK) && !H.has_status_effect(STATUS_EFFECT_ANTIMAGIC))
 						H.visible_message("<font color='white'>Unholy power rebukes [H]!</font>")


### PR DESCRIPTION
## About The Pull Request

semi reverts divine/unholy blast to behave like it did previous to https://github.com/Azure-Peak/Azure-Peak/pull/8339. it's really unhealthy for the game in its current state

also changes the behavior of the blasts! Overall damage is up. We removed Dizzy entirely since it's super buggy, and certain ones have been changed

Astrata does extra fire stacks on matthiosans but refuses to let you burn nobles
Abyssor does direct oxy dmg
Baotha does extra dmg depending on your stress
Graggar just does a flat extra amt of dmg
Matthios has a mini-churn but no longer does extra dmg to nobles



## Testing Evidence

<img width="376" height="45" alt="image" src="https://github.com/user-attachments/assets/6539631b-cd9b-4695-821b-1601572a20ec" />


## Why It's Good For The Game

well i think quite literally everyone agrees it's in a bad state. more presciently; you actually _can not_ fight anyone with current divine blast if you are a holy or magic caster, due to the fact that by the time vuln is cleared and your cast-timer is back up, they are charging divine blast again

not that it's any easier for melee ppl. 52 damage hitscan with full expose and clickcd holy shittttt

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: reverts divine blast to previous behavior
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
