### PR TITLE
[Bugfix] Bunfix

### DIFF
--- a/code/modules/roguetown/roguejobs/gravedigger/tools.dm
+++ b/code/modules/roguetown/roguejobs/gravedigger/tools.dm
@@ -176,12 +176,15 @@
 						if(D.holie && D.holie.stage < 4)
 							D.holie.attackby(src, user)
 						else
-							if(istype(T, /turf/open/floor/rogue/dirt/road))
+							// Prevent deleting graves by changing the turf it's on if there is a grave on the turf
+							if(istype(T, /turf/open/floor/rogue/dirt/road) && !D.holie)
 								qdel(heldclod)
 								T.ChangeTurf(/turf/open/floor/rogue/dirt, flags = CHANGETURF_INHERIT_AIR)
-							else
+							else if (!D.holie)
 								heldclod.forceMove(T)
-
+							else
+								to_chat(user, span_warning("I cannot put the clod here, there's a grave in the way"))
+								return
 							heldclod = null
 							playsound(T,'sound/items/empty_shovel.ogg', 100, TRUE)
 							update_icon()
@@ -395,7 +398,7 @@
 	desc = "This relic, bestowed on the Order of the Veiled Lady, is cold to the touch. Faint whispers of the lost and the damned can be heard in its presence, and an inscription on the handle reads the Order's motto: \"Rest to the Restless, Death to the Deathless\""
 	icon_state = "zoe_silence"
 	icon = 'icons/obj/items/donor_weapons_48.dmi'
-	
+
 /obj/item/rogueweapon/shovel/zoe_silence/getonmobprop(tag)
 	if(tag)
 		switch(tag)

--- a/modular/Neu_Food/code/cooked/cooked_baked.dm
+++ b/modular/Neu_Food/code/cooked/cooked_baked.dm
@@ -247,7 +247,7 @@
 	icon = 'modular/Neu_Food/icons/cooked/cooked_baked.dmi'
 	tastes = list("sweetly-sour jamminess" = 1, "a lavish break from the dae's woes" = 1)
 	icon_state = "bun_jamtallow"
-	list_reagents = list(/datum/reagent/consumable/nutriment = NUTRITION_FULL_MEAL)
+	list_reagents = list(/datum/reagent/consumable/nutriment = NUTRITION_THREE_QUARTER_MEAL)
 	faretype = FARE_FINE
 	w_class = WEIGHT_CLASS_NORMAL
 	bitesize = 4
@@ -262,7 +262,7 @@
 	icon = 'modular/Neu_Food/icons/cooked/cooked_baked.dmi'
 	tastes = list("sweet-tarty jamminess" = 1, "a lavish break from the dae's woes" = 1)
 	icon_state = "bun_marmalade"
-	list_reagents = list(/datum/reagent/consumable/nutriment = NUTRITION_FULL_MEAL)
+	list_reagents = list(/datum/reagent/consumable/nutriment = NUTRITION_THREE_QUARTER_MEAL)
 	faretype = FARE_FINE
 	w_class = WEIGHT_CLASS_NORMAL
 	bitesize = 4
@@ -303,6 +303,7 @@
 	practice to add a slice of marmalade to their crossbuns, in reverance of Her golden authority."
 	icon = 'modular/Neu_Food/icons/cooked/cooked_baked.dmi'
 	icon_state = "crossbun"
+	list_reagents = list(/datum/reagent/consumable/nutriment = SMALLDOUGH_NUTRITION)
 	faretype = FARE_NEUTRAL // Having nobles vomit from eating holy buns is not a good idea
 	w_class = WEIGHT_CLASS_NORMAL
 	tastes = list("bread" = 1)
@@ -316,6 +317,7 @@
 	desc = "So sinfully delicious!"
 	icon = 'modular/Neu_Food/icons/cooked/cooked_baked.dmi'
 	icon_state = "crossbun_jamtallow"
+	list_reagents = list(/datum/reagent/consumable/nutriment = NUTRITION_THREE_QUARTER_MEAL)
 	faretype = FARE_LAVISH
 	w_class = WEIGHT_CLASS_NORMAL
 	bitesize = 4
@@ -333,6 +335,7 @@
 	radiance, though the spiritual implication tends to be lost on more eager-minded children."
 	icon = 'modular/Neu_Food/icons/cooked/cooked_baked.dmi'
 	icon_state = "crossbun_marmalade"
+	list_reagents = list(/datum/reagent/consumable/nutriment = NUTRITION_THREE_QUARTER_MEAL)
 	faretype = FARE_LAVISH
 	w_class = WEIGHT_CLASS_NORMAL
 	bitesize = 4
@@ -363,6 +366,7 @@
 	tears, though the spiritual implication tends to be lost on more eager-minded children."
 	icon = 'modular/Neu_Food/icons/cooked/cooked_baked.dmi'
 	icon_state = "psycrossbun_jamtallow"
+	list_reagents = list(/datum/reagent/consumable/nutriment = NUTRITION_THREE_QUARTER_MEAL)
 	faretype = FARE_LAVISH
 	w_class = WEIGHT_CLASS_NORMAL
 	bitesize = 4
@@ -378,6 +382,7 @@
 	desc = "Wait, isn't it meant to be the other way around? Ah, well!"
 	icon = 'modular/Neu_Food/icons/cooked/cooked_baked.dmi'
 	icon_state = "psycrossbun_marmalade"
+	list_reagents = list(/datum/reagent/consumable/nutriment = NUTRITION_THREE_QUARTER_MEAL)
 	faretype = FARE_LAVISH
 	w_class = WEIGHT_CLASS_NORMAL
 	bitesize = 4
@@ -394,6 +399,7 @@
 	helping of jam or marmalade."
 	icon = 'modular/Neu_Food/icons/cooked/cooked_baked.dmi'
 	icon_state = "decabun"
+	list_reagents = list(/datum/reagent/consumable/nutriment = SMALLDOUGH_NUTRITION)
 	faretype = FARE_NEUTRAL // Having nobles vomit from eating holy buns is not a good idea
 	w_class = WEIGHT_CLASS_NORMAL
 	tastes = list("bread" = 1)
@@ -409,6 +415,7 @@
 	desc = "A decabun, cruelly parted to be slathered with a spread of jamtallow. Seperate, but joined in sweet unity."
 	icon = 'modular/Neu_Food/icons/cooked/cooked_baked.dmi'
 	icon_state = "decabun_jamtallow"
+	list_reagents = list(/datum/reagent/consumable/nutriment = NUTRITION_THREE_QUARTER_MEAL)
 	faretype = FARE_LAVISH
 	w_class = WEIGHT_CLASS_NORMAL
 	bitesize = 4
@@ -425,6 +432,7 @@
 	but the overall texture goes down smoothly."
 	icon = 'modular/Neu_Food/icons/cooked/cooked_baked.dmi'
 	icon_state = "decabun_marmalade"
+	list_reagents = list(/datum/reagent/consumable/nutriment = NUTRITION_THREE_QUARTER_MEAL)
 	faretype = FARE_LAVISH
 	w_class = WEIGHT_CLASS_NORMAL
 	bitesize = 4


### PR DESCRIPTION
## About The Pull Request
fixes #8682 

Standardizes marmeladed buns to 9 nutrition and regular buns to 7.5 nutrition.
Previously two marmeladed buns were 12, but that's a little extreme for a tiny bun with some jam being more filling than a steak.

Previously most buns didn't have any food value, defaulting to 1 nutrition.

## Testing Evidence
Sample Numbah Chanege

## Why It's Good For The Game
bugfix

## Changelog
:cl:
fix: fixed bun nutrition values
/:cl:

