### PR TITLE
Loadout Restoration

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -1422,8 +1422,12 @@ GLOBAL_LIST_EMPTY(personal_objective_minds)
 								I.detail_color = metadata["detail_color"]
 							if(metadata["altdetail_color"] && I.altdetail_tag)
 								I.altdetail_color = metadata["altdetail_color"]
-							if(metadata["custom_name"])
+							if(metadata["custom_name_parsed"])
+								I.name = metadata["custom_name_parsed"] // this is sanitized when we apply the markdown procesor
+							else if(metadata["custom_name"])
 								I.name = sanitize(metadata["custom_name"])
-							if(metadata["custom_desc"])
+							if(metadata["custom_desc_parsed"])
+								I.desc = metadata["custom_desc_parsed"] // this is sanitized when we apply the markdown procesor
+							else if(metadata["custom_desc"])
 								I.desc = html_encode(metadata["custom_desc"])
 							I.update_icon()

--- a/code/modules/client/loadout_menu.dm
+++ b/code/modules/client/loadout_menu.dm
@@ -9,6 +9,7 @@
 /datum/loadout_menu
 	var/client/owner
 	var/list/gear_list = list()
+	var/preview = FALSE
 
 /datum/loadout_menu/New(client/C)
 	owner = C
@@ -91,13 +92,21 @@
 		var/list/meta = gear_list[item_name]
 		if(!islist(meta))
 			meta = list()
+		if(meta["custom_name"] && !meta["custom_name_parsed"]) // handling for older savefiles
+			meta["custom_name_parsed"] = sanitize(meta["custom_name"])
+			gear_list[item_name] = meta
+		if(meta["custom_desc"] && !meta["custom_desc_parsed"]) // handling for older savefiles
+			meta["custom_desc_parsed"] = sanitize(meta["custom_desc"])
+			gear_list[item_name] = meta
 		selected += list(list(
 			"name" = item_name,
 			"color" = meta["color"],
 			"detail_color" = meta["detail_color"],
 			"altdetail_color" = meta["altdetail_color"],
 			"custom_name" = meta["custom_name"],
-			"custom_desc" = meta["custom_desc"]
+			"custom_name_parsed" = meta["custom_name_parsed"],
+			"custom_desc" = meta["custom_desc"],
+			"custom_desc_parsed" = meta["custom_desc_parsed"]
 		))
 
 	var/triumph_discount = (is_donator(user.ckey) || user?.client?.holder) ? LOADOUT_TRIUMPH_DISCOUNT : 0
@@ -106,6 +115,7 @@
 	data["total_triumph_cost"] = total_triumph_cost
 	data["effective_triumph_cost"] = max(0, total_triumph_cost - triumph_discount)
 	data["player_triumphs"] = user.get_triumphs() || 0
+	data["preview"] = preview
 	return data
 
 /datum/loadout_menu/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
@@ -175,8 +185,10 @@
 				gear_list[item_name] = meta
 			if(custom_name)
 				meta["custom_name"] = copytext(custom_name, 1, MAX_NAME_LEN)
+				meta["custom_name_parsed"] = parsemarkdown_basic(html_encode(meta["custom_name"]))
 			else
 				meta -= "custom_name"
+				meta -= "custom_name_parsed"
 			return TRUE
 
 		if("set_custom_desc")
@@ -190,8 +202,11 @@
 				gear_list[item_name] = meta
 			if(custom_desc)
 				meta["custom_desc"] = copytext(custom_desc, 1, LOADOUT_MAX_DESC_LEN)
+				meta["custom_desc_parsed"] = parsemarkdown_basic(html_encode(meta["custom_desc"]))
+				meta["custom_desc_parsed"] = replacetext(meta["custom_desc_parsed"], "\n", "<br/>") // markdown processor eats newlines otherwise
 			else
 				meta -= "custom_desc"
+				meta -= "custom_desc_parsed"
 			return TRUE
 
 		if("clear_all")
@@ -205,6 +220,9 @@
 				owner.prefs.update_pref_data_for_all_viewers()
 			ui.close()
 			return TRUE
+
+		if("preview")
+			preview = !preview
 
 #undef LOADOUT_MAX_POINTS
 #undef LOADOUT_MAX_DESC_LEN

--- a/code/modules/client/loadout_menu.dm
+++ b/code/modules/client/loadout_menu.dm
@@ -96,7 +96,7 @@
 			meta["custom_name_parsed"] = sanitize(meta["custom_name"])
 			gear_list[item_name] = meta
 		if(meta["custom_desc"] && !meta["custom_desc_parsed"]) // handling for older savefiles
-			meta["custom_desc_parsed"] = sanitize(meta["custom_desc"])
+			meta["custom_desc_parsed"] = html_encode(meta["custom_desc"])
 			gear_list[item_name] = meta
 		selected += list(list(
 			"name" = item_name,

--- a/tgui/packages/tgui/interfaces/LoadoutMenu.tsx
+++ b/tgui/packages/tgui/interfaces/LoadoutMenu.tsx
@@ -28,7 +28,9 @@ type SelectedItem = {
   detail_color: string | null;
   altdetail_color: string | null;
   custom_name: string | null;
+  custom_name_parsed: string | null;
   custom_desc: string | null;
+  custom_desc_parsed: string | null;
 };
 
 type Data = {
@@ -45,6 +47,7 @@ type Data = {
   total_triumph_cost: number;
   effective_triumph_cost: number;
   player_triumphs: number;
+  preview: boolean;
 };
 
 export const LoadoutMenu = () => {
@@ -151,7 +154,8 @@ const TweakRow = (props: {
   colorChannels: string[];
 }) => {
   const { itemName, meta, colorChannels } = props;
-  const { act } = useBackend<Data>();
+  const { act, data } = useBackend<Data>();
+  const { preview } = data;
 
   const [localName, setLocalName] = useState(meta?.custom_name || '');
   const [localDesc, setLocalDesc] = useState(meta?.custom_desc || '');
@@ -207,15 +211,29 @@ const TweakRow = (props: {
               <Box inline color="label" mr={0.5}>
                 Name:
               </Box>
-              <Input
-                width="200px"
-                maxLength={42}
-                placeholder="Custom name..."
-                value={localName}
-                onChange={(val) => setLocalName(val)}
-                onEnter={(val) => commitName(val)}
-                onBlur={(val) => commitName(val)}
-              />
+              {preview ? (
+                <Box
+                  as="span"
+                  style={{
+                    backgroundColor: 'var(--color-base-end)',
+                    border: '2px solid var(--section-separator-color)',
+                  }}
+                  dangerouslySetInnerHTML={{
+                    // yes yes i know. this is output from the markdown processor and is presanitized
+                    __html: meta?.custom_name_parsed,
+                  }}
+                />
+              ) : (
+                <Input
+                  width="200px"
+                  maxLength={42}
+                  placeholder="Custom name..."
+                  value={localName}
+                  onChange={(val) => setLocalName(val)}
+                  onEnter={(val) => commitName(val)}
+                  onBlur={(val) => commitName(val)}
+                />
+              )}
             </Box>
           </Box>
           {/* Line 3: Custom desc (full width textarea) */}
@@ -223,16 +241,31 @@ const TweakRow = (props: {
             <Box color="label" mb={0.3}>
               Description (max 1024 chars):
             </Box>
-            <TextArea
-              fluid
-              maxLength={1024}
-              height="60px"
-              placeholder="Custom description..."
-              value={localDesc}
-              onChange={(val) => setLocalDesc(val)}
-              onBlur={(val) => commitDesc(val)}
-              dontUseTabForIndent
-            />
+            {preview ? (
+              <Box
+                style={{
+                  backgroundColor: 'var(--color-base-end)',
+                  border: '2px solid var(--section-separator-color)',
+                }}
+                overflowY="scroll"
+                height="60px"
+                dangerouslySetInnerHTML={{
+                  // yes yes i know. this is output from the markdown processor and is presanitizeda
+                  __html: meta?.custom_desc_parsed,
+                }}
+              />
+            ) : (
+              <TextArea
+                fluid
+                maxLength={1024}
+                height="60px"
+                placeholder="Custom description..."
+                value={localDesc}
+                onChange={(val) => setLocalDesc(val)}
+                onBlur={(val) => commitDesc(val)}
+                dontUseTabForIndent
+              />
+            )}
           </Box>
         </Box>
       </Table.Cell>
@@ -307,6 +340,7 @@ const LoadoutDisplay = () => {
     is_donator,
     triumph_discount,
     donator_bonus,
+    preview,
   } = data;
 
   const currentCategory = activeCategory || categories[0] || '';
@@ -352,14 +386,23 @@ const LoadoutDisplay = () => {
           })}
         </Tabs>
       </Stack.Item>
-      {/* Search bar */}
+      {/* Search bar, preview toggle */}
       <Stack.Item>
-        <Input
-          fluid
-          placeholder="Search items..."
-          value={search}
-          onChange={(val) => setSearch(val)}
-        />
+        <Stack fill>
+          <Stack.Item grow>
+            <Input
+              fluid
+              placeholder="Search items..."
+              value={search}
+              onChange={(val) => setSearch(val)}
+            />
+          </Stack.Item>
+          <Stack.Item>
+            <Button color="good" fontSize={1.1} onClick={() => act('preview')}>
+              {preview ? '\u2713' : '\u25CB'} Toggle Preview
+            </Button>
+          </Stack.Item>
+        </Stack>
       </Stack.Item>
 
       {/* Items table */}


### PR DESCRIPTION
## About The Pull Request
In the great input sanitization debacle (which i caused by finding html injection exploits galore), the ability to add custom formatting to loadout item names/descs was removed. This was because the way it worked was just... direct html input from the user, which is very bad. This PR adds it back, as an actual feature: using the basic version of the markdown processor, properly sanitized.

## Testing Evidence
<img width="768" height="199" alt="image" src="https://github.com/user-attachments/assets/1b3fb229-2dff-4741-859a-8b63cc727d1d" />
<img width="796" height="205" alt="image" src="https://github.com/user-attachments/assets/141cf260-9d24-404f-9b22-8920f9d7903e" />
<img width="776" height="189" alt="image" src="https://github.com/user-attachments/assets/643ccfd8-a828-457d-a582-6ad2a211f5da" />
<img width="511" height="168" alt="image" src="https://github.com/user-attachments/assets/50e6882d-3e64-4844-8244-1d7c2e017de5" />
<img width="526" height="266" alt="image" src="https://github.com/user-attachments/assets/1e2a252d-fa54-4f7b-a01d-96093cda1231" /><br/>
Toggle preview mode on to see how your changes will look ingame, or off to edit. You can use this to kind of larp your items being weird, though it's very easily distinguishable at-a-glance from real heretical items. Best of both worlds, i think.
<br/><br/>
<img width="516" height="270" alt="image" src="https://github.com/user-attachments/assets/443e20cf-01fb-4b4e-9a0f-c911cd413952" /><br/>
This is an item on a character slot that hasn't been touched since the update. The "legacy" sanitized-direct-input (with no formatting) is applied just fine if you don't edit an item to update it to use the new system.

## Why It's Good For The Game
Applying formatting to loadout items was done very sparingly in general - very few players knew you could do it, and those that did used it very tastefully. Losing that was a pretty major blow to like two people, and I think it's a good facet of character expression to add back. Even if all it means is you'll occasionally see people with slightly fancier text in their lore items.

## Changelog

:cl:
add: Loadout item names/descs can now use markdown. Use this tastefully.
/:cl:
