### PR TITLE
[TM] actually fix glue items

### DIFF
--- a/code/modules/mob/living/carbon/human/npc/conjured_horde.dm
+++ b/code/modules/mob/living/carbon/human/npc/conjured_horde.dm
@@ -41,6 +41,8 @@
 	equipOutfit(new /datum/outfit/job/roguetown/conjured_gnome)
 	for(var/obj/item/gear in (get_equipped_items() + held_items))
 		ADD_TRAIT(gear, TRAIT_NODROP, TRAIT_GENERIC)
+	for(var/obj/item/held_item in held_items)
+		held_item.AddComponent(/datum/component/item_on_drop/dust)
 	def_intent_change(INTENT_PARRY)
 	dna.species.handle_body(src)
 	random_voice_NPC()

--- a/code/modules/mob/living/carbon/human/npc/conjured_peasant.dm
+++ b/code/modules/mob/living/carbon/human/npc/conjured_peasant.dm
@@ -21,6 +21,8 @@
 	equipOutfit(outfit)
 	for(var/obj/item/gear in (get_equipped_items() + held_items))
 		ADD_TRAIT(gear, TRAIT_NODROP, TRAIT_GENERIC)
+	for(var/obj/item/held_item in held_items)
+		held_item.AddComponent(/datum/component/item_on_drop/dust)
 
 /mob/living/carbon/human/species/human/northern/conjured_peasant/Destroy()
 	release_conjured_gear()

--- a/code/modules/spells/components/conjured_minion.dm
+++ b/code/modules/spells/components/conjured_minion.dm
@@ -198,6 +198,9 @@
 
 /mob/living/carbon/human/proc/release_conjured_gear()
 	for(var/obj/item/gear in (get_equipped_items() + held_items))
+		if(HAS_TRAIT(gear, TRAIT_NODROP))
+			qdel(gear)
+			continue
 		dropItemToGround(gear, force = TRUE)
 
 /mob/living/proc/add_summoned_minion(mob/living/summon)


### PR DESCRIPTION
## About The Pull Request

what #8947  was trying to fix

## Testing Evidence

local seems fine

## Why It's Good For The Game

superglue was invented n 1942

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: conjured glued-on items no longer stay glued and ash appropriately
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
