### PR TITLE
[Feat (The Red Pill)] More Blackblood Changes

### DIFF
--- a/code/datums/status_effects/rogue/debuff.dm
+++ b/code/datums/status_effects/rogue/debuff.dm
@@ -941,6 +941,7 @@
 	id = "Vampire Bite"
 	alert_type = /atom/movable/screen/alert/status_effect/debuff/vampbite
 	duration = 30 SECONDS
+	tick_interval = 3 SECONDS
 
 /datum/status_effect/debuff/vampbite/on_apply()
 	. = ..()
@@ -956,6 +957,26 @@
 			PM.backdrop(owner)
 			PM = locate(/atom/movable/screen/plane_master/game_world_above) in owner.client.screen
 			PM.backdrop(owner)
+
+/datum/status_effect/debuff/vampbite/tick()
+	. = ..()
+	if(owner.mind)
+		return
+	if(!prob(50))
+		return
+	owner.Immobilize(1.5 SECONDS) // 50% chance
+	if(!prob(50))
+		return
+	owner.apply_status_effect(/datum/status_effect/debuff/clickcd, 8 SECONDS) // 25% chance
+	if(!prob(50))
+		return
+	owner.apply_status_effect(/datum/status_effect/debuff/sensitive_nerves) // 12.5% chance
+	if(!prob(50))
+		return
+	owner.apply_status_effect(/datum/status_effect/debuff/exposed, 3 SECONDS) // 6.25% chance
+	if(!prob(50))
+		return
+	owner.Unconscious(30 SECONDS) // 3.125% chance
 
 /datum/status_effect/debuff/vampbite/on_remove()
 	. = ..()

--- a/code/datums/status_effects/rogue/debuff.dm
+++ b/code/datums/status_effects/rogue/debuff.dm
@@ -941,7 +941,7 @@
 	id = "Vampire Bite"
 	alert_type = /atom/movable/screen/alert/status_effect/debuff/vampbite
 	duration = 30 SECONDS
-	tick_interval = 3 SECONDS
+	tick_interval = 5 SECONDS
 
 /datum/status_effect/debuff/vampbite/on_apply()
 	. = ..()

--- a/code/datums/status_effects/rogue/roguebuff.dm
+++ b/code/datums/status_effects/rogue/roguebuff.dm
@@ -680,7 +680,6 @@
 	examine_text = "<font color='#b3b3b3'>SUBJECTPRONOUN is healing unnaturally fast!</font>"
 	var/fare_power = 0
 	var/healing_on_tick = 1
-	var/outline_colour = "#8a8a8a"
 
 /datum/status_effect/buff/foodhealing/on_creation(mob/living/new_owner, new_healing_on_tick, new_fare_power)
 	if(!isnull(new_healing_on_tick))
@@ -689,19 +688,9 @@
 		fare_power = new_fare_power
 	return ..()
 
-/datum/status_effect/buff/foodhealing/on_apply()
-	var/filter = owner.get_filter(CONSUME_AURA)
-	if(!filter)
-		owner.add_filter(CONSUME_AURA, 2, list("type" = "outline", "color" = outline_colour, "alpha" = 60, "size" = 1))
-	return TRUE
-
-/datum/status_effect/buff/foodhealing/on_remove()
-	. = ..()
-	owner.remove_filter(CONSUME_AURA)
-
 /datum/status_effect/buff/foodhealing/tick()
-	var/obj/effect/temp_visual/heal/H = new /obj/effect/temp_visual/psyheal_rogue(get_turf(owner))
-	H.color = "#bdbdbd"
+	var/obj/effect/temp_visual/heal/H = new /obj/effect/temp_visual/heal_blood(get_turf(owner))
+	H.color = "#830000ff"
 	// Base heal.
 	var/base_heal = healing_on_tick
 	// Fare: +10% healing per tier

--- a/code/datums/status_effects/rogue/roguebuff.dm
+++ b/code/datums/status_effects/rogue/roguebuff.dm
@@ -669,9 +669,6 @@
 
 #undef REWIND_AURA
 
-//lasts shorter than magic, one chomp every 3 seconds is good enough, let's not forget food can have multiple slices. This does not heal wounds, wounds are healed automatically like psydonitian trait, but it consumes 1% hunger a tick.
-#define CONSUME_AURA "consumehealing"
-
 /datum/status_effect/buff/foodhealing
 	id = "consumehealing"
 	status_type = STATUS_EFFECT_UNIQUE
@@ -689,8 +686,6 @@
 	return ..()
 
 /datum/status_effect/buff/foodhealing/tick()
-	var/obj/effect/temp_visual/heal/H = new /obj/effect/temp_visual/heal_blood(get_turf(owner))
-	H.color = "#830000ff"
 	// Base heal.
 	var/base_heal = healing_on_tick
 	// Fare: +10% healing per tier
@@ -709,9 +704,6 @@
 	owner.adjustCloneLoss(-heal_amount, 0)
 	owner.energy_add(10)
 	owner.update_damage_overlays()
-
-#undef CONSUME_AURA
-
 
 /atom/movable/screen/alert/status_effect/buff/healing/campfire
 	name = "Camp Rest"

--- a/code/modules/mob/living/carbon/stress.dm
+++ b/code/modules/mob/living/carbon/stress.dm
@@ -113,8 +113,11 @@ GLOBAL_LIST_INIT(stress_messages, world.file2list("strings/rt/stress_messages.tx
 					src.set_blurriness(100)
 					apply_status_effect(/datum/status_effect/debuff/badvision)
 					add_stress(/datum/stressevent/sun_sensitivity_dark)
-				else
-					add_stress(/datum/stressevent/sun_sensitivity)
+				else if(HAS_TRAIT(src, TRAIT_BLACKBLOOD))
+					if(HAS_TRAIT(src, TRAIT_VAMPBITE))
+						add_stress(/datum/stressevent/sun_sensitivity)
+					else
+						add_stress(/datum/stressevent/sun_sensitivity_dark)
 		else
 			remove_stress(/datum/stressevent/lesser_sun_sensitivity)
 			remove_stress(/datum/stressevent/sun_sensitivity)

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -63,8 +63,8 @@
 		if(ishuman(H))
 			var/mob/living/carbon/human/Hu = H
 			Hu.adjust_hydration(8)
-			if(HAS_TRAIT(Hu, TRAIT_BLACKBLOOD))
-				Hu.reagents.add_reagent(/datum/reagent/medicine/healthpot/zarum/blood, 0.5) // this is a fraction of a fraction in the end, I didn't heal too much from local tests, it's more for situations where you don't have food in pve
+			if(HAS_TRAIT(Hu, TRAIT_BLACKBLOOD) && HAS_TRAIT(Hu, TRAIT_VAMPBITE))
+				Hu.reagents.add_reagent(/datum/reagent/medicine/healthpot/zarum/blood, 1) // exclusive to blackvamps now
 		return
 	H.add_nausea(12)
 	H.adjustToxLoss(2)

--- a/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
@@ -427,9 +427,9 @@ If you want to expand on poisons theres tons of fun effects TG chemistry has tha
 
 
 /datum/reagent/organpoison/on_mob_life(mob/living/carbon/M)
-	if(HAS_TRAIT(M, TRAIT_ORGAN_EATER) || (HAS_TRAIT(eater, TRAIT_BLACKBLOOD) && !HAS_TRAIT(eater, TRAIT_VAMPBITE)))
+	if(HAS_TRAIT(M, TRAIT_ORGAN_EATER) || (HAS_TRAIT(M, TRAIT_BLACKBLOOD) && !HAS_TRAIT(M, TRAIT_VAMPBITE)))
 		M.energy_add(10) //Slowly add energy back.
-		if(HAS_TRAIT(eater, TRAIT_BLACKBLOOD) && !HAS_TRAIT(eater, TRAIT_VAMPBITE))
+		if(HAS_TRAIT(M, TRAIT_BLACKBLOOD) && !HAS_TRAIT(M, TRAIT_VAMPBITE))
 			M.reagents.add_reagent(/datum/reagent/medicine/healthpot/zarum/blood, 1) // exclusive to blackvolfs
 	if(!HAS_TRAIT(M, TRAIT_NASTY_EATER) && !HAS_TRAIT(M, TRAIT_ORGAN_EATER))
 		M.add_nausea(9)

--- a/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
@@ -427,8 +427,10 @@ If you want to expand on poisons theres tons of fun effects TG chemistry has tha
 
 
 /datum/reagent/organpoison/on_mob_life(mob/living/carbon/M)
-	if(HAS_TRAIT(M, TRAIT_ORGAN_EATER))
+	if(HAS_TRAIT(M, TRAIT_ORGAN_EATER) || (HAS_TRAIT(eater, TRAIT_BLACKBLOOD) && !HAS_TRAIT(eater, TRAIT_VAMPBITE)))
 		M.energy_add(10) //Slowly add energy back.
+		if(HAS_TRAIT(eater, TRAIT_BLACKBLOOD) && !HAS_TRAIT(eater, TRAIT_VAMPBITE))
+			M.reagents.add_reagent(/datum/reagent/medicine/healthpot/zarum/blood, 1) // exclusive to blackvolfs
 	if(!HAS_TRAIT(M, TRAIT_NASTY_EATER) && !HAS_TRAIT(M, TRAIT_ORGAN_EATER))
 		M.add_nausea(9)
 		M.adjustToxLoss(2)

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -171,7 +171,7 @@
 	var/obj/item/organ/organ_inside
 
 /obj/item/reagent_containers/food/snacks/organ/On_Consume(mob/living/eater)		//Graggarites looove eating organs, they loooove eating organs!
-	if(HAS_TRAIT(eater, TRAIT_ORGAN_EATER))
+	if(HAS_TRAIT(eater, TRAIT_ORGAN_EATER) || (HAS_TRAIT(eater, TRAIT_BLACKBLOOD) && !HAS_TRAIT(eater, TRAIT_VAMPBITE)))
 		eat_effect = /datum/status_effect/buff/snackbuff
 		foodtype = RAW | MEAT
 	else

--- a/code/modules/virtues/combat.dm
+++ b/code/modules/virtues/combat.dm
@@ -149,10 +149,10 @@
 	add_verb(recipient, /mob/living/carbon/human/proc/emote_ffsalute)
 	add_verb(recipient, /mob/living/carbon/human/proc/toggle_guarded)
 
-
 #define SC_ROTCURED "Rotcured"
 #define SC_PALLID "Pallid"
-#define SC_BLACKBLOOD "Blackblood"
+#define SC_BLACKBLOOD_W "Blackblood Type-W"
+#define SC_BLACKBLOOD_V "Blackblood Type-V"
 
 /datum/virtue/combat/second_chance
 	name = "Second Chance"
@@ -167,12 +167,15 @@
 	extra_choices = list(
 		SC_ROTCURED,
 		SC_PALLID,
-		SC_BLACKBLOOD,
+		SC_BLACKBLOOD_V,
+		SC_BLACKBLOOD_W,
 	)
+
 	choice_tooltips = list(
-		SC_ROTCURED = "<font color='#4a8d48'>I was once afflicted with the accursed rot, and was cured. It has left me changed: my limbs are weaker, but I feel no pain and have no need to breathe.<br><br><font color=red>(Grants Easy Dismember, Painless, Breathless, Deathless, Poison Immune, Deadite Immune, Silver Weakness.)<font color=white><br><br>(Additionally, you can eat brains, you don't suffer nausea, and your heart does not beat.)</font>",
-		SC_PALLID = "<font color='#8d4848'>I was once afflicted with vampirism, but was cured by somethign short of divine intervention. It has left me changed: silver burns my flesh, and the open sky fills me with unease. Yet I draw no breath, and my eyes pierce the darkness. Lingering traces of the curse that once claimed me. Traces I hope will fade in time.<br><br><font color=red>(Grants Darkvision, Breathless, Deadite Immunity and Silver Weakness.)<br><br><font color=white>(Additionally, being outdoors causes stress.)</font>",
-		SC_BLACKBLOOD = "<font color='#8b488d'>I was once a nite-creacher, be it lycanthrope or vampyre, before the Otavan Inquisition subdued and exported me as a test subject of an experimental \"cure\" for my Quicksilver-resistant taint. This intense therapy had me warped, inside, outside, body and mind, into something 'idealistically' humen-like for Otavan standards, even if I am now no different than a sentient, hollowed ghoul.<br><br><font color=red>(Grants Darkvision, Leaden Lux, Strong Bite, Inhumen Digestion, and Silver Weakness.)<br><br><font color=white>(Additionally, consuming any food will grant a minor healing buff. You bleed slower and passively recover from wounds (while not hungry). You will feel stressed when exposed to Sunlight, and panic while being around or interacting with members of the Inquisition.)",
+		SC_ROTCURED = "I was once afflicted with the accursed rot, and was cured. It has left me changed: my limbs are weaker, but I feel no pain and have no need to breathe. (Grants Easy Dismember, Painless, Breathless, Deathless, Poison Immune, Deadite Immune, Silver Weakness.)(Additionally, you can eat brains, you don't suffer nausea, and your heart does not beat.)",
+		SC_PALLID = "I was once afflicted with vampyrism, but was cured by somethign short of divine intervention. It has left me changed: silver burns my flesh, and the open sky fills me with unease. Yet I draw no breath, and my eyes pierce the darkness. Lingering traces of the curse that once claimed me. Traces I hope will fade in time.(Grants Darkvision, Breathless, Deadite Immunity and Silver Weakness.)(Additionally, being outdoors causes stress.)",
+		SC_BLACKBLOOD_V = "I was once a vampyre, before the Otavan Inquisition subdued and exported me as a test subject of an experimental \"cure\" for my Quicksilver-resistant taint. This intense therapy had me warped, inside, outside, body and mind, into something 'idealistically' humen-like for Otavan standards, even if I am now no different than a sentient, hollowed ghoul. (Darkvision, Leaden Lux, Strong Bite, Inhumen Digestion and Silver Weakness. You can regenerate from minor wounds and brute damage, at the cost of hunger. This variant can heal from drinking blood and has a pleasant bite.)",
+		SC_BLACKBLOOD_W = "I was once a lycanthrope, before the Otavan Inquisition subdued and exported me as a test subject of an experimental \"cure\" for my Quicksilver-resistant taint. This intense therapy had me warped, inside, outside, body and mind, into something 'idealistically' humen-like for Otavan standards, even if I am now no different than a sentient, hollowed ghoul. (Darkvision, Leaden Lux, Strong Bite, Inhumen Digestion, and Silver Weakness. You can regenerate from minor wounds and brute damage, at the cost of hunger. This variant knows Beast language and is afflicted less by sunlight.)",
 	)
 
 /datum/virtue/combat/second_chance/apply_to_human(mob/living/carbon/human/recipient)
@@ -180,7 +183,7 @@
 		if(QDELETED(src) || QDELETED(recipient))
 			return
 
-		if(recipient.mind.has_antag_datum(/datum/antagonist/skeleton) || recipient.mind.has_antag_datum(/datum/antagonist/lich) || recipient.mind.has_antag_datum(/datum/antagonist/vampire) || recipient.mind.has_antag_datum(/datum/antagonist/vampire/lord) || recipient.mind.has_antag_datum(/datum/antagonist/werewolf) || recipient.mind.has_antag_datum(/datum/antagonist/zombie))
+		if(recipient.mind && (recipient.mind.has_antag_datum(/datum/antagonist/skeleton) || recipient.mind.has_antag_datum(/datum/antagonist/lich) || recipient.mind.has_antag_datum(/datum/antagonist/vampire) || recipient.mind.has_antag_datum(/datum/antagonist/vampire/lord) || recipient.mind.has_antag_datum(/datum/antagonist/werewolf) || recipient.mind.has_antag_datum(/datum/antagonist/zombie)))
 			to_chat(recipient, "Second Chance cannot be applied to your role, so it has been removed.")
 			QDEL_NULL(src)
 			return
@@ -196,7 +199,7 @@
 					ADD_TRAIT(recipient, TRAIT_TOXIMMUNE, TRAIT_VIRTUE)
 					ADD_TRAIT(recipient, TRAIT_ZOMBIE_IMMUNE, TRAIT_VIRTUE)
 					ADD_TRAIT(recipient, TRAIT_SILVER_WEAK, TRAIT_VIRTUE)
-					to_chat(recipient, "You are no longer a rotting corpse, at least not a dying one.</font>")
+					to_chat(recipient, "You are no longer a rotting corpse, at least not a dying one.")
 
 				if(SC_PALLID)
 					ADD_TRAIT(recipient, TRAIT_PALLID, TRAIT_VIRTUE)
@@ -204,21 +207,18 @@
 					ADD_TRAIT(recipient, TRAIT_NOBREATH, TRAIT_VIRTUE)
 					ADD_TRAIT(recipient, TRAIT_ZOMBIE_IMMUNE, TRAIT_VIRTUE)
 					ADD_TRAIT(recipient, TRAIT_SILVER_WEAK, TRAIT_VIRTUE)
-					to_chat(recipient, "You are no longer one scorned by Astrata, by the mercy of the gods.</font>")
+					to_chat(recipient, "You are no longer one scorned by Astrata, by the mercy of the gods.")
 
-				if(SC_BLACKBLOOD)
+				if(SC_BLACKBLOOD_V)
+					ADD_TRAIT(recipient, TRAIT_VAMPBITE, TRAIT_VIRTUE)
 					ADD_TRAIT(recipient, TRAIT_BLACKBLOOD, TRAIT_VIRTUE)
 					ADD_TRAIT(recipient, TRAIT_HALFHEAL, TRAIT_VIRTUE)
 					ADD_TRAIT(recipient, TRAIT_STRONGBITE, TRAIT_VIRTUE)
-					ADD_TRAIT(recipient, TRAIT_NASTY_EATER, TRAIT_VIRTUE)
 					ADD_TRAIT(recipient, TRAIT_NITEVISION, TRAIT_VIRTUE)
+					ADD_TRAIT(recipient, TRAIT_NASTY_EATER, TRAIT_VIRTUE)
 					ADD_TRAIT(recipient, TRAIT_SILVER_WEAK, TRAIT_VIRTUE)
-					to_chat(recipient, "You are no longer one among the nite creechers, by the ingenuinity of HIS followers.</font>")
-
-					// blackened blood, finally
 					recipient.dna.species.blood_color = "#530000"
-
-					// inquisition trauma goes here
+					to_chat(recipient, "You are no longer one among the bloodsucking nite creechers, by the ingenuity of HIS followers.")
 					if(!(recipient.patron?.type == /datum/patron/old_god))
 						var/datum/charflaw/averse/A
 						for(var/datum/charflaw/averse/F in recipient.charflaws)
@@ -226,19 +226,45 @@
 							break
 						if(A)
 							A.chosen_group |= GLOB.averse_factions["Inquisition"]
-							to_chat(recipient, span_blue("<i>You recall your horrid experiences with the Inquisition... It is rather traumatic. Best to avoid them.</i>"))
 						else
 							A = new
 							A.set_jobflag("Inquisition")
 							recipient.charflaws += A
-							to_chat(recipient, span_blue("<i>You recall your horrid experiences with the Inquisition... It is rather traumatic. Best to avoid them.</i>"))
+						to_chat(recipient, span_blue("<i>You recall your horrid experiences with the Inquisition... It is rather traumatic. Best to avoid them.</i>"))
+					else
+						to_chat(recipient, span_blue("<i>You recall your horrid experiences with the Inquisition... But through your newfound faith in HIM, you ENDURE. You were but one wrong righted, after all.</i>"))
+					to_chat(recipient, span_danger("DISCLAIMER: This Second Choice option exists to support roleplay and backstory continuity, not to diminish the threat or narrative weight of vampires, werewolves, or similar antagonistic entities. You are a tortured survivor of the Otavan Inquisition, and your very LUX fears them. Failure to roleplay this appropriately may result in this option's removal. Have fun and don't be cringe."))
+
+				if(SC_BLACKBLOOD_W)
+					recipient.AddSpell(new /obj/effect/proc_holder/spell/self/howl/call_of_the_moon)
+					ADD_TRAIT(recipient, TRAIT_BLACKBLOOD, TRAIT_VIRTUE)
+					ADD_TRAIT(recipient, TRAIT_HALFHEAL, TRAIT_VIRTUE)
+					ADD_TRAIT(recipient, TRAIT_STRONGBITE, TRAIT_VIRTUE)
+					ADD_TRAIT(recipient, TRAIT_NITEVISION, TRAIT_VIRTUE)
+					ADD_TRAIT(recipient, TRAIT_NASTY_EATER, TRAIT_VIRTUE)
+					ADD_TRAIT(recipient, TRAIT_SILVER_WEAK, TRAIT_VIRTUE)
+					recipient.dna.species.blood_color = "#530000"
+					to_chat(recipient, "You are no longer one among the howling nite creechers, by the ingenuity of HIS followers.")
+					if(!(recipient.patron?.type == /datum/patron/old_god))
+						var/datum/charflaw/averse/A
+						for(var/datum/charflaw/averse/F in recipient.charflaws)
+							A = F
+							break
+						if(A)
+							A.chosen_group |= GLOB.averse_factions["Inquisition"]
+						else
+							A = new
+							A.set_jobflag("Inquisition")
+							recipient.charflaws += A
+						to_chat(recipient, span_blue("<i>You recall your horrid experiences with the Inquisition... It is rather traumatic. Best to avoid them.</i>"))
 					else
 						to_chat(recipient, span_blue("<i>You recall your horrid experiences with the Inquisition... But through your newfound faith in HIM, you ENDURE. You were but one wrong righted, after all.</i>"))
 					to_chat(recipient, span_danger("DISCLAIMER: This Second Choice option exists to support roleplay and backstory continuity, not to diminish the threat or narrative weight of vampires, werewolves, or similar antagonistic entities. You are a tortured survivor of the Otavan Inquisition, and your very LUX fears them. Failure to roleplay this appropriately may result in this option's removal. Have fun and don't be cringe."))
 
 #undef SC_ROTCURED
-#undef SC_BLACKBLOOD
 #undef SC_PALLID
+#undef SC_BLACKBLOOD_W
+#undef SC_BLACKBLOOD_V
 
 /datum/virtue/combat/dualwielder
 	name = "Dual Wielder"


### PR DESCRIPTION
## About The Pull Request
- removes aura from eating food cause yeah, it kind of is too much a tell-tale of what you are for literally anyone with eyes
- splits ww and vamp on bb virtue
- wws cant drink blood to heal but can eat organs to heal
- wws are affected less by sunlight than vamps
- vamps can lewdbite people now
- lewdbite has new effects on npcs

think tank:
- i may remove the ability to eat food to heal all together now, idk. with them drifting away from being inquisition ghouls its a bit pointless a quirk.

## Testing Evidence

It's pretty cool.
<img width="423" height="272" alt="image" src="https://github.com/user-attachments/assets/37687a69-4f99-40d2-9ddf-9a2a0a2b6654" />

## Why It's Good For The Game

i dont have a good argument aside someone wanting vampbite on blackblood and then seeing that I can make them both a little more distinctive from each other, cause the char I personally use is more a wolf than vamp, but this would then ruin the vibe, so tearing them in two pieces and hoping it doesnt cause problems

if this goes through, close https://github.com/Azure-Peak/Azure-Peak/pull/8968

## Changelog
:cl:
add: Split Blackblood into 'Type V and Type W'. Vs will exclusively be able to drink blood to heal, Ws will need organs to heal. Normal food still heals them normally.
balance: Vampire Bite now can randomly immobilize NPCs and cause a cascade of effects if you're lucky enough.
/:cl: