### PR TITLE
Steels your footknight iron warhammer

### DIFF
--- a/code/modules/jobs/job_types/roguetown/retinue/knight.dm
+++ b/code/modules/jobs/job_types/roguetown/retinue/knight.dm
@@ -234,7 +234,7 @@
 			if("Flail")
 				beltr = /obj/item/rogueweapon/flail/sflail
 			if ("Warhammer")
-				beltr = /obj/item/rogueweapon/mace/warhammer //Iron warhammer. This is one-handed and pairs well with shields. They can upgrade to steel in-round.
+				beltr = /obj/item/rogueweapon/mace/warhammer/steel //This is one-handed and pairs well with shields, there are many better weapons w/ specials/reach now.
 			if("Sabre")
 				beltl = /obj/item/rogueweapon/scabbard/sword/noble
 				l_hand = /obj/item/rogueweapon/sword/sabre


### PR DESCRIPTION
## About The Pull Request

Gives keep knights a steel warhammer

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

If it builds, it works. Its one line sire and I know exactly what object the code references.

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

Ages ago, the warhammer was a solid meta-pick for knights when it came to one-handed weaponry, but since several combat changes have come into the game, its sort of obsoleted by specials existing now.

A good example of this is mace specials, or even the sabre doing specials while you can use a shield, same with the longsword choice.

Steel warhammer is not going to kill the balance anymore, if anything its a mercy to martial classes that already struggle and pick this thing for the aura of bashing in a few brigand and peasantry skulls, rejoice!

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Keep Footknights now have steel instead of iron warhammers. Since specials on other weapons made its prior case of being a straight-upgrade moot.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
