### PR TITLE
[Innkeeper] - Gives the innkeeper a random goodie box

### DIFF
--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -62636,6 +62636,7 @@
 /area/rogue/outdoors/exposed/town/keep)
 "lEn" = (
 /obj/structure/table/wood/long_table,
+/obj/item/ration_lootbox,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/tavern)
 "lEq" = (

--- a/modular/Neu_Food/code/cookware/innkeep_lootbox.dm
+++ b/modular/Neu_Food/code/cookware/innkeep_lootbox.dm
@@ -1,0 +1,73 @@
+/obj/item/ration_lootbox
+	name = "mysterious ration package"
+	desc = "An unassuming paper bundle. It feels surprisingly heavy, like it contains a bounty of assorted goodies. Perhaps a RIGHT hand can reveal the bounty?"
+	icon = 'modular/Neu_food/icons/cookware/ration.dmi'
+	icon_state = "ration_large"
+	w_class = WEIGHT_CLASS_HUGE
+	grid_height = 32
+	grid_width = 32
+	color = "#b58fe6"
+
+/obj/item/ration_lootbox/attack_right(mob/user)
+	..()
+	if(!ishuman(user))
+		return
+	var/mob/living/carbon/human/H = user
+	if(do_after(H, 20, target = src))
+		to_chat(H, span_notice("You unwrap the mysterious package..."))
+		var/list/loot_table = list(
+			/obj/item/reagent_containers/food/snacks/chocolate,
+			/obj/item/reagent_containers/food/snacks/dragee,
+			/obj/item/reagent_containers/food/snacks/caramel,
+			/obj/item/reagent_containers/food/snacks/rogue/raisins,
+			/obj/item/reagent_containers/food/snacks/rogue/raisins/raspberry,
+			/obj/item/reagent_containers/food/snacks/rogue/raisins/strawberry,
+			/obj/item/reagent_containers/food/snacks/rogue/raisins/blackberry,
+			/obj/item/reagent_containers/food/snacks/rogue/raisins/plum,
+			/obj/item/reagent_containers/food/snacks/rogue/raisins/pear,
+			/obj/item/reagent_containers/food/snacks/rogue/raisins/tangerine,
+			/obj/item/reagent_containers/food/snacks/rogue/raisins/lemon,
+			/obj/item/reagent_containers/food/snacks/rogue/raisins/lime,
+			/obj/item/reagent_containers/food/snacks/rogue/pesto,
+			/obj/item/reagent_containers/food/snacks/rogue/truffles,
+			/obj/item/reagent_containers/food/snacks/rogue/mushroom,
+			/obj/item/reagent_containers/food/snacks/rogue/fruit/pumpkin_sliced,
+			/obj/item/reagent_containers/food/snacks/rogue/preserved/pumpkin_mashed,
+			/obj/item/reagent_containers/food/snacks/grown/rice,
+			/obj/item/reagent_containers/food/snacks/rogue/fryfish/sole,
+			/obj/item/reagent_containers/food/snacks/rogue/fryfish/cod,
+			/obj/item/reagent_containers/food/snacks/rogue/fryfish/lobster,
+			/obj/item/reagent_containers/food/snacks/rogue/fryfish/salmon,
+			/obj/item/reagent_containers/food/snacks/rogue/fryfish/plaice,
+			/obj/item/reagent_containers/food/snacks/rogue/fryfish/bass,
+			/obj/item/reagent_containers/food/snacks/rogue/fryfish/clam,
+			/obj/item/reagent_containers/food/snacks/rogue/fryfish/shrimp,
+			/obj/item/reagent_containers/food/snacks/grown/tea,
+			/obj/item/reagent_containers/food/snacks/grown/coffeebeansroasted,
+			/obj/item/reagent_containers/food/snacks/pumpkinspice,
+			/obj/item/reagent_containers/powder/rocknut,
+			/obj/item/reagent_containers/food/snacks/grown/fruit/lemon,
+			/obj/item/reagent_containers/food/snacks/grown/fruit/blackberry,
+			/obj/item/reagent_containers/food/snacks/grown/fruit/lime,
+			/obj/item/reagent_containers/food/snacks/grown/fruit/pear,
+			/obj/item/reagent_containers/food/snacks/grown/fruit/plum,
+			/obj/item/reagent_containers/food/snacks/grown/fruit/raspberry,
+			/obj/item/reagent_containers/food/snacks/grown/fruit/strawberry,
+			/obj/item/reagent_containers/food/snacks/grown/fruit/tangerine,
+			/obj/item/reagent_containers/food/snacks/grown/fruit/tomato,
+			/obj/item/reagent_containers/food/snacks/grown/maize,
+			/obj/item/reagent_containers/food/snacks/rogue/meat/bacon,
+			/obj/item/reagent_containers/food/snacks/rogue/meat/ham,
+			/obj/item/reagent_containers/food/snacks/rogue/meat/bear,
+			/obj/item/reagent_containers/food/snacks/rogue/meat/saiga,
+			/obj/item/reagent_containers/food/snacks/rogue/meat/saiga_ribs,
+			/obj/item/reagent_containers/food/snacks/rogue/meat/saiga_z,
+			/obj/item/reagent_containers/food/snacks/rogue/meat/saiga_ribs_z
+		)
+
+		var/num_items = rand(1, 12)
+		for(var/i in 1 to num_items)
+			var/item_type = pick(loot_table)
+			new item_type(get_turf(src))
+
+		qdel(src)

--- a/modular/Neu_Food/code/cookware/innkeep_lootbox.dm
+++ b/modular/Neu_Food/code/cookware/innkeep_lootbox.dm
@@ -34,14 +34,14 @@
 			/obj/item/reagent_containers/food/snacks/rogue/fruit/pumpkin_sliced,
 			/obj/item/reagent_containers/food/snacks/rogue/preserved/pumpkin_mashed,
 			/obj/item/reagent_containers/food/snacks/grown/rice,
-			/obj/item/reagent_containers/food/snacks/rogue/fryfish/sole,
-			/obj/item/reagent_containers/food/snacks/rogue/fryfish/cod,
-			/obj/item/reagent_containers/food/snacks/rogue/fryfish/lobster,
-			/obj/item/reagent_containers/food/snacks/rogue/fryfish/salmon,
-			/obj/item/reagent_containers/food/snacks/rogue/fryfish/plaice,
-			/obj/item/reagent_containers/food/snacks/rogue/fryfish/bass,
-			/obj/item/reagent_containers/food/snacks/rogue/fryfish/clam,
-			/obj/item/reagent_containers/food/snacks/rogue/fryfish/shrimp,
+			/obj/item/reagent_containers/food/snacks/fish/sole,
+			/obj/item/reagent_containers/food/snacks/fish/cod,
+			/obj/item/reagent_containers/food/snacks/fish/lobster,
+			/obj/item/reagent_containers/food/snacks/fish/salmon,
+			/obj/item/reagent_containers/food/snacks/fish/plaice,
+			/obj/item/reagent_containers/food/snacks/fish/bass,
+			/obj/item/reagent_containers/food/snacks/fish/clam,
+			/obj/item/reagent_containers/food/snacks/fish/shrimp,
 			/obj/item/reagent_containers/food/snacks/grown/tea,
 			/obj/item/reagent_containers/food/snacks/grown/coffeebeansroasted,
 			/obj/item/reagent_containers/food/snacks/pumpkinspice,
@@ -65,9 +65,10 @@
 			/obj/item/reagent_containers/food/snacks/rogue/meat/saiga_ribs_z
 		)
 
-		var/num_items = rand(1, 12)
+		var/num_items = rand(9, 15)
+		var/loot_turf = get_turf(src)
 		for(var/i in 1 to num_items)
 			var/item_type = pick(loot_table)
-			new item_type(get_turf(src))
+			new item_type(loot_turf)
 
 		qdel(src)

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -3668,6 +3668,7 @@
 #include "modular\Neu_Food\code\cookware\bowl.dm"
 #include "modular\Neu_Food\code\cookware\cup.dm"
 #include "modular\Neu_Food\code\cookware\fork.dm"
+#include "modular\Neu_Food\code\cookware\innkeep_lootbox.dm"
 #include "modular\Neu_Food\code\cookware\misc_cookware.dm"
 #include "modular\Neu_Food\code\cookware\pan.dm"
 #include "modular\Neu_Food\code\cookware\peppermill.dm"


### PR DESCRIPTION
## About The Pull Request
Folks might remember these from space stations, only this one is a bit more random and not always super useful. Has anything from raisins and deadite meat to basic venison or exotic fruits. Let's go gambling!

Contains 9-15 items (12 average) at random.

## Testing Evidence
<img width="1367" height="1076" alt="image" src="https://github.com/user-attachments/assets/eea5c920-c4bf-493a-af27-874a8c9e46ab" />

## Why It's Good For The Game
I hate free stuff. But what I dislike more, is innkeepers not getting particularly much on their own in the ways of interesting ingredients. No soilson? No merchant? No hunter? Well shucks I guess it's apple pie again.

This doesn't make them much less dependent on those roles. It's just that some rounds you might get coveted strawberries, and other rounds you'll have to pray. But that's part of the fun, isn't it? This also aims to make the innkeep just a little less replaceable by any ol adventurer setting up a soup kitchen, by giving them access to a few unique things that are otherwise hard to come by.

## Changelog

:cl:
add: Innkeeper now gets a random ingredients package in their kitchen
/:cl:

