### PR TITLE
Restored & Improved Licker Obfuscation w/ Residency

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/licker.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/licker.dm
@@ -26,6 +26,7 @@
 			possible_classes += CHECKS
 
 		var/datum/advclass/C = input(H.client, "What is my class?", "Adventure") as null|anything in possible_classes
+		H.licker_subclass = C
 		C.equipme(H)
 
 		H.adjust_skillrank_up_to(/datum/skill/magic/blood, 4, TRUE)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -780,6 +780,8 @@
 		on_examine_face(user)
 		var/used_name = name
 		var/used_title = get_role_title()
+		if(HAS_TRAIT(src, TRAIT_RESIDENT) && used_title == "Licker" && licker_subclass)
+			used_title = licker_subclass.name
 		if(SSticker.regentmob == src)
 			used_title = "[used_title]" + " Regent"
 		var/display_as_wanderer = FALSE

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -165,6 +165,7 @@
 	var/job = null//Living
 	var/migrant_type = null
 	var/advjob = null
+	var/datum/advclass/licker_subclass = null
 
 	/// A list of factions that this mob is currently in, for hostile mob targetting, amongst other things
 	var/list/faction = list(FACTION_NEUTRAL)


### PR DESCRIPTION
## About The Pull Request

A pull request (https://github.com/Azure-Peak/Azure-Peak/pull/8662) allowed for "Well Off -> Residency" to reveal the sub/classes of the wandering classes, removing their obfuscation, but this adversely affected Wretches (Lickers in particular) by removing their obfuscation and thus allowing them to be easily meta'd.

This restores their obfuscation but in a different manner. Their chosen tertiary "subclass" is now their title when they take "Well Off -> Residency".

## Testing Evidence

**Before:**
- <img width="352" height="153" alt="43GaQKaSSQ" src="https://github.com/user-attachments/assets/49319bf5-62a7-43a6-a54c-63cbca91ad10" />


**After:**
- <img width="370" height="184" alt="DGzjLZ4hjA" src="https://github.com/user-attachments/assets/6607cc69-cdb1-4a69-8977-17c465df0474" />
- <img width="363" height="153" alt="9XBrHhDmtb" src="https://github.com/user-attachments/assets/cfba5826-9712-4f21-b214-e15e49e075c3" />

## Why It's Good For The Game

Lickers, and similar antagonistic classes that I will fix if I find them, should NOT have their title obfuscation removed. 
No good-standing role-player will respect this upon examination, and if they will, I would be thoroughly surprised.

## Changelog

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:Fi
fix: Restores and improves the Wretch Licker's title obfuscation when they take the "Well Off -> Residency" virtue.
/:cl:
