### PR TITLE
[fix] revenant vision fix

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1357,3 +1357,12 @@
 	if((cmode) && (mind) && (!handcuffed) && (stat == CONSCIOUS))
 		return 0
 	. = ..()
+
+// reset_perspective is called for things like z-level transitions. however, revs specifically need to not have their perspective reset if their
+// body moves away from their head; otherwise you get rev bodies with full sight
+/mob/living/carbon/reset_perspective(atom/A)
+	var/obj/item/organ/dullahan_vision/vision = getorganslot(ORGAN_SLOT_HUD)
+	var/datum/species/dullahan/our_species = dna?.species
+	if(!A && istype(vision) && vision.viewing_head && istype(our_species))
+		return ..(our_species.my_head)
+	return ..()


### PR DESCRIPTION
## About The Pull Request
revenants going up/down zlevels broke their vision by resetting their perspective to their body allowing them to see while headless. that's bad. this fixes that by overriding reset_perspective on mob/living/carbon to check for rev heads and if one is present it resets to the head instead of the body

## Testing Evidence
<img width="337" height="26" alt="image" src="https://github.com/user-attachments/assets/1033bb5d-7670-468c-b9b3-7a1697e6cb20" />
<br/>
<img width="494" height="417" alt="image" src="https://github.com/user-attachments/assets/4c155cd9-32f5-4ce5-bbaf-9a4e32155a43" />

## Why It's Good For The Game
no more revs seeing from their body that's meant to be blind

## Changelog

:cl:
fix: Revenants no longer become able to see from their body when moving through z-levels or other specific circumstances.
/:cl: