### PR TITLE
fixes Gilbranze halfplate showing as luxplate tier heretical

### DIFF
--- a/code/modules/clothing/rogueclothes/armor/plate.dm
+++ b/code/modules/clothing/rogueclothes/armor/plate.dm
@@ -152,9 +152,6 @@
 	item_state = "ancientplate"
 	smeltresult = /obj/item/ingot/aaslag
 
-/obj/item/clothing/suit/roguetown/armor/plate/paalloy/get_examine_highlight_status()
-	return list(EXAMINEHIGHLIGHT_HERESYSEVERITY_ALARMING, HERESYDESC_ZIZO_ARTIFICE)
-
 /obj/item/clothing/suit/roguetown/armor/plate/paalloy/artificer
 	name = "artificed half-plate"
 	desc = "Forbidden knowledge, resurrected into a weightless vessel of gilbranze-and-magicka. It holds a slot for an arcyne meld to power it."


### PR DESCRIPTION
## About The Pull Request
Removes the `HERESYSEVERITY_ALARMING` examine from ancient halfplate armor.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="795" height="505" alt="image" src="https://github.com/user-attachments/assets/3cca32ab-3f4a-4a4d-bb55-126ee910cf02" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
no other ancient armor (that I could find) is marked like this. I discussed it in the dev chat and double checked with loreheads. Conclusion is that Gilbranze should not be marked as it is just metal, and was probably a mistake when the artificer halfplate was marked as heretical as its a base item in that craft.

To summarize, Gilbranze is older than Zizo, but knowledge of how to make *new* Gilbranze is lost to time. Halfplate as an armor type also wasn't invented by Zizo. Really the only association to Zizo is that she brings back a lot of dead people wearing it, which is kind of like if you got rear ended only by Honda Civics from 1980. Which is weird, maybe, but you shouldn't see a honda civic from 1980 and think "im going to be rammed". And anyways that would mean *everything gilbranze* should be marked in some way (probably odd), which isn't the case for anything else.

Correct me if I'm wrong tho. It's just a steel reskin mechanically anyways that mostly spawns on greater undead and in some dungeons.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
remove: removed the high severity marking on ancient halfplate armor. Artificer halfplate remains just as heretical as it was before.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
