### PR TITLE
[Balance] Hunted/Targeted Vices -> DnR

### DIFF
--- a/code/datums/character_flaw/_character_flaw.dm
+++ b/code/datums/character_flaw/_character_flaw.dm
@@ -389,6 +389,7 @@ GLOBAL_LIST_INIT(averse_factions, list(
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
 		ADD_TRAIT(H, TRAIT_ARMOR_BREAK, TRAIT_GENERIC)
+
 /datum/charflaw/hunted
 	name = "Hunted"
 	desc = "Something in my past has made me a target. I'm always looking over my shoulder.	\
@@ -397,6 +398,10 @@ GLOBAL_LIST_INIT(averse_factions, list(
 	ui_fa_icon = "tooth"
 	needs_extra_vice = TRUE
 	var/logged = FALSE
+
+/datum/charflaw/hunted/on_mob_creation(mob/user)
+	. = ..()
+	ADD_TRAIT(user, TRAIT_DNR, TRAIT_GENERIC)
 
 /datum/charflaw/hunted/flaw_on_life(mob/user)
 	if(!ishuman(user))
@@ -422,6 +427,10 @@ GLOBAL_LIST_INIT(averse_factions, list(
 	ui_fa_icon = "crosshairs"
 	needs_extra_vice = TRUE
 	var/logged = FALSE
+
+/datum/charflaw/targeted/on_mob_creation(mob/user)
+	. = ..()
+	ADD_TRAIT(user, TRAIT_DNR, TRAIT_GENERIC)
 
 /datum/charflaw/targeted/flaw_on_life(mob/user)
 	if(!ishuman(user))


### PR DESCRIPTION
## About The Pull Request

- Hunted and Targeted both set you to DnR, to increase a little more the paranoia of having someone after you.

## Testing Evidence

Code only, compiles.

## Why It's Good For The Game

It kind of sucks to finally kill your target, die for it, then watch them be resurrected anyway. Same lane as Martyr being revived to continue ulting on someone else, or Duke being revived to continue on his post. 

Taking this vice should mean you're putting your round on the line, and your hunter will likely not be able to be revived anyway given antags are scarcely given the chance to not be RR'd.

## Changelog
:cl:
add: Hunted and Targeted set you to DnR.
/:cl: