### PR TITLE
lets go pracitce. .m edicine. .. - allows the doctor's bag to carry vials

### DIFF
--- a/code/datums/components/storage/storage_types.dm
+++ b/code/datums/components/storage/storage_types.dm
@@ -23,15 +23,16 @@
 /datum/component/storage/concrete/roguetown/surgery_bag/New(datum/P, ...)
 	. = ..()
 	can_hold = typecacheof(list(
-	/obj/item/rogueweapon/surgery,
 	/obj/item/needle,
+	/obj/item/rogueweapon/surgery,
 	/obj/item/rogueweapon/huntingknife/stoneknife,
-	/obj/item/reagent_containers/glass/bottle/rogue/beer,
-	/obj/item/reagent_containers/glass/bottle/alchemical/fermented_crab,
-	/obj/item/reagent_containers/glass/bottle/rogue/healthpot/zarum,
-	/obj/item/natural/worms/leech,
 	/obj/item/reagent_containers/lux,
 	/obj/item/reagent_containers/lux_impure,
+	/obj/item/reagent_containers/glass/bottle/rogue/beer,
+	/obj/item/reagent_containers/glass/bottle/rogue/healthpot/zarum,
+	/obj/item/reagent_containers/glass/bottle/alchemical,
+	/obj/item/reagent_containers/glass/bottle/alchemical/fermented_crab,
+	/obj/item/natural/worms/leech,
 	/obj/item/natural/bundle/cloth/bandage,
 	/obj/item/natural/cloth))
 


### PR DESCRIPTION
## About The Pull Request

* The Doctor's Bag can now carry vials.

## Testing Evidence

* It's chill, just a one-line change.

## Why It's Good For The Game

* Allows for Physicians and other doctorly sorts to better stock their bags with vials of varyingly medicinal qualities.

## Changelog

:cl:
balance: The Doctor's Bag can now carry vials of all types.
/:cl: