### PR TITLE
Update Avatar of Rage

### DIFF
--- a/code/modules/spells/pantheon/inhumen/graggar.dm
+++ b/code/modules/spells/pantheon/inhumen/graggar.dm
@@ -413,7 +413,7 @@
 
 /datum/action/cooldown/spell/graggar/avatar
 	name = "Avatar of Rage"
-	desc = "Unleash your true rage for an entire MINUTE, making you immune to slowdown from pain, uncapping strength and granting +3 on top. Removes stun-adjacent & stun effects which is only part that works on a GNOLL"
+	desc = "Unleash your true rage for an entire MINUTE, making you immune to slowdown from pain, uncapping strength and granting +3 on top. Removes stun-adjacent & stun effects as well can be cast while incapacitated."
 	button_icon_state = "avatar"
 	sound = 'sound/magic/graggar_rage.ogg'
 	glow_intensity = GLOW_INTENSITY_MEDIUM
@@ -431,12 +431,14 @@
 
 	charge_required = TRUE
 	charge_slowdown = 2
-	charge_time = 2 SECONDS
+	charge_time = 1 SECONDS
 	cooldown_time = 6 MINUTES
 
-	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC | SPELL_REQUIRES_HUMAN | SPELL_REQUIRES_SAME_Z
+	check_flags = AB_CHECK_CONSCIOUS
+	spell_requirements =	SPELL_REQUIRES_HUMAN | SPELL_REQUIRES_SAME_Z
 
 	var/static/list/purged_effects = list(
+	/datum/status_effect/incapacitating/off_balanced,
 	/datum/status_effect/incapacitating/immobilized,
 	/datum/status_effect/incapacitating/paralyzed,
 	/datum/status_effect/incapacitating/stun,
@@ -450,9 +452,8 @@
 		return FALSE
 	for(var/effect in purged_effects)
 		user.remove_status_effect(effect)
-	if(!isgnoll(user))//Gnolls don't get this
-		user.apply_status_effect(/datum/status_effect/buff/bloodrage)
-		user.emote("warcry")
+	user.apply_status_effect(/datum/status_effect/buff/bloodrage)
+	user.emote("warcry")
 	return TRUE
 
 #define BLOODRAGE_FILTER "bloodrage"


### PR DESCRIPTION
## About The Pull Request

It now fully works on gnolls, can be actually used while incapacitated (except when you get full on knocked out), works on off balance, reduced cast time to 1 second.

## Testing Evidence

Meeh

## Why It's Good For The Game

IG
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Avatar of Rage (graggar T4) now fully works on gnolls, can be actually used while incapacitated (except when you get full on knocked out), works on off balance, reduced cast time to 1 second.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
