### PR TITLE
Devotion Bugfix Package 6 Act 2

### DIFF
--- a/code/modules/jobs/job_types/roguetown/church/templar/templar_spellblade.dm
+++ b/code/modules/jobs/job_types/roguetown/church/templar/templar_spellblade.dm
@@ -10,7 +10,7 @@
 	allowed_patrons = list(/datum/patron/divine/noc)
 	maximum_possible_slots = 2 // The Special Snowflake And Their Friend
 	subclass_languages = list(/datum/language/grenzelhoftian)
-	traits_applied = list(TRAIT_MEDIUMARMOR, TRAIT_ARCYNE)
+	traits_applied = list(TRAIT_MEDIUMARMOR, TRAIT_ARCYNE, TRAIT_UNCONVERTIBLE)
 	tempo_capable = FALSE
 	subclass_stats = list(
 		STATKEY_STR = 1,

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -80,7 +80,7 @@
 	message_admins("[follower_ident] [ADMIN_SM(follower)] [ADMIN_FLW(follower)] prays: [span_info(prayer)]")
 	user.log_message("(follower of [patron]) prays: [prayer]", LOG_GAME)
 
-	follower.whisper(prayer)
+	follower.whisper(prayer, sanitize=FALSE) // we already sanitized this above
 
 	if(SEND_SIGNAL(follower, COMSIG_CARBON_PRAY, prayer) & CARBON_PRAY_CANCEL)
 		return

--- a/code/modules/spells/orison.dm
+++ b/code/modules/spells/orison.dm
@@ -648,12 +648,13 @@ GLOBAL_LIST_INIT(convert_incantations, list(
 		// however, they can have TRAIT_PSYDONITE as a treat
 		ADD_TRAIT(new_convert, TRAIT_PSYDONITE, ROUNDSTART_TRAIT)
 
-	// give a small mood buff to both parties, identical to prayer; psydonites get the same thing but with more ambiguous wording
-	if(istype(new_convert.patron, /datum/patron/old_god))
-		caster.add_stress(/datum/stressevent/convert/psydon)
-	else
-		caster.add_stress(/datum/stressevent/convert)
-	new_convert.add_stress(/datum/stressevent/convert/recipient)
+	if(!(ispath(new_patron, /datum/patron/divine) && istype(old_patron, /datum/patron/divine))) // sigh.
+		// give a small mood buff to both parties, identical to prayer; psydonites get the same thing but with more ambiguous wording
+		if(istype(new_convert.patron, /datum/patron/old_god))
+			caster.add_stress(/datum/stressevent/convert/psydon)
+		else
+			caster.add_stress(/datum/stressevent/convert)
+		new_convert.add_stress(/datum/stressevent/convert/recipient)
 
 	message_admins("CONVERSION: [caster.real_name] ([caster.ckey]) has converted [new_convert.real_name] ([new_convert.ckey]) to [new_convert.patron.name]")
 	log_game("CONVERSION: [caster.real_name] ([caster.ckey]) converted [new_convert.real_name] ([new_convert.ckey]) to [new_convert.patron.name]")


### PR DESCRIPTION
## About The Pull Request
(sigh.)
- Nocblades are now unconvertible, because they're patronlocked.
- Prayers are no longer double-sanitized in chat.
- Conversions from one of the Ten to another no longer give the mood buffs. Intra-pantheon conversions already conveyed no other benefit, but I saw a bishop announcing that they were offering conversions "to change your patron" ic and that's not it guys come on.

## Testing Evidence
<img width="521" height="168" alt="image" src="https://github.com/user-attachments/assets/34165707-0c8a-44f2-a2cc-dc559aba0ec1" />

## Why It's Good For The Game
Nocblades with undivided miracles = hell
Prayer double sanitization leads to the dreaded apostrophe obliter8ion
I am very tired of people treating mechanical patron as a super gamey thing ic if you're a tennite (particularly. a member of the _church of the ten_) you should be venerating all ten not going "my patron is xyz" that's a game term not a lore term do not announce patron conversions over the global announcements please

## Changelog

:cl:
fix: Nocblades are now unconvertible, as a patron-locked role.
fix: Prayers are no longer double-sanitized in chat, meaning apostrophes will no longer be mutated in your prayer whisper
fix: Conversions from one of the Ten to another no longer provide a mood buff, this was the last mechanical benefit they had. This isn't a gamey thing it's meant to be a roleplay tool, guys, come on.
/:cl: