### PR TITLE
Re-Allow Second Chance Wretches

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
@@ -28,7 +28,7 @@
 	always_show_on_latechoices = TRUE
 	job_reopens_slots_on_death = FALSE
 	same_job_respawn_delay = 1 MINUTES
-	virtue_restrictions = list(/datum/virtue/heretic/zchurch_keyholder, /datum/virtue/combat/second_chance) //all wretch classes automatically get this /// oh boi incoming a massive tsunami of hatemails for this
+	virtue_restrictions = list(/datum/virtue/heretic/zchurch_keyholder) //all wretch classes automatically get this ///
 	job_traits = list(TRAIT_STEELHEARTED, TRAIT_OUTLAW, TRAIT_HERESIARCH, TRAIT_SELF_SUSTENANCE, TRAIT_ZURCH)
 	job_subclasses = list(
 		/datum/advclass/wretch/licker,


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

Re-allows Wretches to benefit from the Second Chance combat virtue. 

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

<img width="1540" height="724" alt="Capture" src="https://github.com/user-attachments/assets/e37c94af-6754-4ebe-bef9-16570e95e1da" />

When playing a Licker, Second Chance will disable itself entirely.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

Second Chance was barred from wretches as part of adding Blackblooded to the game. Some of the stated reasoning included that Blackblood could not be allowed to occur on vampires. Blackblooded has checks that make it deactivate if a vampire/skeleton/other inappropriate character has it. Therefore, I am reverting wretches to their previous Second Chance accessibility.

I have received permission from the developer of Second Chance to make such a PR.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
refactor: Reverted wretches to previous Second Chance availability
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
