### PR TITLE
[Sniffer update] Gnoll QoL - stealth respecting sniffing, area hints, shard client outlining

### DIFF
--- a/code/game/area/actualcoast.dm
+++ b/code/game/area/actualcoast.dm
@@ -12,6 +12,7 @@
 	converted_type = /area/rogue/under/lake
 	first_time_text = "CITY HARBOR"
 	deathsight_message = "a windswept shore"
+	area_sniff_message = "You smell the town, faintly, buried underneath the scent of the sea."
 	detail_text = DETAIL_TEXT_ACTUAL_COAST
 
 // No sea raiders here! The Central Coast is relatively safe.
@@ -27,6 +28,7 @@
 	)
 	first_time_text = "CENTRAL COAST"
 	threat_region = THREAT_REGION_AZURE_GROVE
+	area_sniff_message = "You smell the seas and the sands."
 
 /area/rogue/outdoors/beach/north
 	name = "Northern Coast"
@@ -42,6 +44,7 @@
 	)
 	first_time_text = "NORTHERN COAST"
 	threat_region = THREAT_REGION_AZUREAN_COAST
+	area_sniff_message = "You smell the seas and the sands."
 
 /area/rogue/outdoors/beach/south
 	name = "Southern Coast"
@@ -58,3 +61,4 @@
 	first_time_text = "SOUTHERN COAST"
 	detail_text = DETAIL_TEXT_CITY_COAST
 	threat_region = THREAT_REGION_AZURE_BASIN
+	area_sniff_message = "You smell the seas and the sands."

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -112,6 +112,8 @@
 	var/threat_region = "" // Key used to look up threat region this area belongs to
 	/// Message used for deathsight. Try to be deliberately obtuse but not too obtuse.
 	var/deathsight_message
+	/// Custom description displayed when tracking targets with Gnoll Sniff
+	var/area_sniff_message
 
 	var/coven_protected = FALSE
 	/// Whether or not an area protects against Necra's vengeful fog

--- a/code/game/area/basingrove.dm
+++ b/code/game/area/basingrove.dm
@@ -14,6 +14,7 @@
 	droning_sound_night = 'sound/music/area/sleeping.ogg'
 	converted_type = /area/rogue/indoors/shelter/rtfield
 	deathsight_message = "somewhere in the wilds, next to towering walls"
+	area_sniff_message = "You smell the faint scent of the town together with that of fresh grass."
 	warden_area = TRUE
 	threat_region = THREAT_REGION_AZURE_BASIN
 	detail_text = DETAIL_TEXT_AZURE_BASIN
@@ -26,3 +27,4 @@
 	droning_sound_dusk = 'sound/music/area/septimus.ogg'
 	droning_sound_night = list ('sound/ambience/rivernight (1).ogg','sound/ambience/rivernight (2).ogg','sound/ambience/rivernight (3).ogg' )
 	detail_text = DETAIL_TEXT_DRUIDS_GROVE
+	area_sniff_message = "You smell old roots and plenty of burnt swampweed."

--- a/code/game/area/generic_caves.dm
+++ b/code/game/area/generic_caves.dm
@@ -22,12 +22,14 @@
 				/mob/living/simple_animal/hostile/retaliate/rogue/minotaur = 5,
 				/mob/living/simple_animal/hostile/retaliate/rogue/ooze_blob = 10)
 	converted_type = /area/rogue/outdoors/caves
+	area_sniff_message = "You smell the distant stench of the sewer, muddied by a damp and murky scent."
 
 /area/rogue/under/cave/peace
 	icon_state = "caves"
 	droning_sound = 'sound/music/area/peace.ogg'
 	droning_sound_dusk = null
 	droning_sound_night = null
+	area_sniff_message = "You smell sweetly scenter water and old roots."
 
 // Shameless copy of peace cave since someone liked it so much.
 /area/rogue/under/cave/abyssor
@@ -36,11 +38,13 @@
 	droning_sound = 'sound/music/area/peace.ogg'
 	droning_sound_dusk = null
 	droning_sound_night = null
+	area_sniff_message = "You smell strange chemicals and paints."
 
 // Can use the normal caves music
 /area/rogue/under/cave/abyssor/inner
 	name = "inner abyssal grotto"
 	first_time_text = "THE ABYSSAL GROTTO"
+	area_sniff_message = "You smell strange chemicals and paints."
 
 /area/rogue/outdoors/caves
 	icon_state = "caves"
@@ -58,6 +62,7 @@
 	droning_sound_night = null
 	converted_type = /area/rogue/outdoors/spidercave
 	loot_budget = LOOT_BUDGET_ARAIGNEE
+	area_sniff_message = "You smell raw spidersilk and corpses since long preserved."
 
 /area/rogue/outdoors/spidercave
 	icon_state = "spidercave"

--- a/code/game/area/hotsprings.dm
+++ b/code/game/area/hotsprings.dm
@@ -11,6 +11,7 @@
 	converted_type = /area/rogue/indoors/shelter/rtfield
 	deathsight_message = "somewhere high up in a mountains, where cherry blossoms bloom"
 	detail_text = DETAIL_TEXT_EORAN_SHRINE
+	area_sniff_message = "You smell cherry blossoms."
 
 /area/rogue/outdoors/rtfield/abandonedhotsprings
 	name = "Abandoned Hot Springs"
@@ -25,6 +26,7 @@
 	converted_type = /area/rogue/indoors/abandonedhotsprings
 	deathsight_message = "somewhere above a swamp, where cherry blossoms bloom and spiders chitter"
 	detail_text = DETAIL_TEXT_ABANDONED_HOT_SPRINGS
+	area_sniff_message = "You smell mineral water."
 
 /area/rogue/indoors/abandonedhotsprings
 	icon_state = "eora"
@@ -34,3 +36,4 @@
 	droning_sound = 'sound/newmusic/lovecraft2.ogg'
 	droning_sound_dusk = 'sound/newmusic/lovecraft2.ogg'
 	droning_sound_night = 'sound/newmusic/lovecraft2.ogg'
+	area_sniff_message = "You smell mineral water and dried tea."

--- a/code/game/area/miscareas.dm
+++ b/code/game/area/miscareas.dm
@@ -14,3 +14,4 @@
 	first_time_text = "ABYSSOR'S GRASP"
 	deathsight_message = "amidst abyssor's grasp"
 	detail_text = DETAIL_TEXT_ABYSSORS_GRASP
+	area_sniff_message = "You smell the sea and wet stone."

--- a/code/game/area/mountdecap.dm
+++ b/code/game/area/mountdecap.dm
@@ -32,6 +32,7 @@
 	deathsight_message = "a twisted tangle of soaring peaks"
 	threat_region = THREAT_REGION_MOUNT_DECAP
 	detail_text = DETAIL_TEXT_DECAP
+	area_sniff_message = "You smell ancient bones and pine wood."
 
 /area/rogue/indoors/shelter/mountains/decap
 	name = "Mount Decapitation"
@@ -44,6 +45,7 @@
 	threat_region = THREAT_REGION_MOUNT_DECAP
 	deathsight_message = "a twisted tangle of soaring peaks"
 	detail_text = DETAIL_TEXT_DECAP_TARICHEA
+	area_sniff_message = "You smell ancient bones and pine wood planks."
 
 /area/rogue/outdoors/mountains/decap/stepbelow
 	name = "Tarichea - Valley of Loss"
@@ -77,6 +79,7 @@
 	converted_type = /area/rogue/indoors/shelter/mountains/decap
 	threat_region = THREAT_REGION_MOUNT_DECAP
 	detail_text = DETAIL_TEXT_DECAP_TARICHEA
+	area_sniff_message = "You smell sulfur."
 
 /area/rogue/outdoors/mountains/decap/gunduzirak
 	name = "Gundu Zirak"
@@ -96,6 +99,7 @@
 	ceiling_protected = TRUE
 	threat_region = THREAT_REGION_MOUNT_DECAP
 	detail_text = DETAIL_TEXT_DECAP_GUNDU_ZIRAK
+	area_sniff_message = "You smell old grudges and copper flakes."
 
 /area/rogue/outdoors/mountains/decap/gunduzirak/bossarena
 	name = "Baronness Boss Arena"
@@ -118,6 +122,7 @@
 	deathsight_message = "a twisted tangle of soaring peaks"
 	threat_region = THREAT_REGION_MOUNT_DECAP
 	detail_text = DETAIL_TEXT_DECAP_DRAGONDEN
+	area_sniff_message = "You smell drakynn."
 
 /area/rogue/under/cave/dragonden/can_craft_here()
 	return FALSE
@@ -134,6 +139,7 @@
 	deathsight_message = "a twisted tangle of soaring peaks"
 	threat_region = THREAT_REGION_MOUNT_DECAP
 	detail_text = DETAIL_TEXT_DECAP_GOBLIN_FORTRESS
+	area_sniff_message = "You smell vile daemonspawn."
 
 /area/rogue/under/cave/scarymaze
 	name = "Necran Labyrinth"
@@ -147,6 +153,7 @@
 	deathsight_message = "a twisted tangle of soaring peaks"
 	threat_region = THREAT_REGION_MOUNT_DECAP
 	detail_text = DETAIL_TEXT_DECAP_NECRAN_LABYRINTH
+	area_sniff_message = "You smell death and black roses."
 
 /area/rogue/outdoors/mountains/decap/minotaurfort
 	name = "Ancient Dwarven Forge"
@@ -161,6 +168,7 @@
 	ceiling_protected = TRUE
 	threat_region = THREAT_REGION_MOUNT_DECAP
 	detail_text = DETAIL_TEXT_DECAP_MINOTAUR_FORTRESS
+	area_sniff_message = "You smell beef."
 
 /area/rogue/outdoors/mountains/decap/minotaurfort/can_craft_here()
 	return FALSE
@@ -178,6 +186,7 @@
 	converted_type = /area/rogue/indoors/shelter/mountains/decap
 	ceiling_protected = TRUE
 	threat_region = THREAT_REGION_MOUNT_DECAP
+	area_sniff_message = "You smell sweaty men, women, and pine wood."
 
 /area/rogue/indoors/shelter/mountains/decap/banditcamp
 	name = "Bandit Camp"
@@ -192,6 +201,7 @@
 	converted_type = /area/rogue/indoors/shelter/mountains/decap
 	ceiling_protected = TRUE
 	threat_region = DETAIL_TEXT_DECAP
+	area_sniff_message = "You smell sweat men, women, and pine wood."
 
 /area/rogue/under/cave/minotaurcave
 	name = "Minotaur Cave"
@@ -204,6 +214,7 @@
 	deathsight_message = "a twisted tangle of soaring peaks"
 	threat_region = THREAT_REGION_MOUNT_DECAP
 	detail_text = DETAIL_TEXT_DECAP
+	area_sniff_message = "You smell beef and undergrowth."
 
 /area/rogue/under/cave/taricheamanor
 	name = "Manor of Tarichea"
@@ -216,3 +227,4 @@
 	deathsight_message = "a twisted tangle of soaring peaks"
 	threat_region = THREAT_REGION_MOUNT_DECAP
 	detail_text = DETAIL_TEXT_DECAP_TARICHEA
+	area_sniff_message = "You smell stone floors and sulfur."

--- a/code/game/area/northcoast.dm
+++ b/code/game/area/northcoast.dm
@@ -1,4 +1,4 @@
-// Azure Coast - the northern part of the map - may not be actually coast 
+// Azure Coast - the northern part of the map - may not be actually coast
 /area/rogue/outdoors/beach/forest
 	name = "Azure Coast"
 	loot_budget = LOOT_BUDGET_AZURE_COAST
@@ -37,6 +37,7 @@
 	deathsight_message = "somewhere betwixt Abyssor's realm and Dendor's bounty"
 	threat_region = THREAT_REGION_AZUREAN_COAST
 	detail_text = DETAIL_TEXT_NORTH_COAST
+	area_sniff_message = "You smell deadite animals."
 
 /area/rogue/outdoors/beach/forest/hamlet
 	name = "The Azure Coast - Hamlet"
@@ -44,6 +45,7 @@
 	ambush_mobs = null // We don't want actual ambushes in Hamlet but we also don't want to misuse outdoors/beach lol
 	threat_region = THREAT_REGION_AZUREAN_COAST
 	detail_text = DETAIL_TEXT_NORTH_COAST_HAMLET
+	area_sniff_message = "You smell deadites and the sea."
 
 /area/rogue/outdoors/beach/forest/north
 	name = "The Azure Coast - North"
@@ -64,3 +66,4 @@
 	deathsight_message = "somewhere betwixt Abyssor's realm and Dendor's bounty"
 	threat_region = THREAT_REGION_AZUREAN_COAST
 	detail_text = DETAIL_TEXT_MAD_DUKE_COURT
+	area_sniff_message = "You smell an old fool."

--- a/code/game/area/roguetownareas.dm
+++ b/code/game/area/roguetownareas.dm
@@ -162,6 +162,7 @@ GLOBAL_LIST_INIT(roguetown_areas_typecache, typecacheof(list(/area/rogue/indoors
 	soundenv = 17
 	converted_type = /area/rogue/indoors/shelter/mountains
 	deathsight_message = "a twisted tangle of soaring peaks"
+	area_sniff_message = "You smell little but stone."
 	// I SURE HOPE NO ONE USE THIS HUH
 
 
@@ -190,6 +191,7 @@ GLOBAL_LIST_INIT(roguetown_areas_typecache, typecacheof(list(/area/rogue/indoors
 	droning_sound_night = 'sound/music/area/sleeping.ogg'
 	converted_type = /area/rogue/indoors/shelter/rtfield
 	deathsight_message = "somewhere in the wilds, next to towering walls"
+	area_sniff_message = "You smell the fields, grass, and the distant stench of town."
 	warden_area = TRUE
 	threat_region = THREAT_REGION_AZURE_BASIN
 
@@ -200,6 +202,7 @@ GLOBAL_LIST_INIT(roguetown_areas_typecache, typecacheof(list(/area/rogue/indoors
 	droning_sound = list('sound/ambience/riverday (1).ogg','sound/ambience/riverday (2).ogg','sound/ambience/riverday (3).ogg')
 	droning_sound_dusk = 'sound/music/area/septimus.ogg'
 	droning_sound_night = list ('sound/ambience/rivernight (1).ogg','sound/ambience/rivernight (2).ogg','sound/ambience/rivernight (3).ogg' )
+	area_sniff_message = "You smell old roots and burnt swampweed."
 
 /area/rogue/indoors/shelter/rtfield
 	icon_state = "rtfield"
@@ -245,6 +248,7 @@ GLOBAL_LIST_INIT(roguetown_areas_typecache, typecacheof(list(/area/rogue/indoors
 	droning_sound_dusk = null
 	droning_sound_night = null
 	converted_type = /area/rogue/outdoors/exposed/decap
+	area_sniff_message = "You smell sulfur"
 
 /area/rogue/outdoors/exposed/decap
 	icon_state = "decap"
@@ -302,13 +306,14 @@ GLOBAL_LIST_INIT(roguetown_areas_typecache, typecacheof(list(/area/rogue/indoors
 	first_time_text = "THE CITY OF AZURE PEAK"
 	town_area = TRUE
 	fog_protected = TRUE
+	area_sniff_message = "You smell the stench of the town."
 
 /area/rogue/indoors/shelter/town
 	icon_state = "town"
 	droning_sound = 'sound/music/area/townstreets.ogg'
 	droning_sound_dusk = 'sound/music/area/septimus.ogg'
 	droning_sound_night = 'sound/music/area/sleeping.ogg'
-
+	area_sniff_message = "You smell the stench of the town."
 
 /area/rogue/outdoors/town/sargoth
 	name = "outdoors"
@@ -319,6 +324,7 @@ GLOBAL_LIST_INIT(roguetown_areas_typecache, typecacheof(list(/area/rogue/indoors
 	droning_sound_night = null
 	converted_type = /area/rogue/indoors/shelter/town/sargoth
 	first_time_text = "SARGOTH"
+
 /area/rogue/indoors/shelter/town/sargoth
 	icon_state = "sargoth"
 	droning_sound = 'sound/music/area/sargoth.ogg'
@@ -344,6 +350,7 @@ GLOBAL_LIST_INIT(roguetown_areas_typecache, typecacheof(list(/area/rogue/indoors
 	icon_state = "manor"
 	keep_area = TRUE
 	town_area = TRUE
+	area_sniff_message = "You smell the stench of the keep."
 
 /area/rogue/indoors/shelter/town/roofs
 	icon_state = "roofs"
@@ -381,8 +388,7 @@ GLOBAL_LIST_INIT(roguetown_areas_typecache, typecacheof(list(/area/rogue/indoors
 	icon_state = "dream"
 	first_time_text = "Abyssal Dream"
 	deathsight_message = "a vast, endless dreamscape"
-
-
+	area_sniff_message = "YOU SMELL ANCIENT HORROR."
 
 /area/rogue/indoors/deathsedge
 	name = "Death's Precipice"

--- a/code/game/area/terrorbog.dm
+++ b/code/game/area/terrorbog.dm
@@ -34,6 +34,7 @@
 	deathsight_message = "a wretched, fetid bog"
 	detail_text = DETAIL_TEXT_TERRORBOG
 	var/list/recent_intruders = list()
+	area_sniff_message = "You smell peat."
 
 /area/rogue/outdoors/bog/Entered(atom/movable/AM)
 	..()
@@ -46,7 +47,7 @@
 
 	if(L in GLOB.active_hags)
 		return
-	
+
 	GLOB.bogged_players += L.real_name
 
 	if(recent_intruders[L] && recent_intruders[L] > world.time)
@@ -76,6 +77,7 @@
 	droning_sound_dusk = null
 	droning_sound_night = null
 	deathsight_message = "a wretched, fetid bog"
+	area_sniff_message = "You smell peat, but muted."
 
 /area/rogue/outdoors/bog/north
 	name = "Northern Terrorbog"
@@ -109,6 +111,7 @@
 	droning_sound_night = null
 	deathsight_message = "a nasty wicked place deep betwixt the roots of the bog"
 	var/list/recent_intruders = list()
+	area_sniff_message = "You smell the fey."
 
 /area/rogue/indoors/shelter/bog_hag/root_maze
 	name = "The Deepest Roots"
@@ -128,7 +131,7 @@
 		return
 
 	GLOB.bogged_players += L.real_name
-	
+
 	if(recent_intruders[L] && recent_intruders[L] > world.time)
 		return
 

--- a/code/game/area/undercoast.dm
+++ b/code/game/area/undercoast.dm
@@ -8,6 +8,7 @@
 	soundenv = 8
 	deathsight_message = "a dark cave where Abyssor's dream echoes"
 	detail_text = DETAIL_TEXT_UNDERCOAST
+	area_sniff_message = "You smell the sea and the damp, murky depths."
 
 /area/rogue/indoors/cave/underhamlet
 	name = "The Underhamlet"

--- a/code/game/area/underdark.dm
+++ b/code/game/area/underdark.dm
@@ -27,6 +27,7 @@
 	)
 	converted_type = /area/rogue/outdoors/caves
 	deathsight_message = "an acid-scarred depths"
+	area_sniff_message = "You smell mushrooms."
 	detail_text = DETAIL_TEXT_UNDERDARK
 	threat_region = THREAT_REGION_UNDERDARK
 
@@ -46,3 +47,4 @@
 	droning_sound_dusk = null
 	droning_sound_night = null
 	detail_text = DETAIL_TEXT_MELTED_UNDERCITY
+	area_sniff_message = "You smell acid."

--- a/code/game/area/undergrove.dm
+++ b/code/game/area/undergrove.dm
@@ -22,6 +22,7 @@
 	converted_type = /area/rogue/outdoors/caves
 	deathsight_message = "root-bound caverns"
 	detail_text = DETAIL_TEXT_UNDERGROVE
+	area_sniff_message = "You smell roots and the murky depths."
 
 /area/rogue/under/cavewet/bogcaves
 	name = "The Undergrove"

--- a/code/game/area/woods.dm
+++ b/code/game/area/woods.dm
@@ -28,6 +28,7 @@
 	deathsight_message = "somewhere in the wilds"
 	threat_region = THREAT_REGION_AZURE_GROVE
 	detail_text = DETAIL_TEXT_AZURE_GROVE
+	area_sniff_message = "You smell old, mighty trees."
 
 /area/rogue/indoors/shelter/woods
 	name = "Azure Grove"
@@ -37,7 +38,7 @@
 	droning_sound_night = 'sound/music/area/forestnight.ogg'
 	threat_region = THREAT_REGION_AZURE_GROVE
 	deathsight_message = "somewhere in the wilds"
-
+	area_sniff_message = "You smell old, mighty trees... But someone cut them into planks."
 
 /area/rogue/outdoors/woods/north
 	name = "Azure Grove - North"

--- a/code/modules/antagonists/roguetown/villain/gnoll/gnoll_spells.dm
+++ b/code/modules/antagonists/roguetown/villain/gnoll/gnoll_spells.dm
@@ -15,9 +15,9 @@
 
 /obj/effect/proc_holder/spell/invoked/gnoll_sniff
 	name = "Track"
-	desc = "Graggar has some worthy folks for you, hunt them down! Cast on self to set target, cast to track target, cast on a person to remember their scent temporarily."
+	desc = "Graggar has some worthy folks for you, hunt them down! Cast on self to set target, cast to track target, cast on a person to remember their scent temporarily. Does not break stealth on use."
 	recharge_time = 0.5 SECONDS
-	chargetime = 0.1 SECONDS
+	chargetime = 0
 	overlay_icon = 'icons/mob/actions/gnollmiracles.dmi'
 	action_icon = 'icons/mob/actions/gnollmiracles.dmi'
 	overlay_state = "sniff"
@@ -39,6 +39,7 @@
 	)
 	var/mob/living/tracked_target = null
 	var/shown_hunt_disclaimer = FALSE
+	breaks_invisibility = FALSE
 
 /obj/effect/proc_holder/spell/invoked/gnoll_sniff/cast(list/targets, mob/user)
 	var/mob/living/target = targets[1]
@@ -101,6 +102,12 @@
 
 	var/turf/user_turf = get_turf(user)
 	var/turf/target_turf = get_turf(tracked_target)
+	var/area/target_area = get_area(target_turf)
+	if(target_area)
+		if(target_area.area_sniff_message)
+			to_chat(user, span_notice("[target_area.area_sniff_message]"))
+		else
+			to_chat(user, span_notice("The scent of the area is difficult to discern."))
 
 	if(user_turf.z != target_turf.z)
 		to_chat(user, span_notice("The scent of [tracked_target.real_name] drifts from [user_turf.z > target_turf.z ? "below" : "above"] you."))

--- a/code/modules/clothing/rogueclothes/armor/special/vampiric_comp.dm
+++ b/code/modules/clothing/rogueclothes/armor/special/vampiric_comp.dm
@@ -132,6 +132,7 @@
 		landing_turf = locate(spawn_location.x + 1, spawn_location.y, spawn_location.z)
 	var/obj/effect/temp_visual/dream_shard/vampiric/S = new shard_type(spawn_location, 10 SECONDS, shard_repair_value, landing_turf)
 	S.creator_ref = WEAKREF(parent)
+	S.setup_owner_outline(parent)
 
 /datum/component/vampiric_striker/proc/on_shard_crossed(obj/effect/temp_visual/dream_shard/S, atom/movable/AM)
 	SIGNAL_HANDLER
@@ -192,6 +193,8 @@
 	/// Weak reference to the player mob who spawned this shard
 	var/datum/weakref/creator_ref
 	effect_color = "#440101"
+	/// Client image overlay given exclusively to the creator to show an outline
+	var/image/outline_image
 
 /obj/effect/temp_visual/dream_shard/vampiric/Crossed(atom/movable/AM)
 	if(!creator_ref)
@@ -223,3 +226,27 @@
 	E.color = effect_color
 	playsound(creator, 'sound/magic/magic_nulled.ogg', 70, TRUE)
 	qdel(src)
+
+/obj/effect/temp_visual/dream_shard/vampiric/proc/setup_owner_outline(mob/living/owner)
+	if(!owner?.client)
+		return
+
+	var/alpha_hex = "BF"
+	var/final_color = effect_color ? effect_color : "#d40000"
+	if(length(final_color) == 7 && copytext(final_color, 1, 2) == "#")
+		final_color = "[final_color][alpha_hex]"
+
+	var/image/I = image(icon = icon, loc = src, icon_state = icon_state, layer = layer + 0.05)
+	I.filters += filter(type = "outline", size = 2, color = final_color)
+
+	outline_image = I
+	owner.client.images += outline_image
+
+/obj/effect/temp_visual/dream_shard/vampiric/Destroy()
+	if(outline_image)
+		var/mob/living/creator = creator_ref?.resolve()
+		if(creator?.client)
+			creator.client.images -= outline_image
+		qdel(outline_image)
+		outline_image = null
+	return ..()

--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -41,6 +41,7 @@
 	var/ignore_armor_penalty = FALSE
 
 	var/skipcharge = FALSE
+	var/breaks_invisibility = TRUE
 
 /obj/effect/proc_holder/Initialize(mapload)
 	. = ..()
@@ -608,14 +609,15 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 	before_cast(targets, user = user)
 	if(user && user.ckey)
 		user.log_message(span_danger("cast the spell [name]."), LOG_ATTACK)
-	if(user.mob_timers[MT_INVISIBILITY] > world.time)
-		user.mob_timers[MT_INVISIBILITY] = world.time
-		user.update_sneak_invis(reset = TRUE)
-	if(isliving(user))
-		var/mob/living/L = user
-		if(L.rogue_sneaking)
-			L.mob_timers[MT_FOUNDSNEAK] = world.time
-			L.update_sneak_invis(reset = TRUE)
+	if(breaks_invisibility)
+		if(user.mob_timers[MT_INVISIBILITY] > world.time)
+			user.mob_timers[MT_INVISIBILITY] = world.time
+			user.update_sneak_invis(reset = TRUE)
+		if(isliving(user))
+			var/mob/living/L = user
+			if(L.rogue_sneaking)
+				L.mob_timers[MT_FOUNDSNEAK] = world.time
+				L.update_sneak_invis(reset = TRUE)
 	if(cast(targets, user = user))
 		// Self spells bypass the ranged_ability click pipeline, which is where
 		// releasedrain stamina cost is normally applied (via mob_helpers.dm).


### PR DESCRIPTION
## About The Pull Request
- Gnolls now get a message on certain areas providing a description of the area's scent. This is mostly so gnolls can determine if someone is in town or not, which should make hunting a little easier.
- Using gnoll track no longer breaks stealth.
- Shards created by gnolls now have a red outline only visible to the gnoll that can pick the shard up.

## Testing Evidence
<img width="938" height="656" alt="image" src="https://github.com/user-attachments/assets/d9dc6d66-f508-41e3-8203-1bed57df727a" />

## Why It's Good For The Game
Hunting people in town is high risk, but not every target in the south is going to be in town. This gives gnolls a bit more information so they can determine who they want to hunt. Breaking stealth just for tracking a target kind of defeats the purpose of stealth. This wasn't ever really intended.

Finally, the outline is good for gnolls fighting in groups, so they do not destroy each other's shards by accident trying to pick up their own.

## Changelog

:cl:
qol: Gnoll track no longer breaks stealth
qol: Gnoll track now provides a scent description of the area a target is in
qol: Gnoll shards are now hilighted for the gnoll who owns a shard
/:cl:

