### PR TITLE
imagine caring about drip, couldn't be me (Additional Cadwyn Items to Donor Ckeys)

### DIFF
--- a/code/datums/loadout/loadout_donators.dm
+++ b/code/datums/loadout/loadout_donators.dm
@@ -576,12 +576,12 @@
 /datum/loadout_item/donator/koruu/kukri
 	name = "Donator Kit - Leachwhacker"
 	path = /obj/item/enchantingkit/weapon/koruu_kukri
-	ckeywhitelist = list("koruu", "pneumothorax", "ryan180602", "vakiova", "maesune")
+	ckeywhitelist = list("koruu", "pneumothorax", "ryan180602", "vakiova", "maesune", "nooriginality")
 
 /datum/loadout_item/donator/koruu/kukri/warden
 	name = "Donator Kit - Warden Leachwhacker"
 	path = /obj/item/enchantingkit/weapon/koruu_kukri/warden
-	ckeywhitelist = list("koruu", "pneumothorax", "ryan180602", "vakiova", "maesune", "dakken12")
+	ckeywhitelist = list("koruu", "pneumothorax", "ryan180602", "vakiova", "maesune", "dakken12", "nooriginality")
 
 /datum/loadout_item/donator/dakken
 	name = "Donator Kit - Armoured Avantyne Barbute"
@@ -702,7 +702,7 @@
 /datum/loadout_item/donator/koruu_silver_kukri
 	name = "Donator Kit - Psydonic Leachwhacker"
 	path = /obj/item/enchantingkit/weapon/koruu_kukri_silver
-	ckeywhitelist = list("koruu", "pepperoniplayboy")
+	ckeywhitelist = list("koruu", "pepperoniplayboy", "nooriginality")
 
 /datum/loadout_item/donator/koruu_longsword
 	name = "Donator Kit - Excaliber"
@@ -1048,12 +1048,22 @@
 	path = /obj/item/clothing/head/roguetown/wizhat/bighat
 	ckeywhitelist = list("glassfeddockterr")
 
-/datum/loadout_item/donator/koruu_cadwyncloak
+/datum/loadout_item/donator/koruu_cadwyncloak_ravox
 	name = "Donator Item - Sefirot's Cloak"
 	path = /obj/item/clothing/cloak/templar/ravoxcleric/koruu
-	ckeywhitelist = list("koruu")
+	ckeywhitelist = list("koruu", "oddbomber3768", "nooriginality", "vakiova", "maesune")
 
-/datum/loadout_item/donator/koruu_cadwynhelm
+/datum/loadout_item/donator/koruu_cadwynhelm_ravox
 	name = "Donator Item - Gebura"
 	path = /obj/item/enchantingkit/donator_koruu_ravoxclerichelm
-	ckeywhitelist = list("koruu")
+	ckeywhitelist = list("koruu", "oddbomber3768", "nooriginality", "vakiova", "maesune")
+
+/datum/loadout_item/donator/koruu_cadwyncloak_astrata
+	name = "Donator Item - Cloak of the Order of the Sun"
+	path = /obj/item/clothing/cloak/templar/astratancleric/koruu
+	ckeywhitelist = list("koruu", "oddbomber3768", "nooriginality", "vakiova", "maesune")
+
+/datum/loadout_item/donator/koruu_cadwynhelm_astrata
+	name = "Donator Item - Lux In Tenebris"
+	path = /obj/item/enchantingkit/donator_koruu_astrataclerichelm
+	ckeywhitelist = list("koruu", "oddbomber3768", "nooriginality", "vakiova", "maesune")

--- a/code/game/objects/items/donator_fluff_items.dm
+++ b/code/game/objects/items/donator_fluff_items.dm
@@ -3763,3 +3763,14 @@ As Excaliber."
 	desc = "Adorned with powerful ox horns and a seamless blindfold, this helm embodies the steadfast resolve of Ravox. Blind, is our justice. Ever-defying, is our tenacity."
 	icon_state = "ravoxclerichelmet"
 	item_state = "ravoxclerichelmet"
+
+/obj/item/clothing/cloak/templar/astratancleric/koruu
+	name = "Cloak of the Order of the Sun"
+	desc = "A golden-colored cloak with frayed edges, bearing the radiant hues of Astrata. It marks the wearer as a beacon of light amidst the chaos of battle."
+	armor = ARMOR_CLOTHING
+
+/obj/item/clothing/head/roguetown/helmet/heavy/astratahelm/cleric/koruu
+	name = "Lux In Tenebris"
+	desc = "Topped with a magnificent plume, this helmet turns the wearer into a walking beacon of Astrata's wrath. Designed to cut a striking silhouette, it strikes terror into the hearts of nonbelievers from afar."
+	icon_state = "astrataclerichelm"
+	item_state = "astrataclerichelm"

--- a/code/game/objects/items/donator_modkit.dm
+++ b/code/game/objects/items/donator_modkit.dm
@@ -1452,7 +1452,7 @@
 
 /obj/item/enchantingkit/donator_koruu_astrataclerichelm
 	name = "'Lux In Tenebris' morphing elixir"
-	desc = "A small container of special morphing dust, perfect to make a specific item. It can be used to alter the appearance of a Justice Eagle."
+	desc = "A small container of special morphing dust, perfect to make a specific item. It can be used to alter the appearance of an Astratan Helmet."
 	target_items = list(
 		/obj/item/clothing/head/roguetown/helmet/heavy/astratahelm		= /obj/item/clothing/head/roguetown/helmet/heavy/astratahelm/cleric/koruu,
 	)

--- a/code/game/objects/items/donator_modkit.dm
+++ b/code/game/objects/items/donator_modkit.dm
@@ -1449,3 +1449,12 @@
 	)
 	result_item = null
 	exact_type = TRUE
+
+/obj/item/enchantingkit/donator_koruu_astrataclerichelm
+	name = "'Lux In Tenebris' morphing elixir"
+	desc = "A small container of special morphing dust, perfect to make a specific item. It can be used to alter the appearance of a Justice Eagle."
+	target_items = list(
+		/obj/item/clothing/head/roguetown/helmet/heavy/astratahelm		= /obj/item/clothing/head/roguetown/helmet/heavy/astratahelm/cleric/koruu,
+	)
+	result_item = null
+	exact_type = TRUE


### PR DESCRIPTION
## About The Pull Request

Adding Donor Ckeys to Previous Donor Items.
Adding Astratan Cadwyn Order items for Specific Ckeys and adding Ckeys to Ravox Cadwyn Order Items

## Testing Evidence

<img width="445" height="551" alt="9e745e9f87c42436b15426465df52f66" src="https://github.com/user-attachments/assets/0270be52-0d89-40ea-a757-2d4766e1204f" />
<img width="374" height="975" alt="5ee24fb01776ad268f07f93070555873" src="https://github.com/user-attachments/assets/42100bdf-bd32-4c87-8c4c-7a9ced838d9d" />

Confirmed that the enchanting kit does not change the armor values of the helmet. Entirely cosmetic. 

## Why It's Good For The Game

It's not good nor bad for the game. These changes are purely cosmetic. 

## Changelog

:cl:
add: Added ckeys to previous donor items originally merged by my request. 
add: Added Astratan Cadwyn Items for Specific Donors
add: Added additional Ckeys to Ravoxian Cadwyn Items. 