### PR TITLE
summoned skeletons no longer have vices

### DIFF
--- a/code/modules/mob/living/carbon/human/npc/skeleton/skeleton.dm
+++ b/code/modules/mob/living/carbon/human/npc/skeleton/skeleton.dm
@@ -133,6 +133,11 @@ GLOBAL_LIST_INIT(skeleton_aggro, list(
 /mob/living/carbon/human/species/skeleton/npc/no_equipment/after_creation()
 	..()
 	STAINT = 1
+	if(src.charflaws)
+		for(var/datum/charflaw/cf in src.charflaws)
+			src.charflaws.Remove(cf)
+			QDEL_NULL(cf)
+
 
 /mob/living/carbon/human/species/skeleton/no_equipment
 	skel_outfit = null


### PR DESCRIPTION
## About The Pull Request
- on creation /equipmentless skeletons have charflaws removed
- yeah thats it
it was already hard cus become_skeleton removes ur vices n stuff. this just removes it from the skeletons made by the dark crystal / raise undead spell. afaik theres nothing else that like. controls that?
i also dont know if skeletons are supposed to get critical weakness as a "flaw" or something as they still had some other weird adjacent thing i saw in the traits and its kinda confusing. please @ me if i've missed something and/or i need to double check this before merge
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
- spawned various skeletons from dark heart and lich
- also spaned npc skeleetons
- everythin SEEMED to work as intended?
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
- no more targeted skeleton
- no more hunted skeleton
- no more wanted-- actually im not sure if this'll 100% stop wanted skeletons bc that probably happens on spawn before the proc goes off. idk i cant do shit abt htat one
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: summoned skeletons no longer have vices
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
