### PR TITLE
The black rot is kind of a big thing sire

### DIFF
--- a/code/__DEFINES/highlight_examine_defines.dm
+++ b/code/__DEFINES/highlight_examine_defines.dm
@@ -36,6 +36,10 @@
 #define HERESYDESC_DREAMWALKER_WEAPON "An enchanced weapon from Abyssor's dream, wielded by Abyssor's cursed - the enigmatic and violent Dreamwalkers"
 #define HERESYDESC_DREAMWALKER_ARMOR "An armor piece from Abyssor's dream, worn by Abyssor's cursed - the enigmatic and violent Dreamwalkers"
 
+// Pestran Herecy
+#define HERESYDESC_PESTRA_WEAPON "An unsanctioned weapon created by heretical Pestran secrets to spread her black rot"
+#define HERESYDESC_BLACK_ROT "A stabilised form of the black rot, it is extremely dangerous should not be seen outside of santified hands"
+
 // Misc items / Donor
 #define HERESYDESC_GRONN "A symbol of the North's archaic beliefs"
 #define HERESYDESC_GILBRANZE_ARTIFICE "A blade of polished gilbranze in extraordinary quality. Someone's Artifice..?" // ATICIUS DONOR

--- a/code/__DEFINES/highlight_examine_defines.dm
+++ b/code/__DEFINES/highlight_examine_defines.dm
@@ -37,8 +37,8 @@
 #define HERESYDESC_DREAMWALKER_ARMOR "An armor piece from Abyssor's dream, worn by Abyssor's cursed - the enigmatic and violent Dreamwalkers"
 
 // Pestran Herecy
-#define HERESYDESC_PESTRA_WEAPON "An unsanctioned weapon created by heretical Pestran secrets to spread her black rot"
-#define HERESYDESC_BLACK_ROT "A stabilised form of the black rot, it is extremely dangerous should not be seen outside of santified hands"
+#define HERESYDESC_PESTRA_WEAPON "An unsanctioned weapon created by heretical Pestran secrets to spread the black rot"
+#define HERESYDESC_BLACK_ROT "A stabilised form of the black rot, it is extremely dangerous should not be seen outside of sanctified hands"
 
 // Misc items / Donor
 #define HERESYDESC_GRONN "A symbol of the North's archaic beliefs"

--- a/code/modules/roguetown/roguemachine/heartbeast/fleshcrafting/flesh_rose.dm
+++ b/code/modules/roguetown/roguemachine/heartbeast/fleshcrafting/flesh_rose.dm
@@ -6,6 +6,9 @@
 	w_class = WEIGHT_CLASS_SMALL
 	var/effect_desc = "You know this can be implanted with the cure rot miracle within a follower of Pestra. It protects her followers."
 
+/obj/item/black_rose/get_examine_highlight_status()
+	return list(EXAMINEHIGHLIGHT_HERESYSEVERITY_ODD, HERESYDESC_BLACK_ROT)
+
 /obj/item/black_rose/examine(mob/user)
 	. = ..()
 	if(iscarbon(user))

--- a/code/modules/spells/roguetown/acolyte/pestra/pestra_weapons.dm
+++ b/code/modules/spells/roguetown/acolyte/pestra/pestra_weapons.dm
@@ -9,6 +9,9 @@
 	// Identical to dagger except it uses the heavier cut to help build rot.
 	possible_item_intents = list(/datum/intent/dagger/thrust, /datum/intent/dagger/cut/heavy, /datum/intent/dagger/thrust/pick, /datum/intent/dagger/sucker_punch)
 
+/obj/item/rogueweapon/huntingknife/idagger/steel/rotfang/get_examine_highlight_status()
+	return list(EXAMINEHIGHLIGHT_HERESYSEVERITY_ALARMING, HERESYDESC_PESTRA_WEAPON)
+
 /obj/item/rogueweapon/huntingknife/idagger/steel/rotfang/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/ichor_stained)
@@ -18,6 +21,9 @@
 	desc = "A malevolent little ball of stabilized black rot, siphoned from the heartbeast."
 	icon = 'icons/obj/structures/heart_items.dmi'
 	icon_state = "ichor"
+
+/obj/item/reagent_containers/powder/black_ichor/get_examine_highlight_status()
+	return list(EXAMINEHIGHLIGHT_HERESYSEVERITY_ODD, HERESYDESC_BLACK_ROT)
 
 /datum/component/ichor_stained
 	dupe_mode = COMPONENT_DUPE_UNIQUE


### PR DESCRIPTION
## About The Pull Request

Adds suitable herecy descriptions to Pestra's black rot.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

Its a few lines sire. but (*yes these are old and have spelling errors, corrected*)

<img width="730" height="817" alt="Screenshot 2026-09-04 174351" src="https://github.com/user-attachments/assets/319dc978-fc61-4284-bd32-aaef7e89dafa" />


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

The black rot is Pestra's strongest affliction, a literal divine-blessed plague that inflicts a horrible way to die.

It probably should not be in unauthorised hands.

The malpractioner wretch role is literally using heretical arts, their dagger shouldn't be kept, or freely handed around.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Pestra's black rot items are correctly marked as oddly heretical.
balance: the heretical rotfang dagger that literally says its herecy, is now reasonably an alarmingly suspicious heretical item.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
