### PR TITLE
BUGFIX: Wretch berserker punchdagger nonexistent

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/berserker.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/berserker.dm
@@ -85,7 +85,7 @@
 					if("Knuckledusters")
 						gloves = /obj/item/clothing/gloves/roguetown/knuckles
 					if("Punch Dagger")
-						beltr = /obj/item/rogueweapon/katar/punchdagger
+						r_hand = /obj/item/rogueweapon/katar/punchdagger
 			if("Martial Expert") // designed to compete with unarmed by giving you alternatives to approaching fights- only expert
 				var/list/martial_options = list("Greatsword", "Battle Axe", "Grand Mace", "Longsword")
 				var/weapon_choice = input(H, "Choose your WEAPONS of WAR!", "SPILL THEIR ENTRAILS.") as anything in martial_options


### PR DESCRIPTION
## About The Pull Request

Fixed bug with punchdagger nonexistent upon chosing 

## Testing Evidence

Vérifié sur son serveur

## Why It's Good For The Game

you will not believe it, but bugs are still bad

## Changelog
:cl:
fix: Fixed pathing in berserker's loadout that tried to place punchdagger on belt when it cannot be there, so dagger just dissapeared. Now it's placed in players hand upon chosing
/:cl:

