### PR TITLE
[Fix] Psychosis infinite screenshake

### DIFF
--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -734,6 +734,8 @@
 	update_inv_hands()
 
 
+#define CMODE_SHAKE_ANIMATION "cmode_shake"
+
 /mob/verb/toggle_cmode()
 	set name = "cmode-change"
 	set hidden = 1
@@ -750,6 +752,8 @@
 			playsound_local(src, 'sound/misc/comboff.ogg', 100)
 			SSdroning.play_area_sound(get_area(src), client)
 			cmode = FALSE
+			if(client)
+				animate(client, tag = CMODE_SHAKE_ANIMATION)
 		if(hud_used)
 			if(hud_used.cmode_button)
 				hud_used.cmode_button.update_icon()
@@ -758,8 +762,8 @@
 		playsound_local(src, 'sound/misc/comboff.ogg', 100)
 		SSdroning.play_area_sound(get_area(src), client)
 		cmode = FALSE
-		if(client && HAS_TRAIT(src, TRAIT_SCREENSHAKE))
-			animate(client, pixel_y)
+		if(client)
+			animate(client, tag = CMODE_SHAKE_ANIMATION)
 	else
 		cmode = TRUE
 		playsound_local(src, 'sound/misc/combon.ogg', 100)
@@ -768,7 +772,7 @@
 		else if(L.cmode_music)
 			SSdroning.play_combat_music(L.cmode_music, client)
 		if(client && HAS_TRAIT(src, TRAIT_PSYCHOSIS))
-			animate(client, pixel_y = 1, time = 1, loop = -1, flags = ANIMATION_RELATIVE)
+			animate(client, pixel_y = 1, time = 1, loop = -1, flags = ANIMATION_RELATIVE, tag = CMODE_SHAKE_ANIMATION)
 			animate(pixel_y = -1, time = 1, flags = ANIMATION_RELATIVE)
 	if(hud_used)
 		if(hud_used.cmode_button)

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -783,6 +783,8 @@
 			hud_used.cmode_button.update_icon()
 	on_cmode()
 
+#undef CMODE_SHAKE_ANIMATION
+
 /mob/proc/on_cmode()
 	return
 

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -743,9 +743,9 @@
 	if(SSticker.current_state >= GAME_STATE_FINISHED)
 		return
 
-	var/mob/living/L
-	if(isliving(src))
-		L = src
+	if(!isliving(src))
+		return
+	var/mob/living/L = src
 	var/client/client = L.client
 	if(L.IsSleeping() || L.surrendering)
 		if(cmode)
@@ -771,9 +771,13 @@
 			SSdroning.play_combat_music(L.cmode_music_override, client)
 		else if(L.cmode_music)
 			SSdroning.play_combat_music(L.cmode_music, client)
-		if(client && HAS_TRAIT(src, TRAIT_PSYCHOSIS))
+		if(client && (HAS_TRAIT(src, TRAIT_PSYCHOSIS) || HAS_TRAIT(src, TRAIT_SCREENSHAKE)))
 			animate(client, pixel_y = 1, time = 1, loop = -1, flags = ANIMATION_RELATIVE, tag = CMODE_SHAKE_ANIMATION)
 			animate(pixel_y = -1, time = 1, flags = ANIMATION_RELATIVE)
+			if(HAS_TRAIT(src, TRAIT_PSYCHOSIS) && !HAS_TRAIT(src, TRAIT_SCREENSHAKE))
+				spawn(4 SECONDS)
+					if(cmode && client)
+						animate(client, tag = CMODE_SHAKE_ANIMATION)
 	if(hud_used)
 		if(hud_used.cmode_button)
 			hud_used.cmode_button.update_icon()


### PR DESCRIPTION
## About The Pull Request

- Psychosis rat-shaker when toggling Combat Mode should only last for the initial 4 seconds, instead of ∞ seconds.

## Testing Evidence

Compiles, tested it a couple of times by using Matthios Glasses which give me the trait and remove it. All good on my end.

## Why It's Good For The Game

A pretty round-ending bug, ser. There is 'no' way to stop this currently, even with admin intervention or even death.

## Changelog
:cl:
fix: Psychosis should no longer shake your screen forever. It goes away after some time and if you turn off combat mode.
/:cl: