### PR TITLE
Small mage note tweak and craftable wisp

### DIFF
--- a/code/game/objects/structures/fluff.dm
+++ b/code/game/objects/structures/fluff.dm
@@ -1659,3 +1659,25 @@
 /obj/effect/wisp/prestidigitation/willowwisp
 	name = "Will-o'-the-wisp"
 	desc = "A small, fiery ball of light made up of mystical energy."
+
+/obj/structure/wisp_lantern
+	name = "bound wisp"
+	desc = "A will-o'-the-wisp, coaxed into a fragile shell of fae magic. The light dances within, eager to be free."
+	icon = 'icons/roguetown/items/lighting.dmi'
+	icon_state = "wisp"
+	anchored = TRUE
+	density = FALSE
+	layer = ABOVE_ALL_MOB_LAYER
+	max_integrity = 35
+	light_outer_range = 5
+	light_color = "#3FBAFD"
+	light_system = MOVABLE_LIGHT
+	resistance_flags = LAVA_PROOF | FIRE_PROOF | FREEZE_PROOF
+
+/obj/structure/wisp_lantern/Initialize(mapload)
+	. = ..()
+	set_light_range(light_outer_range)
+
+/obj/structure/wisp_lantern/examine(mob/user)
+	. = ..()
+	. += span_notice("It glows with an ethereal blue light.")

--- a/code/modules/roguetown/roguejobs/mages/arcana_crafting.dm
+++ b/code/modules/roguetown/roguejobs/mages/arcana_crafting.dm
@@ -209,3 +209,10 @@
 	reqs = list(/obj/item/rogueweapon/huntingknife/idagger/silver = 1,
 				/obj/item/rogueore/cinnabar = 1)
 
+/datum/crafting_recipe/roguetown/arcana/bound_wisp
+	name = "bound wisp"
+	result = /obj/structure/wisp_lantern
+	reqs = list(/obj/item/magic/fae/fairydust = 2)
+	req_table = FALSE
+	craftdiff = 0
+

--- a/code/modules/spells/roguetown/acolyte/xylix.dm
+++ b/code/modules/spells/roguetown/acolyte/xylix.dm
@@ -39,20 +39,24 @@
 	antimagic_allowed = TRUE
 	recharge_time = 30 SECONDS
 	var/firstcast = TRUE
-	var/icon/clone_icon
 	ignore_combat_tag = TRUE
 
 /obj/effect/proc_holder/spell/invoked/mastersillusion/cast(list/targets, mob/living/carbon/human/user = usr)
 	if(firstcast)
 		to_chat(user, span_italics("...Oh, oh, thy visage is so grand! Let us prepare it for tricks!"))
-		clone_icon = get_flat_human_icon("[user.real_name] decoy", null, null, DUMMY_HUMAN_SLOT_MANIFEST, GLOB.cardinals, TRUE, user, TRUE) // We can only set our decoy icon once. This proc is sort of expensive on generation.
 		firstcast = FALSE
 		name = "Master's Illusion"
 		to_chat(user, "There we are... Perfect.")
 		revert_cast()
 		return
 	var/turf/T = get_turf(user)
-	new /mob/living/simple_animal/hostile/rogue/xylixdouble(T, user, clone_icon)
+	var/saved_alpha = user.alpha
+	user.alpha = 255
+	var/mob/living/simple_animal/hostile/rogue/xylixdouble/double = new(T, user)
+	double.appearance = user.appearance
+	double.name = user.name
+	double.summoner = user.name
+	user.alpha = saved_alpha
 	animate(user, alpha = 0, time = 0 SECONDS, easing = EASE_IN)
 	user.mob_timers[MT_INVISIBILITY] = world.time + 7 SECONDS
 	addtimer(CALLBACK(user, TYPE_PROC_REF(/mob/living/carbon/human, update_sneak_invis), TRUE), 7 SECONDS)
@@ -71,9 +75,7 @@
 	footstep_type = FOOTSTEP_MOB_BAREFOOT
 	del_on_death = TRUE
 	loot = list(/obj/item/bomb/smoke/decoy)
-	can_have_ai = FALSE
-	AIStatus = AI_OFF
-	ai_controller = /datum/ai_controller/mudcrab // doesnt really matter
+	ai_controller = /datum/ai_controller/rat/undead/summoned
 
 
 /obj/item/bomb/smoke/decoy/Initialize(mapload)
@@ -81,11 +83,9 @@
 	playsound(loc, 'sound/magic/decoylaugh.ogg', 50)
 	explode()
 
-/mob/living/simple_animal/hostile/rogue/xylixdouble/Initialize(mapload, mob/living/carbon/human/copycat, icon/I)
+/mob/living/simple_animal/hostile/rogue/xylixdouble/Initialize(mapload, mob/living/carbon/human/copycat)
 	. = ..()
 	addtimer(CALLBACK(src, TYPE_PROC_REF(/mob/living/simple_animal, death), TRUE), 7 SECONDS)
-	icon = I
-	name = copycat.name
 
 
 /obj/effect/proc_holder/spell/self/xylixslip

--- a/code/modules/spells/roguetown/acolyte/xylix.dm
+++ b/code/modules/spells/roguetown/acolyte/xylix.dm
@@ -39,24 +39,20 @@
 	antimagic_allowed = TRUE
 	recharge_time = 30 SECONDS
 	var/firstcast = TRUE
+	var/icon/clone_icon
 	ignore_combat_tag = TRUE
 
 /obj/effect/proc_holder/spell/invoked/mastersillusion/cast(list/targets, mob/living/carbon/human/user = usr)
 	if(firstcast)
 		to_chat(user, span_italics("...Oh, oh, thy visage is so grand! Let us prepare it for tricks!"))
+		clone_icon = get_flat_human_icon("[user.real_name] decoy", null, null, DUMMY_HUMAN_SLOT_MANIFEST, GLOB.cardinals, TRUE, user, TRUE) // We can only set our decoy icon once. This proc is sort of expensive on generation.
 		firstcast = FALSE
 		name = "Master's Illusion"
 		to_chat(user, "There we are... Perfect.")
 		revert_cast()
 		return
 	var/turf/T = get_turf(user)
-	var/saved_alpha = user.alpha
-	user.alpha = 255
-	var/mob/living/simple_animal/hostile/rogue/xylixdouble/double = new(T, user)
-	double.appearance = user.appearance
-	double.name = user.name
-	double.summoner = user.name
-	user.alpha = saved_alpha
+	new /mob/living/simple_animal/hostile/rogue/xylixdouble(T, user, clone_icon)
 	animate(user, alpha = 0, time = 0 SECONDS, easing = EASE_IN)
 	user.mob_timers[MT_INVISIBILITY] = world.time + 7 SECONDS
 	addtimer(CALLBACK(user, TYPE_PROC_REF(/mob/living/carbon/human, update_sneak_invis), TRUE), 7 SECONDS)
@@ -75,7 +71,9 @@
 	footstep_type = FOOTSTEP_MOB_BAREFOOT
 	del_on_death = TRUE
 	loot = list(/obj/item/bomb/smoke/decoy)
-	ai_controller = /datum/ai_controller/rat/undead/summoned
+	can_have_ai = FALSE
+	AIStatus = AI_OFF
+	ai_controller = /datum/ai_controller/mudcrab // doesnt really matter
 
 
 /obj/item/bomb/smoke/decoy/Initialize(mapload)
@@ -83,9 +81,11 @@
 	playsound(loc, 'sound/magic/decoylaugh.ogg', 50)
 	explode()
 
-/mob/living/simple_animal/hostile/rogue/xylixdouble/Initialize(mapload, mob/living/carbon/human/copycat)
+/mob/living/simple_animal/hostile/rogue/xylixdouble/Initialize(mapload, mob/living/carbon/human/copycat, icon/I)
 	. = ..()
 	addtimer(CALLBACK(src, TYPE_PROC_REF(/mob/living/simple_animal, death), TRUE), 7 SECONDS)
+	icon = I
+	name = copycat.name
 
 
 /obj/effect/proc_holder/spell/self/xylixslip

--- a/code/modules/spells/spell_types/wizard/utility/prestidigitation.dm
+++ b/code/modules/spells/spell_types/wizard/utility/prestidigitation.dm
@@ -37,12 +37,20 @@
 
 	switch(caster.used_intent.type)
 		if(/datum/intent/hand/clean)
+			if(ishuman(victim))
+				var/mob/living/carbon/human/human_victim = victim
+				if(human_victim == caster && human_victim.has_status_effect(/datum/status_effect/prestidigitation_light))
+					human_victim.remove_status_effect(/datum/status_effect/prestidigitation_light)
+					to_chat(caster, span_notice("I channel my arcyne power inward, snuffing out the magelight."))
 			if(presti_hand.clean_thing(victim, caster))
 				handle_presti_cost(caster, PRESTI_CLEAN)
 		if(/datum/intent/hand/spark)
 			if(presti_hand.create_spark(caster, victim))
 				handle_presti_cost(caster, PRESTI_SPARK)
 		if(/datum/intent/hand/light)
+			if(victim != caster)
+				to_chat(caster, span_warning("I can only channel magelight upon myself!"))
+				return FALSE
 			if(presti_hand.handle_mote(caster))
 				handle_presti_cost(caster, PRESTI_MOTE)
 		if(/datum/intent/hand/sense)
@@ -194,20 +202,12 @@
 
 	var/int_bonus = max(user.STAINT - 10, 0)
 	var/mote_power = 5 + FLOOR(int_bonus * 0.3, 1)
-	mote.set_light_range(mote_power)
-	if(mote.light_system == STATIC_LIGHT)
-		mote.update_light()
 
-	if(mote.loc == src)
-		user.visible_message(span_notice("[user] holds open the palm of [user.p_their()] hand and concentrates..."), span_notice("I hold open the palm of my hand and concentrate on my arcyne power..."))
-		if(do_after(user, initial(motespeed) * get_int_speed_mult(user), target = user))
-			mote.orbit(user, 1, TRUE, 0, 48, TRUE)
-			return TRUE
-		return FALSE
-	else
-		user.visible_message(span_notice("[user] wills \the [mote.name] back into [user.p_their()] hand and closes it, extinguishing its light."), span_notice("I will \the [mote.name] back into my palm and close it."))
-		mote.forceMove(src)
+	user.visible_message(span_notice("[user] holds open the palm of [user.p_their()] hand and concentrates..."), span_notice("I hold open the palm of my hand and concentrate on my arcyne power..."))
+	if(do_after(user, initial(motespeed) * get_int_speed_mult(user), target = user))
+		user.apply_status_effect(/datum/status_effect/prestidigitation_light, mote_power)
 		return TRUE
+	return FALSE
 
 /obj/item/melee/new_touch_attack/prestidigitation/proc/create_spark(mob/living/carbon/human/user, atom/thing)
 	var/actual_sparkspeed = initial(sparkspeed) * get_int_speed_mult(user)
@@ -281,6 +281,54 @@
 	if(istype(rune) && rune.active)
 		return FALSE
 	return TRUE
+
+/atom/movable/screen/alert/status_effect/prestidigitation_light
+	name = "Magelight"
+	desc = "A mote of arcyne light dances around me."
+	icon_state = "stressvg"
+
+/datum/status_effect/prestidigitation_light
+	id = "prestidigitation_light_buff"
+	alert_type = /atom/movable/screen/alert/status_effect/prestidigitation_light
+	duration = 5 MINUTES
+	status_type = STATUS_EFFECT_REFRESH
+	examine_text = "SUBJECTPRONOUN is surrounded by a faint arcyne glow."
+	/// The object attached to the mob that emits light
+	var/obj/effect/dummy/lighting_obj/moblight/mob_light_obj
+	/// Amount of light our buff emits, scales with INT
+	var/magelight_power = 5
+	/// The mote orbiting the owner
+	var/obj/effect/wisp/prestidigitation/linked_mote
+
+/datum/status_effect/prestidigitation_light/on_creation(mob/living/new_owner, light_power)
+	if(light_power > magelight_power)
+		magelight_power = light_power
+	return ..()
+
+/datum/status_effect/prestidigitation_light/refresh(mob/living/owner, light_power)
+	duration += initial(duration)
+	if(light_power > magelight_power)
+		magelight_power = light_power
+		if(mob_light_obj)
+			mob_light_obj.light_power = magelight_power
+
+/datum/status_effect/prestidigitation_light/on_apply()
+	. = ..()
+	if(!.)
+		return
+	playsound(owner, 'sound/magic/whiteflame.ogg', 50, FALSE)
+	to_chat(owner, span_notice("A mote of magelight flickers to life around me!"))
+	mob_light_obj = owner.mob_light(magelight_power, magelight_power, _color = "#3FBAFD")
+	mob_light_obj.light_power = magelight_power
+	linked_mote = new(get_turf(owner))
+	linked_mote.orbit(owner, 1, TRUE, 0, 48, TRUE)
+	return TRUE
+
+/datum/status_effect/prestidigitation_light/on_remove()
+	playsound(owner, 'sound/items/firesnuff.ogg', 50, FALSE)
+	to_chat(owner, span_notice("The magelight fades from around me..."))
+	QDEL_NULL(mob_light_obj)
+	QDEL_NULL(linked_mote)
 
 /obj/effect/wisp/prestidigitation
 	name = "minor magelight mote"


### PR DESCRIPTION
## About The Pull Request

Mage note (basic light from default spell) now acts like Orison's light, and not taking your hand out for one of the worst light sources in the game. Still applied only on caster, to clear buff use clean intent on yourself

Also added basically a will-o-wisp clone with hp for crafting with 2 fairy dust, so mages can decorate their places in cooler ways

## Testing Evidence

Tested on local

## Why It's Good For The Game

Light from prestidigitation mogged by orison so much it's better to buy a lamp at this point. Now they are almost the same, miracles still better but not so much. Restriction to use only on caster should preserve already limited usage "Light" spell have

Craftable wisp is just new way of decorating, nothing more
## Changelog
:cl:
add: Craftable will-o-wisp for mages
balance: prestidigitation light now acts more like orison's, but restricted for caster-only
/:cl: