### PR TITLE
CSR Fixes: Add forced grid size, fix highlight_color, fix preview refresh, fix taur disease

### DIFF
--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -1034,7 +1034,7 @@ GLOBAL_LIST_EMPTY(friendly_animal_types)
 		var/mob/living/carbon/human/dummy/body = generate_or_wait_for_human_dummy(dummy_key)
 
 		if(prefs)
-			prefs.copy_to(body,TRUE,FALSE)
+			prefs.copy_to(body, TRUE, FALSE, character_setup = TRUE)
 		if(human_gear_override) //EVIL CODE!!
 			var/static/list/all_item_slots = ALL_ITEM_SLOTS
 			for(var/slot in all_item_slots)
@@ -1078,7 +1078,7 @@ GLOBAL_LIST_EMPTY(friendly_animal_types)
 
 		if(icon_id)
 			humanoid_icon_cache[icon_id] = out_icon
-		dummy_key? unset_busy_human_dummy(dummy_key) : qdel(body)
+		dummy_key ? unset_busy_human_dummy(dummy_key) : qdel(body)
 		return out_icon
 	else
 		return humanoid_icon_cache[icon_id]

--- a/code/modules/client/character_setup/act/character_creator.dm
+++ b/code/modules/client/character_setup/act/character_creator.dm
@@ -90,6 +90,9 @@ Add a new override in your modular folder that looks like this:
 		if("set_preview_background")
 			character_preview_view?.preview_background.set_background(params["bg"])
 			return CHARACTER_ACT_DATA_UPDATE
+		if("cycle_preview_size")
+			character_preview_view?.cycle_forced_size(user)
+			return CHARACTER_ACT_DATA_UPDATE
 		if("cycle_boner_preview")
 			cycle_boner_preview()
 			return CHARACTER_ACT_PREVIEW_UPDATE

--- a/code/modules/client/character_setup/act/character_creator/descriptors.dm
+++ b/code/modules/client/character_setup/act/character_creator/descriptors.dm
@@ -68,9 +68,8 @@
 			return CHARACTER_ACT_DATA_UPDATE
 
 		if("preview_examine")
-			var/datum/examine_panel/preview_examine_panel = new(user)
+			var/datum/examine_panel/preview_examine_panel = new()
 			preview_examine_panel.pref = src
-			preview_examine_panel.holder = user
 			preview_examine_panel.viewing = user
 			preview_examine_panel.ui_interact(user)
 			return CHARACTER_ACT_DATA_UPDATE

--- a/code/modules/client/character_setup/preview_view.dm
+++ b/code/modules/client/character_setup/preview_view.dm
@@ -38,6 +38,7 @@
 
 	/// The preferences this refers to
 	var/datum/preferences/preferences
+	var/forced_grid_size = 0
 
 	var/atom/movable/screen/background/char_preview/preview_background
 
@@ -69,21 +70,37 @@
 	var/mob/living/carbon/human/dummy/mannequin = generate_or_wait_for_human_dummy(DUMMY_HUMAN_SLOT_PREFERENCES)
 
 	appearance = preferences.render_new_preview_appearance(mannequin)
-	var/body_size = ROUND_UP(mannequin.dna.current_body_size - 0.1) // arbitrarily chosen wiggle room
-
+	var/grid_size = forced_grid_size || ROUND_UP(mannequin.dna.current_body_size - 0.1) // arbitrarily chosen wiggle room
 	// this calls wipe_state()
 	unset_busy_human_dummy(DUMMY_HUMAN_SLOT_PREFERENCES)
+	update_size(grid_size)
 
+/atom/movable/screen/map_view/char_preview/proc/cycle_forced_size(mob/user)
+	switch(forced_grid_size)
+		if(0)
+			forced_grid_size = 1
+		if(1)
+			forced_grid_size = 2
+		if(2)
+			forced_grid_size = 3
+		else
+			forced_grid_size = 0
+
+	to_chat(user, span_notice("Your character will now be displayed [forced_grid_size == 0 ? "according to their size" : "on a [forced_grid_size]x[forced_grid_size] grid"]"))
+	update_size(forced_grid_size || preferences.features["body_size"])
+
+/atom/movable/screen/map_view/char_preview/proc/update_size(grid_size)
 	// this isn't required upstream but helps tremendously with sizes >110% downstream
-	preview_background.fill_rect(1, 1, body_size, body_size)
-	set_position((body_size + 1) / 2, 1)
+	preview_background.fill_rect(1, 1, grid_size, grid_size)
+	set_position((grid_size + 1) / 2, 1)
 
 /// This is an old-fashioned fix for the ByondUI Layout bug, changing the screen_loc slightly will force a re-layout
 /atom/movable/screen/map_view/char_preview/proc/jiggle_map()
+	var/old_pos = screen_loc
 	sleep(1 TICKS)
 	set_position(1, 1, 2, 2)
 	sleep(1 TICKS)
-	set_position(1, 1)
+	screen_loc = old_pos
 
 
 // Cycling Background

--- a/code/modules/mob/living/carbon/human/examine_tgui.dm
+++ b/code/modules/mob/living/carbon/human/examine_tgui.dm
@@ -204,7 +204,7 @@
 		"nsfw_ooc_extra_image" = nsfw_ooc_extra_image,
 		"has_song" = has_song,
 		"is_vet" = is_vet,
-		"is_donator" = is_donator(holder.ckey),
+		"is_donator" = is_donator(holder?.ckey),
 		"is_naked" = is_naked,
 		"examine_theme" = char_examine_theme,
 		"song_title" = has_song ? song_title : null

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/dullahan/dullahan_head.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/dullahan/dullahan_head.dm
@@ -572,7 +572,7 @@
 			keenears = HAS_TRAIT(H, TRAIT_KEENEARS)
 			var/name_to_highlight = H.nickname
 			if(name_to_highlight && name_to_highlight != "" && name_to_highlight != "Please Change Me")	//We don't need to highlight an unset or blank one.
-				highlighted_message = replacetext_char(message, name_to_highlight, "<b><font color = #[H.highlight_color]>[name_to_highlight]</font></b>")
+				highlighted_message = replacetext_char(message, name_to_highlight, "<b><font color = '[H.highlight_color]'>[name_to_highlight]</font></b>")
 		var/atom/movable/tocheck = AM
 		if(isdullahan(AM))
 			var/mob/living/carbon/human/target = AM

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -306,7 +306,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 			keenears = HAS_TRAIT(H, TRAIT_KEENEARS)
 			var/name_to_highlight = H.nickname
 			if(name_to_highlight && name_to_highlight != "" && name_to_highlight != "Please Change Me")	//We don't need to highlight an unset or blank one.
-				highlighted_message = replacetext_char(message, name_to_highlight, "<b><font color = #[H.highlight_color]>[name_to_highlight]</font></b>")
+				highlighted_message = replacetext_char(message, name_to_highlight, "<b><font color = '[H.highlight_color]'>[name_to_highlight]</font></b>")
 		if(eavesdrop_range && get_dist(source, AM) > message_range+keenears && !(the_dead[AM]))
 			AM.Hear(eavesrendered, src, message_language, eavesdropping, , spans, message_mode, original_message)
 		else if(highlighted_message)
@@ -506,7 +506,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 			keenears = HAS_TRAIT(H, TRAIT_KEENEARS)
 			var/name_to_highlight = H.nickname
 			if(name_to_highlight && name_to_highlight != "" && name_to_highlight != "Please Change Me")	//We don't need to highlight an unset or blank one.
-				highlighted_message = replacetext_char(message, name_to_highlight, "<b><font color = #[H.highlight_color]>[name_to_highlight]</font></b>")
+				highlighted_message = replacetext_char(message, name_to_highlight, "<b><font color = '[H.highlight_color]'>[name_to_highlight]</font></b>")
 
 			if(H != src && message_mode != MODE_WHISPER && H.has_flaw(/datum/charflaw/addiction/clamorous))
 				var/chance = 5

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/tabs/CharacterCreator.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/tabs/CharacterCreator.tsx
@@ -183,6 +183,13 @@ const Sidebar = () => {
                 onClick={() => act('refresh_character_preview')}
               />
             </Stack.Item>
+            <Stack.Item>
+              <Button
+                icon="maximize"
+                tooltip="Change grid size"
+                onClick={() => act('cycle_preview_size')}
+              />
+            </Stack.Item>
           </Stack>
         </Stack.Item>
         <Stack.Item>


### PR DESCRIPTION
## About The Pull Request
- You can now force the preview grid size to 1x1, 2x2, or 3x3 instead of autosizing to character.
- Refreshing preview while outside 1x1 grid size will no longer break the character position.
- highlight_color ignored the red channel, no longer.
- Taurs will no longer infect every credit icon after them with their tauriness

## Testing Evidence
<img width="267" height="327" alt="image" src="https://github.com/user-attachments/assets/79b4d34e-c697-4de7-9d8c-8fd6615a3d32" />

## Why It's Good For The Game
Fixing bugs, also being able to view extra large head pieces

## Changelog
:cl:
add: You can now force the preview grid size to 1x1, 2x2, or 3x3 instead of autosizing to character.
fix: Refreshing preview while outside 1x1 grid size will no longer break the character position.
fix: highlight_color ignored the red channel, no longer.
fix: Taurs will no longer infect every credit icon after them with their tauriness
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
