### PR TITLE
Notorious F.I.X

### DIFF
--- a/code/modules/roguetown/roguemachine/questing/types/kill/quest_notorious_bounty.dm
+++ b/code/modules/roguetown/roguemachine/questing/types/kill/quest_notorious_bounty.dm
@@ -191,6 +191,8 @@
 		var/mob/dead/new_player/N = chosen
 		N.close_spawn_windows()
 	boss.key = chosen.key
+	if(boss.client && boss.ai_controller)
+		QDEL_NULL(boss.ai_controller)
 	RegisterSignal(boss, COMSIG_LIVING_DEATH, PROC_REF(on_player_boss_death))
 	// Prevent the mob from getting instaambushed
 	boss.ambushable = FALSE


### PR DESCRIPTION
## About The Pull Request

<img width="452" height="131" alt="image" src="https://github.com/user-attachments/assets/b10f12ac-2570-42a7-9b27-fcc1eba832f1" />
Notorious mobs had the mob ai controller on them which cancelled their getups whenever attacked. Also it made them forcesay and emote. Maybe it also did more unknown scary stuff. 

## Testing Evidence

Literally can't.

## Why It's Good For The Game

Stuff working is good.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Notorious contract mobs are no longer ai-piloted when taken by a player.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
