### PR TITLE
BUGFIX: Fixes merchant's pq requirments on latejoin

### DIFF
--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -277,11 +277,10 @@ GLOBAL_LIST_INIT(roleplay_readme, world.file2list("strings/rt/rp_prompt.txt"))
 	if(job.plevel_req > client.patreonlevel())
 		return JOB_UNAVAILABLE_GENERIC
 	#ifdef USES_PQ
-	if(!job.required || latejoin)
-		if(!isnull(job.min_pq) && (get_playerquality(ckey) < job.min_pq))
-			return JOB_UNAVAILABLE_PQ
-		if(!isnull(job.max_pq) && (get_playerquality(ckey) > job.max_pq))
-			return JOB_UNAVAILABLE_PQ
+	if(!isnull(job.min_pq) && (get_playerquality(ckey) < job.min_pq))
+		return JOB_UNAVAILABLE_PQ
+	if(!isnull(job.max_pq) && (get_playerquality(ckey) > job.max_pq))
+		return JOB_UNAVAILABLE_PQ
 	#endif
 	var/datum/species/pref_species = client.prefs.pref_species
 	if(length(job.forbidden_races) && (pref_species.type in job.forbidden_races))


### PR DESCRIPTION
## About The Pull Request

Previously any player with any amount of PQ could join as a merchant if used latejoin button. Now it's fixed. Not like anyone could not get ONE PQ, but you never know

## Testing Evidence

i totally tested that on local, trust

## Why It's Good For The Game

bugs are bad

## Changelog


:cl:
fix: fixed merchant's pq requirements not working on latejoin
/:cl:
