### PR TITLE
Devotion Bugfix Package 6 Act 1

### DIFF
--- a/code/game/objects/structures/fluff.dm
+++ b/code/game/objects/structures/fluff.dm
@@ -1166,10 +1166,8 @@
 	var/mob/living/living_user = user
 	if(user.mind.assigned_role == "Bishop")
 		. += span_info("As the Bishop, you can marry two people by having them both bite an apple, then offering it to the cross.")
-		. += span_info("The second person to bite the apple will take the last name of whoever bit it first.")
 	else if(istype(living_user) && HAS_TRAIT(living_user, TRAIT_MARRIAGE_CAPABLE))
 		. += span_info("As an Eoran, you can marry two people by having them both bite an apple, then offering it to the cross.")
-		. += span_info("The second person to bite the apple will take the last name of whoever bit it first.")
 
 /obj/structure/fluff/psycross/Initialize(mapload)
 	. = ..()
@@ -1327,6 +1325,8 @@
 	divine = FALSE
 	max_integrity = 350
 
+#define MARRIAGE_PROMPTS_TIMEOUT 30 // in seconds
+
 /obj/structure/fluff/psycross/attackby(obj/item/W, mob/user, params)
 	if(user.mind)
 		var/mob/living/living_user = user
@@ -1334,8 +1334,12 @@
 		if(HAS_TRAIT(living_user, TRAIT_MARRIAGE_CAPABLE))
 			if(istype(W, /obj/item/reagent_containers/food/snacks/grown/apple))
 				var/obj/item/reagent_containers/food/snacks/grown/apple/A = W
+				if(A.busy)
+					return ..()
 				//The MARRIAGE TEST BEGINS
 				if(A.bitten_names.len == 2)
+					A.rotprocess = null // stops it from rotting mid-ceremony
+					A.busy = TRUE // stops spamclicking mid-rite from doing anything
 					// Find the groom and bride from those who bit the apple
 					var/mob/living/carbon/human/thegroom
 					var/mob/living/carbon/human/thebride
@@ -1354,40 +1358,82 @@
 							thebride = C
 
 					if(!thegroom || !thebride)
-						to_chat(user, span_warn("nonexistent"))
+						to_chat(user, span_warn("Both of the betrothed must be within sight of the cross."))
+						A.busy = FALSE
 						return
 
-					// Astounding update: marriage now requires consent (it didn't before)
-					var/groom_confirm = input(thegroom, "Do you want to marry [thebride]?") as null|anything in list("Yes", "No")
-					if(groom_confirm != "Yes")
-						to_chat(user, span_warning("The groom has declined the marriage!"))
+					var/list/consent = list("groom" = FALSE, "bride" = FALSE)
+					var/list/participants = list(living_user, thebride, thegroom) // used for to_chats
+
+					to_chat(participants, span_green("The rite of marriage begins!")) // mostly so the eoran (who doesn't get any prompts) knows it's working
+
+					// this is going to look like black magic but basically i'm reinventing multithreading here
+					// to run two inputs at once, one for each of the betrothed. spawn() makes a copy of the proc
+					// including all variables, so normally you can't alter the state between spawn and main. HOWEVER
+					// lists are objects, so alterations maid to the list in a spawn()ed proc will affect the state of the main function
+					// we will use this trick several more times in this function
+					spawn(0)
+						consent["groom"] = input(thegroom, "Do you want to marry [thebride]?") as anything in list("Yes", "No")
+					spawn(0)
+						consent["bride"] = input(thebride, "Do you want to marry [thegroom]?") as anything in list("Yes", "No")
+
+					for(var/i in 1 to MARRIAGE_PROMPTS_TIMEOUT)
+						if(consent["groom"] && consent["bride"])
+							break
+						stoplag(1 SECONDS)
+						if(i == MARRIAGE_PROMPTS_TIMEOUT)
+							to_chat(participants, span_warning("Marriage prompt timeout!"))
+							A.busy = FALSE
+							return ..()
+
+					if((consent["groom"] != "Yes") || (consent["bride"] != "Yes"))
+						to_chat(participants, span_warning("One of the betrothed has declined the marriage!"))
+						A.busy = FALSE
 						return ..()
 
-					var/bride_confirm = input(thebride, "Do you want to marry [thegroom]?") as null|anything in list("Yes", "No")
-					if(bride_confirm != "Yes")
-						to_chat(user, span_warning("The bride has declined the marriage!"))
+					// setting last names in code is always going to be a buggy mess idk why anyone even tried? we can just prompt them
+					var/list/names = list("groom" = FALSE, "bride" = FALSE)
+					spawn(0)
+						var/gname = input(thegroom, "What would you like your new name to be (leave blank to leave your name unchanged)?")
+						names["groom"] = (gname || thegroom.real_name)
+					spawn(0)
+						var/bname = input(thebride, "What would you like your new name to be (leave blank to leave your name unchanged)?")
+						names["bride"] = (bname || thebride.real_name)
+
+					for(var/i in 1 to MARRIAGE_PROMPTS_TIMEOUT)
+						if(names["groom"] && names["bride"])
+							break
+						stoplag(1 SECONDS)
+						if(i == MARRIAGE_PROMPTS_TIMEOUT)
+							to_chat(participants, span_warning("Marriage prompt timeout!"))
+							A.busy = FALSE
+							return ..()
+
+					consent = list("groom" = FALSE, "bride" = FALSE)
+					to_chat(participants, span_green("[thegroom.real_name] will become [names["groom"]].\n[thebride.real_name] will become [names["bride"]].\n\nIs this acceptable?"))
+
+					// need to give a confirm in case one of them misinputs or the names look ugly next to each other or something
+					spawn(0)
+						consent["groom"] = input(thegroom, "Are these names acceptable?") as anything in list("Yes", "No")
+					spawn(0)
+						consent["bride"] = input(thebride, "Are these names acceptable?") as anything in list("Yes", "No")
+
+					for(var/i in 1 to MARRIAGE_PROMPTS_TIMEOUT)
+						if(consent["groom"] && consent["bride"])
+							break
+						stoplag(1 SECONDS)
+						if(i == MARRIAGE_PROMPTS_TIMEOUT)
+							to_chat(participants, span_warning("Marriage prompt timeout!"))
+							A.busy = FALSE
+							return ..()
+
+					if((consent["groom"] != "Yes") || (consent["bride"] != "Yes"))
+						to_chat(participants, span_warning("One of the betrothed has declined the marriage!"))
+						A.busy = FALSE
 						return ..()
 
-					// Horrible terrible last name necromancy (sometimes works)
-					var/groom_index = findtext(thegroom.real_name, " ")
-					var/bride_index = findtext(thebride.real_name, " ")
-					var/bride_firstname = bride_index ? copytext(thebride.real_name, 1, bride_index) : thebride.real_name
-
-					// Get groom's surname
-					var/groom_surname = copytext(thegroom.real_name, groom_index + 1)
-					if(!groom_index)
-						groom_surname = null
-					else if(findtext(thegroom.real_name, " of ") || findtext(thegroom.real_name, " the "))
-						groom_surname = null
-
-					var/final_bride_name
-					// Ask bride if she wants to take the groom's surname
-					if(groom_surname != null)
-						var/bride_surname_choice = input(thebride, "Do you want to take [thegroom]'s surname? (Your new name will be [bride_firstname] [groom_surname])") as null|anything in list("Yes", "No")
-						final_bride_name = (bride_surname_choice == "Yes") ? (bride_firstname + " " + groom_surname) : thebride.real_name
-
-					// Apply the changes
-					thebride.change_name(final_bride_name)
+					thegroom.change_name(names["groom"])
+					thebride.change_name(names["bride"])
 
 					thegroom.marriedto = thebride.real_name
 					thebride.marriedto = thegroom.real_name
@@ -1396,8 +1442,12 @@
 					thebride.adjust_triumphs(1)
 
 					priority_announce("[thegroom.real_name] has married [thebride.real_name]!", title = "Holy Union!", sound = 'sound/misc/bell.ogg')
+					record_round_statistic(STATS_MARRIAGES_MADE)
+					A.busy = FALSE
 					return ..()
 	return ..()
+
+#undef MARRIAGE_PROMPTS_TIMEOUT
 
 /obj/structure/fluff/psycross/copper/Destroy()
 	addomen("psycross")

--- a/code/modules/farming/produce.dm
+++ b/code/modules/farming/produce.dm
@@ -164,6 +164,7 @@
 	chopping_sound = TRUE
 	var/equippedloc = null
 	var/list/bitten_names = list()
+	var/busy = FALSE // this is set to true at the start of the marriage flow to prevent spamclicking from fucking everything up
 
 /obj/item/reagent_containers/food/snacks/grown/apple/On_Consume(mob/living/eater)
 	..()

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -1,5 +1,10 @@
 
 /mob/living/carbon/human/proc/change_name(new_name)
+	for(var/mob/living/carbon/human/H in GLOB.player_list)
+		var/datum/mind/M = H.mind
+		if(M && (real_name in M.known_people))
+			M.known_people[new_name] = M.known_people[real_name]
+			M.known_people.Remove(real_name)
 	real_name = new_name
 	SStreasury?.rename_account(src, new_name)
 

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/dullahan/dullahan_head.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/dullahan/dullahan_head.dm
@@ -69,7 +69,7 @@
 // Remove head.
 /datum/species/dullahan/help(mob/living/carbon/human/user, mob/living/carbon/human/target, datum/martial_art/attacker_style)
 	// Only do it if the precise selection is the head, to avoid mistakes. Also STRONG intent because this is irritating to do on accident.
-	if(target != user || user.zone_selected != BODY_ZONE_HEAD || !istype(user.rmb_intent, /datum/rmb_intent/strong)) 
+	if(target != user || user.zone_selected != BODY_ZONE_HEAD || !istype(user.rmb_intent, /datum/rmb_intent/strong))
 		return ..()
 
 	if(headless)
@@ -518,16 +518,21 @@
 	var/rendered = compose_message(src, message_language, message, , spans, message_mode)
 	for(var/_AM in listening)
 		var/atom/movable/AM = _AM
-		var/turf/listener_turf = get_turf(AM)
+		var/atom/movable/loc_check = AM // revs hear from their head, so we need to check the positioning of the head, not the body
+		if(isdullahan(AM))
+			var/mob/living/carbon/human/target = AM
+			var/datum/species/dullahan/target_species = target.dna.species
+			loc_check = target_species.headless ? target_species.my_head : AM
+		var/turf/listener_turf = get_turf(loc_check)
 		var/turf/listener_ceiling = get_step_multiz(listener_turf, UP)
 		if(listener_ceiling)
 			listener_has_ceiling = TRUE
 			if(istransparentturf(listener_ceiling))
 				listener_has_ceiling = FALSE
 		if((!Zs_too && !isobserver(AM)) || message_mode == MODE_WHISPER)
-			if(AM.z != src.loc.z)
+			if(loc_check.z != src.loc.z)
 				continue
-		if(Zs_too && AM.z != src.loc.z && !Zs_all)
+		if(Zs_too && loc_check.z != src.loc.z && !Zs_all)
 			if(!Zs_yell && !HAS_TRAIT(AM, TRAIT_KEENEARS))
 				if(listener_turf.z < speaker_turf.z && listener_has_ceiling)	//Listener is below the speaker and has a ceiling above them
 					continue
@@ -546,11 +551,18 @@
 					for(var/mob/living/MH in viewers(world.view, speaker_ceiling))
 						if(M == MH && MH.z == speaker_ceiling?.z)
 							speaker_obstructed = FALSE
+					for(var/obj/item/bodypart/head/dullahan/DH in range(world.view, speaker_ceiling))
+						if(DH.original_owner && M == DH.original_owner && DH.z == speaker_ceiling?.z)
+							speaker_obstructed = FALSE
 
 				if(!listener_has_ceiling)
 					for(var/mob/living/ML in viewers(world.view, listener_ceiling))
 						if(ML == src && ML.z == listener_ceiling?.z)
 							listener_obstructed = FALSE
+					for(var/obj/item/bodypart/head/dullahan/DH in range(world.view, listener_ceiling))
+						if(DH.original_owner && src == DH.original_owner && DH.z == listener_ceiling?.z)
+							speaker_obstructed = FALSE
+
 				if(listener_obstructed && speaker_obstructed)
 					continue
 		var/highlighted_message

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -450,7 +450,12 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	for(var/_AM in listening)
 		var/hearall = FALSE
 		var/atom/movable/AM = _AM
-		var/turf/listener_turf = get_turf(AM)
+		var/atom/movable/loc_check = AM // revs hear from their head, so we need to check the positioning of the head, not the body
+		if(isdullahan(AM))
+			var/mob/living/carbon/human/target = AM
+			var/datum/species/dullahan/target_species = target.dna.species
+			loc_check = target_species.headless ? target_species.my_head : AM
+		var/turf/listener_turf = get_turf(loc_check)
 		var/turf/listener_ceiling = get_step_multiz(listener_turf, UP)
 		if(istype(_AM, /obj/item/listeningdevice)) // Very evil snowflake code.
 			hearall = TRUE
@@ -460,7 +465,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 				listener_has_ceiling = FALSE
 		if(!hearall)
 			if((!Zs_too && !isobserver(AM)) || message_mode == MODE_WHISPER)
-				if(AM.z != src.z)
+				if(loc_check.z != src.loc.z)
 					continue
 		if(Zs_too && listener_turf.z != speaker_turf.z && !Zs_all)
 			if(!Zs_yell && !HAS_TRAIT(AM, TRAIT_KEENEARS) && !hearall)
@@ -481,11 +486,17 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 					for(var/mob/living/MH in viewers(world.view, speaker_ceiling))
 						if(M == MH && MH.z == speaker_ceiling?.z)
 							speaker_obstructed = FALSE
+					for(var/obj/item/bodypart/head/dullahan/DH in range(world.view, speaker_ceiling))
+						if(DH.original_owner && M == DH.original_owner && DH.z == speaker_ceiling?.z)
+							speaker_obstructed = FALSE
 
 				if(!listener_has_ceiling)
 					for(var/mob/living/ML in viewers(world.view, listener_ceiling))
 						if(ML == src && ML.z == listener_ceiling?.z)
 							listener_obstructed = FALSE
+					for(var/obj/item/bodypart/head/dullahan/DH in range(world.view, listener_ceiling))
+						if(DH.original_owner && src == DH.original_owner && DH.z == listener_ceiling?.z)
+							speaker_obstructed = FALSE
 				if(listener_obstructed && speaker_obstructed)
 					continue
 		var/highlighted_message

--- a/code/modules/roguetown/roguejobs/blacksmith/smelter.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/smelter.dm
@@ -126,7 +126,7 @@
 
 	if(attacking_item.firefuel)
 		. = ..()
-		if(!.) //False/null if using the item as fuel. If true, we want to try smelt it so go onto next segment.
+		if(!attacking_item || QDELING(attacking_item) || attacking_item.loc != user) //Tries to use the item as fuel. ..() returns true even if it does get consumed so we have to loc check.
 			return
 
 	if(attacking_item.smeltresult)


### PR DESCRIPTION
## About The Pull Request
(i guess we're just embracing the bit at this point)

Foxes a few bugs. Idk what else to put here
- Fixes, uh, all of marriage code. It was janky and bad and it is no longer. The marriage flow is now sensible, prompts people for what name to change to instead of doing buggy string manipulation crimes to try to guess a last name, gives proper feedback to all participants along the way, and gracefully handles every edge case we could think of in testing. I also invented multithreading in byond for this, look at the code it's fun.
    - Also as part of this I fixed a bug where changing a mob's truename wouldn't actually update knownlists. It now does, because previously you could end up with dead entries in your mind's knownlist after someone gets married.
- Fixes revenant hearing. They hear from their heads, not their bodies, but the checks for whether they COULD hear were using the position and zlevel of the body, not the head. It now works properly and you can hear from your head no matter where it is.
- Fixes a duplication exploit allowing INFINITE COAL... literally, coal is one of the items it worked with. It could also dupe a bunch of other stuff.

## Testing Evidence
<img width="516" height="593" alt="image" src="https://github.com/user-attachments/assets/37b2f1f3-60ab-402d-b6ed-144eb9e2c0ca" /><br/>
If we put screenshots here of every edge case we tested the PR would be ten miles long but here is how the flow works usually. Both betrothed bite the apple, the eoran/bishop offers it to the cross. They all get a message saying it's begun, and the betrothed get consent prompts (both at once). If either cancels, it ends, otherwise, they get a second pair of prompts to pick their new names. The new name layout is displayed to all parties, and the betrothed are given one final chance to cancel - say, if one of them typed a name wrong or they just weren't on the same page for how the names would look - before the marriage goes through, names are changed, etc.<br/><br/>
<img width="278" height="249" alt="image" src="https://github.com/user-attachments/assets/f21fb656-6f1b-434c-a4b9-0dab9ca36a55" />
<img width="515" height="464" alt="image" src="https://github.com/user-attachments/assets/e450d68b-e0af-443f-9248-70361e9f5f10" />
<img width="377" height="269" alt="image" src="https://github.com/user-attachments/assets/0b6f9b06-038d-4f6b-a603-7416d4b6077e" /><br/>
Yes, you can marry gnolls and familiars. Love wins? Any reasons not to do this are IC, i feel.<br/><br/>
<img width="1001" height="1026" alt="image" src="https://github.com/user-attachments/assets/b0878795-4447-4b0d-85fa-dac2f81dc3b9" />
<img width="524" height="102" alt="image" src="https://github.com/user-attachments/assets/ada15e9c-c3a4-4e77-9dca-cd320067d355" /><br/>
The head is 1 z-level down, and offscreen to the right, but I can still hear its messages being relayed to me because it can hear itself. The messages being heard are me thinking I broke something, but I was actually just getting spamfiltered bcs i was using "test" as a test message.<br/><br/>
<img width="536" height="318" alt="image" src="https://github.com/user-attachments/assets/6c9efc67-5626-4170-a828-d6c621b1a4ee" /><br/>
This doesn't make much sense as proof unless you know how the original exploit worked. But this is a screenshot of me attempting to use it, and it's not working.

## Why It's Good For The Game
Searching for mites and fleas

## Changelog

:cl:
fix: Marriage is now properly functional. Again. But like actually this time.
fix: Revenants now hear from their head, not their body, consistently. Previously, this was only true if the head was near the body and on the same zlevel.
fix: Fixed a duplication exploit allowing for infinite coal. You can already get that from the azure peak playerbase, you don't need an exploit for it.
/:cl:
