### PR TITLE
The Monkey's Paw Curls: hair layering enrages me

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -56,6 +56,7 @@
 #define CLOAK_LAYER				17		//only when looking north or west/east
 #define HOOD_LAYER				16
 #define HAIR_LAYER				15		//TODO: make part of head layer?
+#define CUSTOM_HAIR_LAYER		14.95
 #define CUSTOM_HAIR_COVERED_LAYER 14.9	// WHY ARE TOP SNOUTS LIKE THIS I HATE FURRIES
 #define MASK_LAYER				14
 #define HAIREXTRA_LAYER			13
@@ -66,7 +67,6 @@
 #define HANDCUFF_LAYER			8
 #define LEGCUFF_LAYER			7
 #define BODY_FRONT_LAYER		6
-#define CUSTOM_HAIR_LAYER		5.9
 #define BODY_FRONT_FRONT_LAYER	5
 #define HALO_LAYER				4		//blood cult ascended halo, because there's currently no better solution for adding/removing
 #define SUNDER_LAYER			3

--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -56,8 +56,8 @@
 #define CLOAK_LAYER				17		//only when looking north or west/east
 #define HOOD_LAYER				16
 #define HAIR_LAYER				15		//TODO: make part of head layer?
-#define CUSTOM_HAIR_LAYER		14.95
-#define CUSTOM_HAIR_COVERED_LAYER 14.9	// WHY ARE TOP SNOUTS LIKE THIS I HATE FURRIES
+#define CUSTOM_HAIR_LAYER		14.95	//obviously above (below?) hair layer so it shows up
+#define CUSTOM_HAIR_COVERED_LAYER 14.9	//hat or mask is hiding the hair underneath
 #define MASK_LAYER				14
 #define HAIREXTRA_LAYER			13
 #define MOUTH_LAYER				12
@@ -67,6 +67,7 @@
 #define HANDCUFF_LAYER			8
 #define LEGCUFF_LAYER			7
 #define BODY_FRONT_LAYER		6
+#define CUSTOM_HAIR_ABOVE_SNOUT_LAYER 5.9	//so hair renders over (top) snouts using BODY_FRONT_LAYER (WHY ARE TOP SNOUTS LIKE THIS I HATE FURRIES)
 #define BODY_FRONT_FRONT_LAYER	5
 #define HALO_LAYER				4		//blood cult ascended halo, because there's currently no better solution for adding/removing
 #define SUNDER_LAYER			3

--- a/code/modules/mob/dead/new_player/sprite_accessory/snouts.dm
+++ b/code/modules/mob/dead/new_player/sprite_accessory/snouts.dm
@@ -3,6 +3,7 @@
 	icon = 'icons/mob/sprite_accessory/snouts/snouts.dmi'
 	color_key_name = "Snout"
 	relevant_layers = list(BODY_ADJ_LAYER)
+	var/draws_over_hair = FALSE // For top snout jank. Should always be false unless an accessory is meant to layer over top of your hair.
 
 /datum/sprite_accessory/snout/is_visible(obj/item/organ/organ, obj/item/bodypart/bodypart, mob/living/carbon/owner)
 	return is_human_part_visible(owner, HIDESNOUT)
@@ -325,6 +326,7 @@
 /datum/sprite_accessory/snout/front
 	abstract_type = /datum/sprite_accessory/snout/front
 	relevant_layers = list(BODY_FRONT_LAYER)
+	draws_over_hair = TRUE
 
 /datum/sprite_accessory/snout/front/sharp
 	name = "Sharp (Top)"
@@ -520,3 +522,4 @@
 	icon_state = "masked"
 	color_key_name = "Veil"
 	relevant_layers = list(BODY_ADJ_LAYER, BODY_FRONT_LAYER)
+	draws_over_hair = TRUE

--- a/code/modules/surgery/bodyparts/bodypart_features/features.dm
+++ b/code/modules/surgery/bodyparts/bodypart_features/features.dm
@@ -41,12 +41,23 @@
 		return TRUE
 	return FALSE
 
+/datum/bodypart_feature/hair/proc/get_custom_hair_pixel_layer(obj/item/bodypart/bodypart)
+	if(custom_pixels_covered(bodypart))
+		return CUSTOM_HAIR_COVERED_LAYER
+	var/mob/living/carbon/human/human = bodypart?.owner
+	if(!istype(human))
+		return CUSTOM_HAIR_LAYER
+	var/obj/item/organ/snout/snout = human.getorganslot(ORGAN_SLOT_SNOUT)
+	var/datum/sprite_accessory/snout/accessory = snout?.accessory_type ? SPRITE_ACCESSORY(snout.accessory_type) : null
+	if(accessory?.draws_over_hair)
+		return CUSTOM_HAIR_ABOVE_SNOUT_LAYER
+	return CUSTOM_HAIR_LAYER
+
 /datum/bodypart_feature/hair/extra_bodypart_overlays(obj/item/bodypart/bodypart)
 	var/icon/custom_icon = get_custom_overlay_icon()
 	if(!custom_icon)
 		return
-	var/pixel_layer = custom_pixels_covered(bodypart) ? CUSTOM_HAIR_COVERED_LAYER : CUSTOM_HAIR_LAYER
-	return list(mutable_appearance(custom_icon, layer = -pixel_layer))
+	return list(mutable_appearance(custom_icon, layer = -get_custom_hair_pixel_layer(bodypart)))
 
 /// Derives cache from bodyparts_covered.
 /datum/bodypart_feature/hair/get_cache_key(obj/item/bodypart/bodypart)
@@ -54,7 +65,7 @@
 	var/mask_hash = get_custom_mask_hash()
 	if(!mask_hash)
 		return .
-	return "[.]-[mask_hash]-[custom_pixels_covered(bodypart)]"
+	return "[.]-[mask_hash]-[get_custom_hair_pixel_layer(bodypart)]"
 
 /// Drops the cached mask derivatives when they no longer describe the current mask data.
 /datum/bodypart_feature/hair/proc/validate_custom_cache()


### PR DESCRIPTION
## About The Pull Request

https://github.com/Azure-Peak/Azure-Peak/pull/8370

So, this PR introduced a bug that made custom hair layer OVER your weapons/masks/etc. Not good. Especially not good if you're rocking a full head of custom hair like how I do.

<img width="82" height="126" alt="image" src="https://github.com/user-attachments/assets/b15a5d73-8fa2-4ed9-b904-42f4d417b65a" />

Here's my character's hair layering over their both their mace and their flower crown. Not good!
Just a simple layering tweak to fix it.

<img width="68" height="105" alt="image" src="https://github.com/user-attachments/assets/61150172-dd20-4d3b-9628-8a55d33bfddb" />

👍
Bad news, is this reintroduces the thing Ryan was trying to patch out, where top snouts (because they layer on layer god damn six) now layer over custom hair. I don't see the problem with this, but it warranted a PR to change it so I am legally required to try and abide by it.

We now have to introduce a whole new check to first see if the player has one of these GODSFORSAKEN top snouts, and adjust the hair layer accordingly. Otherwise, it operates on old behavior - yay! This code is ugly as fuck and probably poorly-written and there's probably a way better way to do it but it *shouldn't* be *too too bad* since it only runs whenever other hair rendering takes place, so putting on a hat etc. Maybe if the entire server takes on and off their hat seventy times it'll add up enough to a palpable performance loss.

Now, here's the monkey's paw curling. The quirk with hair layering over your mask and equipped items persists if you use a top snout. Is there a way to fix this WITHOUT rewriting how shit layers and turning this was-supposed-to-be-simple bug fix into a two thousand line rewrite? Probably? I don't know.

Here's a screenshot of custom hair layering over an ugly randomize wildkin's top snout.

<img width="144" height="200" alt="image" src="https://github.com/user-attachments/assets/024750ca-b042-4219-84d7-8ff2a289370b" />

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

Read the above block.

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

Monkey's paw bugfixing. Eliminate a common bug by moving it to a much more niche circumstance with way too much code.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: custom hair no longer layers above equipped items. this bug still exists if you are using custom hair as well as a top snout, sorry about that manne!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
