### PR TITLE
Removes known menu metaing

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -193,6 +193,9 @@ GLOBAL_LIST_EMPTY(personal_objective_minds)
 			known_people[H.real_name] = list()
 		known_people[H.real_name]["VCOLOR"] = H.voice_color
 		var/used_title = H.get_role_title()
+		var/datum/job/J = SSjob.GetJob(H.job)
+		if(J && J.wanderer_examine && !(HAS_TRAIT(src, TRAIT_RESIDENT)))
+			used_title = "Wanderer"
 		if(!used_title)
 			used_title = "unknown"
 		known_people[H.real_name]["FJOB"] = used_title

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -232,6 +232,9 @@ GLOBAL_LIST_EMPTY(personal_objective_minds)
 					M.known_people[H.real_name] = list()
 				M.known_people[H.real_name]["VCOLOR"] = H.voice_color
 				var/used_title = H.get_role_title()
+				var/datum/job/J = SSjob.GetJob(H.job)
+				if(J && J.wanderer_examine && !(HAS_TRAIT(src, TRAIT_RESIDENT)))
+					used_title = "Wanderer"
 				if(!used_title)
 					used_title = "unknown"
 				M.known_people[H.real_name]["FJOB"] = used_title


### PR DESCRIPTION
## About The Pull Request
Longstanding bug, idk why nobody bothered to fix it before now. You can no longer shift-click wretches to view their exact subclass in your known menu. Residents show up as their subclass as usual, but everyone else with a "wanderer" job will now show up as such in known as well.

## Testing Evidence
<img width="490" height="419" alt="image" src="https://github.com/user-attachments/assets/bc54831f-652d-4fe3-b289-9ed6bfc44935" />

## Why It's Good For The Game
People using this to be shitters = bad

## Changelog

:cl:
fix: Wanderers will now show up as such in the known menu, instead of showing up as "Malpractitioner" or "Hag"
/:cl:
