### PR TITLE
cap gambling withdrawal to stop crashing the server

### DIFF
--- a/code/modules/roguetown/roguemachine/lottery.dm
+++ b/code/modules/roguetown/roguemachine/lottery.dm
@@ -149,14 +149,14 @@
 			mod = 5
 		var/maxwithdraw = min(floor(gamblingprice/mod), 20)
 		var/coin_amt = input(user, "Sayyid, you have [src.gamblingprice] mammon in tithes. You may withdraw [maxwithdraw] [selection] COINS.", src) as null|num
-		coin_amt = round(coin_amt)
+		coin_amt = min(round(coin_amt), 20)
 		if(coin_amt < 1)
 			return
 		if(!Adjacent(user))
 			return
 		if(src.stopgambling == 1) // double check because it's possible to have input field open before starting gambling
 			return
-		if((coin_amt*mod) > min(gamblingprice, 200))
+		if((coin_amt*mod) > gamblingprice)
 			playsound(src, 'sound/misc/machineno.ogg', 100, FALSE, -1)
 			return
 		else

--- a/code/modules/roguetown/roguemachine/lottery.dm
+++ b/code/modules/roguetown/roguemachine/lottery.dm
@@ -37,7 +37,7 @@
 		return
 	if(istype(P, /obj/item/roguecoin/aalloy))
 		return
-	if(istype(P, /obj/item/roguecoin/inqcoin))	
+	if(istype(P, /obj/item/roguecoin/inqcoin))
 		return
 	if(istype(P, /obj/item/roguecoin))
 		if(src.gamblingprice + (P.sellprice * P.quantity) > src.maxtithing)
@@ -147,7 +147,8 @@
 			mod = 10
 		if(selection == "SILVER")
 			mod = 5
-		var/coin_amt = input(user, "Sayyid, you have [src.gamblingprice] mammon in tithes. You may withdraw [floor(gamblingprice/mod)] [selection] COINS.", src) as null|num
+		var/maxwithdraw = min(floor(gamblingprice/mod), 20)
+		var/coin_amt = input(user, "Sayyid, you have [src.gamblingprice] mammon in tithes. You may withdraw [maxwithdraw] [selection] COINS.", src) as null|num
 		coin_amt = round(coin_amt)
 		if(coin_amt < 1)
 			return
@@ -155,7 +156,7 @@
 			return
 		if(src.stopgambling == 1) // double check because it's possible to have input field open before starting gambling
 			return
-		if((coin_amt*mod) > gamblingprice)
+		if((coin_amt*mod) > min(gamblingprice, 200))
 			playsound(src, 'sound/misc/machineno.ogg', 100, FALSE, -1)
 			return
 		else


### PR DESCRIPTION
## About The Pull Request
As funny as it was to have someone crash the server like this. Uh. Yeah. You can now withdraw 200 mammons max at once.
<img width="607" height="407" alt="image" src="https://github.com/user-attachments/assets/956eefdf-7f06-48f9-9f31-4501243276cc" />
<img width="837" height="82" alt="image" src="https://github.com/user-attachments/assets/08fbff7d-62d5-43e8-9bdf-cb2a867a8a70" />

## Testing Evidence
<img width="249" height="298" alt="image" src="https://github.com/user-attachments/assets/fc8a764c-db9e-4839-a55f-4080ffa97f30" />
<img width="355" height="187" alt="image" src="https://github.com/user-attachments/assets/abc81062-a2af-4a7a-a8a6-1da8159fc55f" />
<img width="518" height="209" alt="image" src="https://github.com/user-attachments/assets/ac7def94-2028-4f99-bb0d-ef72a7b132cc" />
<img width="251" height="276" alt="image" src="https://github.com/user-attachments/assets/5cb19897-5594-4bc9-b947-e3c21097cecf" />

## Why It's Good For The Game
Xylix's strongest fool crashing the server at will is bad, actually.

## Changelog

:cl:
fix: You can no longer crash the server via excessive gambling.
/:cl:

