### PR TITLE
[QoL] Adds an IC verb to open the sleep menu

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1222,6 +1222,28 @@ GLOBAL_VAR_INIT(mobids, 1)
 	var/datum/language_holder/H = get_language_holder()
 	H.open_language_menu(usr)
 
+///Show the sleep level up screen if available
+/mob/living/verb/open_sleep_adv_menu()
+	set name = "Open Dream Menu"
+	set category = "IC"
+	set hidden = FALSE
+
+	if(!mind || !mind.sleep_adv)
+		to_chat(src, span_warning("You have no dreams to contemplate."))
+		return
+
+	if(!IsSleeping())
+		to_chat(src, span_warning("You must be asleep to enter your dreams."))
+		return
+
+	var/datum/sleep_adv/SA = mind.sleep_adv
+
+	if(SA.sleep_adv_points <= 0)
+		to_chat(src, span_warning("You lack the inspiration granted by a proper rest in order to contemplate your dreams."))
+		return
+
+	SA.show_ui(src)
+
 /// Custom pose setting
 /mob/living/carbon/human/verb/set_pose()
 	set name = "Set Pose"


### PR DESCRIPTION
## About The Pull Request
fixes #5568 
fixes #8606 

Adds an IC verb to pull up the sleep menu again.
- Doesn't work if you don't have any points.
- Doesn't work if you aren't asleep.
- Doesn't grant any NEW inspirations or dream dust (points)

## Testing Evidence
<img width="1707" height="1031" alt="image" src="https://github.com/user-attachments/assets/b8dbb4ee-7e9a-4d9b-b91d-b50c6f07b2ca" />

## Why It's Good For The Game
Makes sure people don't just lose their opportunity to level up skills for points they'd already secured just because they aren't tired anymore. This also makes taking a bath less of a self-grief. Best solution I could think of that isn't annoying, like reopening the menu for every minor doze.

## Changelog

:cl:
qol: Added an ic verb to level up your skills if you are asleep and have points
/:cl:

