### PR TITLE
[Bugfix] Safety check to revert late stage item giving if unsuccessful

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -2778,8 +2778,17 @@ GLOBAL_LIST_INIT(sight_trait_signals, build_sight_trait_signals())
 	return TRUE
 
 /mob/living/proc/accept_offered_item(mob/living/offerer, obj/offered_item, stealthy)
-	transferItemToLoc(offered_item, src)
+	transferItemToLoc(offered_item, src.loc)
 	put_in_active_hand(offered_item)
+
+	// Safety check
+	if(!offered_item || offered_item.loc != src)
+		transferItemToLoc(offered_item, offerer.loc, TRUE)
+		offerer.put_in_active_hand(offered_item)
+		to_chat(src, span_warning("I couldn't accept the item! I let go!"))
+		offerer.stop_offering_item()
+		return FALSE
+
 	if(stealthy)
 		to_chat(offerer, span_notice("[src] takes the secretly offered [offered_item]."))
 		to_chat(src, span_notice("I take the secretly offered [offered_item] from [offerer]."))
@@ -2793,6 +2802,7 @@ GLOBAL_LIST_INIT(sight_trait_signals, build_sight_trait_signals())
 		)
 	SEND_SIGNAL(offered_item, COMSIG_OBJ_HANDED_OVER, src, offerer)
 	offerer.stop_offering_item()
+	return TRUE
 
 /// Marks a freshly-spawned mob as belonging to a contract/quest: strips its head bounty so it
 /// can't be farmed at a HEADEATER, and arranges for the corpse to dust shortly after death.


### PR DESCRIPTION
## About The Pull Request
fixes #8802 
Previously, items that couldn't be placed in hand were STUCK in your BODY. Not sure how having a silver knife embedded in between your skin wasn't turning you into a headline, but here we are.

## Testing Evidence
<img width="1615" height="934" alt="image" src="https://github.com/user-attachments/assets/c83b6310-3ac1-4686-bdb6-30f189299e7d" />


## Why It's Good For The Game
bugfix

## Changelog

:cl:
fix: reverts item giving if an item can't be transferred successfully
/:cl:


