### PR TITLE
[QoL] Hunted/Targeted Segmented

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -340,9 +340,10 @@
 // ASSASSIN ANTAG TRAITS
 #define TRAIT_CLAIMED_BY_DARKSTAR "Claimed by the Dark Star" // applied to targeted users that get dagger'd
 #define TRAIT_ASSASSIN	"Assassin" // needed by assassin to use dagger
+#define TRAIT_STALKPHOBIA "Disturbing Revelations"
 
 // GNOLL ANTAG TRAITS
-#define TRAIT_GNOLLPHOBIA "Gnollphobia"
+#define TRAIT_GNOLLPHOBIA "Phobia of Gnolls"
 
 //ASCENDANT GOD CURSES
 
@@ -708,6 +709,7 @@ GLOBAL_LIST_INIT(roguetraits, list(
 	TRAIT_ENGINEERING_GOGGLES = span_warning("I can see structural details others can't."),
 	TRAIT_ASSASSIN = span_cult("Holy my Hecatomb. Holy my Hunger. Wholly I offer my flesh. The Sinistar has chosen me to be one of his huntsmen."),
 	TRAIT_GNOLLPHOBIA = span_cult("I just can't with Gnolls. I can hand on anything in this world except for them. If I ever try to fight one, I'll certainly lose."),
+	TRAIT_STALKPHOBIA = span_cult("Ever since I read that letter, something primal has awaken within me that fears whatever blade is pointed to my neck. I'll certainly lose if I try to fight an Assassin."),
 	TRAIT_MASTER_CARPENTER = span_warning("I've been trained to make the most of wood"),
 	TRAIT_MASTER_MASON = span_warning("I've been trained to make the most of stone"),
 	TRAIT_EQUESTRIAN = span_warning("I am a capable rider. My mount is an extension of me."),

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -341,6 +341,8 @@
 #define TRAIT_CLAIMED_BY_DARKSTAR "Claimed by the Dark Star" // applied to targeted users that get dagger'd
 #define TRAIT_ASSASSIN	"Assassin" // needed by assassin to use dagger
 
+// GNOLL ANTAG TRAITS
+#define TRAIT_GNOLLPHOBIA "Gnollphobia"
 
 //ASCENDANT GOD CURSES
 
@@ -705,6 +707,7 @@ GLOBAL_LIST_INIT(roguetraits, list(
 	TRAIT_DREAMWALKER = span_warning("I walk the dream and reality at the same time. My mind frays, but my vision shall be reality."),
 	TRAIT_ENGINEERING_GOGGLES = span_warning("I can see structural details others can't."),
 	TRAIT_ASSASSIN = span_cult("Holy my Hecatomb. Holy my Hunger. Wholly I offer my flesh. The Sinistar has chosen me to be one of his huntsmen."),
+	TRAIT_GNOLLPHOBIA = span_cult("I just can't with Gnolls. I can hand on anything in this world except for them. If I ever try to fight one, I'll certainly lose."),
 	TRAIT_MASTER_CARPENTER = span_warning("I've been trained to make the most of wood"),
 	TRAIT_MASTER_MASON = span_warning("I've been trained to make the most of stone"),
 	TRAIT_EQUESTRIAN = span_warning("I am a capable rider. My mount is an extension of me."),

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -139,6 +139,13 @@
 		to_chat(user, span_warning("I don't want to harm other living beings!"))
 		return
 
+	if(force && HAS_TRAIT(user, TRAIT_GNOLLPHOBIA) && isgnoll(M))
+		if(prob(50))
+			user.emote("scream")
+			user.Stun(2 SECONDS)
+			user.OffBalance(5 SECONDS)
+			return FALSE
+
 	if(force && user.has_status_effect(/datum/status_effect/debuff/deadite_grace) && M.mind)
 		to_chat(user, span_warning("Ah, Lux... I calm down considerably, but my hunger only increases."))
 		user.remove_status_effect(/datum/status_effect/debuff/deadite_grace)

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -146,6 +146,13 @@
 			user.OffBalance(5 SECONDS)
 			return FALSE
 
+	if(force && HAS_TRAIT(user, TRAIT_STALKPHOBIA) && M.mind?.has_antag_datum(/datum/antagonist/assassin))
+		if(prob(50))
+			user.emote("scream")
+			user.Stun(2 SECONDS)
+			user.OffBalance(5 SECONDS)
+			return FALSE
+
 	if(force && user.has_status_effect(/datum/status_effect/debuff/deadite_grace) && M.mind)
 		to_chat(user, span_warning("Ah, Lux... I calm down considerably, but my hunger only increases."))
 		user.remove_status_effect(/datum/status_effect/debuff/deadite_grace)

--- a/code/datums/character_flaw/_character_flaw.dm
+++ b/code/datums/character_flaw/_character_flaw.dm
@@ -417,7 +417,7 @@ GLOBAL_LIST_INIT(averse_factions, list(
 
 /datum/charflaw/hunted
 	name = "Gnoll Prey (Hunted)"
-	desc = "I have been marked for the hunt by Sinistar's champions for one reason or another. I can try to fight back and escape, but they will actively pursue me. YOU ARE SIGNING UP TO BE HUNTED, EXPECT LOW ESCALATION."
+	desc = "I have been marked for the hunt by Sinistar's champions for one reason or another. I can try to fight back and escape, but they will actively pursue me. YOU ARE SIGNING UP TO BE HUNTED, EXPECT LOW ESCALATION. (THIS REMOVES ANY SCENE PROTECTION FOR BOTH YOU AND YOUR PARTNER)."
 	ui_fa_icon = "tooth"
 	needs_extra_vice = TRUE
 	var/logged = FALSE
@@ -438,7 +438,7 @@ GLOBAL_LIST_INIT(averse_factions, list(
 
 /datum/charflaw/bloodprice
 	name = "Gnoll Prey (Blood Price)"
-	desc = "I have a price on my blood, and Sinistar's champions want me DEAD and GONE. My death is their priority above capture, intimidation, or sport. YOU ARE SIGNING UP TO BE A MARKED TARGET FOR DEATH. EXPECT NO ESCALATION, YOU ARE WAIVERING ALL RULE PROTECTIONS."
+	desc = "I have a price on my blood, and Sinistar's champions want me DEAD and GONE. My death is their priority above capture, intimidation, or sport. YOU ARE SIGNING UP TO BE A MARKED TARGET FOR DEATH. EXPECT NO ESCALATION. (THIS REMOVES ANY SCENE PROTECTION FOR BOTH YOU AND YOUR PARTNER)."
 	ui_fa_icon = "tooth"
 	needs_extra_vice = TRUE
 	var/logged = FALSE
@@ -463,7 +463,7 @@ GLOBAL_LIST_INIT(averse_factions, list(
 
 /datum/charflaw/targeted
 	name = "Assassin's Mark (Targeted)"
-	desc = "Someone has offered my name to the Bloodsworn of Graggar. Their assassins may hunt me at any time, and if they kill me, I will be temporarily removed from the round, until their cursed is broken. THIS VICE ALLOWS ASSASSINS TO ATTACK WITHOUT ESCALATION. EXPECT RANDOM ATTACKS AND POSSIBLE ROUND REMOVAL. YOU STILL HAVE ERP PROTECTION."
+	desc = "Someone has offered my name to the Bloodsworn of Graggar. Their assassins may hunt me at any time, and if they kill me, I will be temporarily removed from the round, until their cursed is broken. THIS VICE ALLOWS ASSASSINS TO ATTACK WITHOUT ESCALATION. EXPECT RANDOM ATTACKS AND POSSIBLE ROUND REMOVAL. (THIS REMOVES ANY SCENE PROTECTION FOR BOTH YOU AND YOUR PARTNER)."
 	ui_fa_icon = "crosshairs"
 	needs_extra_vice = TRUE
 	var/logged = FALSE
@@ -484,7 +484,7 @@ GLOBAL_LIST_INIT(averse_factions, list(
 
 /datum/charflaw/marked_for_death
 	name = "Assassin's Mark (Marked for Death)"
-	desc = "Someone has offered my name to the Bloodsworn of Graggar, and sacrificed themselves to curse my Lux. Their assassins will hunt me relentlessly, and if they kill me, I'm done for. THIS VICE ALLOWS ASSASSINS TO HUNT AND ATTACK WITHOUT ESCALATION. EXPECT RANDOM ATTACKS AND GUARANTEED ROUND REMOVAL ON DEATH. YOU HAVE NO PROTECTION."
+	desc = "Someone has offered my name to the Bloodsworn of Graggar, and sacrificed themselves to curse my Lux. Their assassins will hunt me relentlessly, and if they kill me, I'm done for. THIS VICE ALLOWS ASSASSINS TO HUNT AND ATTACK WITHOUT ESCALATION. EXPECT RANDOM ATTACKS AND GUARANTEED ROUND REMOVAL ON DEATH. (THIS REMOVES ANY SCENE PROTECTION FOR BOTH YOU AND YOUR PARTNER)"
 	ui_fa_icon = "crosshairs"
 	needs_extra_vice = TRUE
 	var/logged = FALSE
@@ -503,6 +503,31 @@ GLOBAL_LIST_INIT(averse_factions, list(
 			logged = TRUE
 
 /datum/charflaw/marked_for_death/apply_post_equipment(mob/user)
+	..()
+	if(!ishuman(user))
+		return
+
+/datum/charflaw/low_profile
+	name = "Assassin's Mark (Low Profile)"
+	desc = "Someone has offered my name to the Bloodsworn of Graggar, but I was deemed unworthy. I have received a disturbing letter from them about it, and that I'll be under watch, and to cooperate, or else. THIS VICE IS PURELY FOR ROLEPLAY. ENCOUNTERS ARE LIKELY NOT GOING TO BE LETHAL, BUT CAN BE. EXPECT THEM TO ALWAYS KNOW WHERE YOU ARE."
+	ui_fa_icon = "crosshairs"
+	needs_extra_vice = TRUE
+	var/logged = FALSE
+
+/datum/charflaw/low_profile/on_mob_creation(mob/user)
+	. = ..()
+	ADD_TRAIT(user, TRAIT_STALKPHOBIA, TRAIT_GENERIC)
+
+/datum/charflaw/low_profile/flaw_on_life(mob/user)
+	if(!ishuman(user))
+		return
+	var/mob/living/carbon/human/H = user
+	if(logged == FALSE)
+		if(H.name)
+			log_hunted("[H.ckey] playing as [H.name] had the ASSASSIN'S MARK (LOW PROFILE) flaw by vice (No DnR, Low-Esc, Non-Lethal).")
+			logged = TRUE
+
+/datum/charflaw/low_profile/apply_post_equipment(mob/user)
 	..()
 	if(!ishuman(user))
 		return

--- a/code/datums/character_flaw/_character_flaw.dm
+++ b/code/datums/character_flaw/_character_flaw.dm
@@ -390,12 +390,34 @@ GLOBAL_LIST_INIT(averse_factions, list(
 		var/mob/living/carbon/human/H = user
 		ADD_TRAIT(H, TRAIT_ARMOR_BREAK, TRAIT_GENERIC)
 
+/datum/charflaw/stalked
+	name = "Gnoll Prey (Lamb)"
+	desc = "I have been marked as leisure prey by Sinistar's champions. But I have a phobia of these creachers, leaving me helpless against them and expected to fear, flee, hide, or submit rather than fight back. THIS VICE IS PURELY FOR ROLEPLAY, DO NOT EXPECT COMBAT. YOU ARE SIGNING UP TO BE THE VICTIM."
+	ui_fa_icon = "tooth"
+	needs_extra_vice = TRUE
+	var/logged = FALSE
+
+/datum/charflaw/stalked/on_mob_creation(mob/user)
+	. = ..()
+	ADD_TRAIT(user, TRAIT_GNOLLPHOBIA, TRAIT_GENERIC)
+
+/datum/charflaw/stalked/flaw_on_life(mob/user)
+	if(!ishuman(user))
+		return
+	var/mob/living/carbon/human/H = user
+	if(logged == FALSE)
+		if(H.name)
+			log_hunted("[H.ckey] playing as [H.name] had the GNOLL PREY (LAMB) flaw by vice (Non-Lethal, No/Low-Esc, Victim).")
+			logged = TRUE
+
+/datum/charflaw/stalked/apply_post_equipment(mob/user)
+	..()
+	if(!ishuman(user))
+		return
+
 /datum/charflaw/hunted
-	name = "Hunted"
-	desc = "Something in my past has drawn the attention of Sinistar's champions. Gnolls have marked me as prey, and they may appear at any time to hunt me down. Their intent is to pursue, intimidate, capture, or otherwise harass me, but they are not automatically out for my death. \
-	\nTHIS IS A DIFFICULT FLAW. YOU WILL BE HUNTED BY GNOLLS. EXPECT A MORE DIFFICULT EXPERIENCE AND BE PREPARED TO PLAY ALONG WITH THEIR ATTENTION. \
-	\nThis is a NON-SERIOUS threat. Gnolls MUST ESCALATE before attempting to engage in combat against you. Having this flaw means accepting that you may be pursued or attacked, not that you have been given a death sentence, so expect roleplay over combat. \
-	\nPLAY AT YOUR OWN RISK. THIS FLAW REQUIRES AN EXTRA VICE."
+	name = "Gnoll Prey (Hunted)"
+	desc = "I have been marked for the hunt by Sinistar's champions for one reason or another. I can try to fight back and escape, but they will actively pursue me. YOU ARE SIGNING UP TO BE HUNTED, EXPECT LOW ESCALATION."
 	ui_fa_icon = "tooth"
 	needs_extra_vice = TRUE
 	var/logged = FALSE
@@ -406,21 +428,17 @@ GLOBAL_LIST_INIT(averse_factions, list(
 	var/mob/living/carbon/human/H = user
 	if(logged == FALSE)
 		if(H.name)
-			log_hunted("[H.ckey] playing as [H.name] had the hunted flaw by vice.")
+			log_hunted("[H.ckey] playing as [H.name] had the GNOLL PREY (HUNTED) flaw by vice (Lethal, Low-Esc).")
 			logged = TRUE
 
 /datum/charflaw/hunted/apply_post_equipment(mob/user)
 	..()
-
 	if(!ishuman(user))
 		return
 
 /datum/charflaw/bloodprice
-	name = "Blood Price"
-	desc = "Something in my past has earned me the hatred of Sinistar's champions. Gnolls have placed a price upon my blood, and they do not merely wish to frighten or drive me away — they want me dead. I am a marked enemy, and their hunters may pursue me wherever I go. \
-	\nTHIS IS A DIFFICULT FLAW. YOU WILL BE HUNTED BY GNOLLS WHO ACTIVELY SEEK YOUR DEATH. EXPECT A MORE DIFFICULT EXPERIENCE AND BE PREPARED FOR DEADLY ATTACKS. \
-	\nThis is a SERIOUS threat. Gnolls hunting you have NO ESCALATION REQUIREMENT and may immediately resort to deadly violence against you. They hate you, and killing you is the purpose of their hunt. \
-	\nPLAY AT YOUR OWN RISK. THIS FLAW REQUIRES AN EXTRA VICE."
+	name = "Gnoll Prey (Blood Price)"
+	desc = "I have a price on my blood, and Sinistar's champions want me DEAD and GONE. My death is their priority above capture, intimidation, or sport. YOU ARE SIGNING UP TO BE A MARKED TARGET FOR DEATH. EXPECT NO ESCALATION, YOU ARE WAIVERING ALL RULE PROTECTIONS."
 	ui_fa_icon = "tooth"
 	needs_extra_vice = TRUE
 	var/logged = FALSE
@@ -435,7 +453,7 @@ GLOBAL_LIST_INIT(averse_factions, list(
 	var/mob/living/carbon/human/H = user
 	if(logged == FALSE)
 		if(H.name)
-			log_hunted("[H.ckey] playing as [H.name] had the blood price flaw by vice.")
+			log_hunted("[H.ckey] playing as [H.name] had the GNOLL PREY (BLOOD PRICE) flaw by vice (DnR, Lethal, No-Esc).")
 			logged = TRUE
 
 /datum/charflaw/bloodprice/apply_post_equipment(mob/user)
@@ -444,12 +462,8 @@ GLOBAL_LIST_INIT(averse_factions, list(
 		return
 
 /datum/charflaw/targeted
-	name = "Targeted"
-	desc = "Someone, somewhere, has offered up my name to the Bloodsworn of Graggar. \
-	Assassins may seek my skin-and-soul to steal-and-bind." + span_artery("\nHaving this vice will add you to a list of targets hunted by a powerful \
-	class. If they are successful in killing you, you may be round-removed for a time, though you will be recoverable if the assassin is slain and \
-	their dagger is broken.") + span_danger("\nAssassins DO-NOT NEED to ESCALATE against you if you have this vice. To reiterate: please expect \
-	random attacks and-or potential round removal, even if not permanent. You are still granted ERP protection.")
+	name = "Assassin's Mark (Targeted)"
+	desc = "Someone has offered my name to the Bloodsworn of Graggar. Their assassins may hunt me at any time, and if they kill me, I will be temporarily removed from the round, until their cursed is broken. THIS VICE ALLOWS ASSASSINS TO ATTACK WITHOUT ESCALATION. EXPECT RANDOM ATTACKS AND POSSIBLE ROUND REMOVAL. YOU STILL HAVE ERP PROTECTION."
 	ui_fa_icon = "crosshairs"
 	needs_extra_vice = TRUE
 	var/logged = FALSE
@@ -460,7 +474,7 @@ GLOBAL_LIST_INIT(averse_factions, list(
 	var/mob/living/carbon/human/H = user
 	if(logged == FALSE)
 		if(H.name)
-			log_hunted("[H.ckey] playing as [H.name] had the targeted flaw by vice.")
+			log_hunted("[H.ckey] playing as [H.name] had the ASSASSIN'S MARK (TARGETED) flaw by vice (No DnR, Low-Esc).")
 			logged = TRUE
 
 /datum/charflaw/targeted/apply_post_equipment(mob/user)
@@ -469,12 +483,8 @@ GLOBAL_LIST_INIT(averse_factions, list(
 		return
 
 /datum/charflaw/marked_for_death
-	name = "Marked for Death"
-	desc = "Someone, somewhere, has offered up my name to the Bloodsworn of Graggar, and sacrificed themselves to further curse the end of your existence. \
-	Assassins may seek my skin-and-soul to steal-and-bind." + span_artery("\nHaving this vice will add you to a list of targets hunted by a powerful \
-	class. If they are successful in killing you, you may be round-removed for a time, though you will be recoverable if the assassin is slain and \
-	their dagger is broken.") + span_danger("\nAssassins DO-NOT NEED to ESCALATE against you if you have this vice. To reiterate: please expect \
-	random attacks and guaranteed round removal. You are still granted ERP protection.")
+	name = "Assassin's Mark (Marked for Death)"
+	desc = "Someone has offered my name to the Bloodsworn of Graggar, and sacrificed themselves to curse my Lux. Their assassins will hunt me relentlessly, and if they kill me, I'm done for. THIS VICE ALLOWS ASSASSINS TO HUNT AND ATTACK WITHOUT ESCALATION. EXPECT RANDOM ATTACKS AND GUARANTEED ROUND REMOVAL ON DEATH. YOU HAVE NO PROTECTION."
 	ui_fa_icon = "crosshairs"
 	needs_extra_vice = TRUE
 	var/logged = FALSE
@@ -489,7 +499,7 @@ GLOBAL_LIST_INIT(averse_factions, list(
 	var/mob/living/carbon/human/H = user
 	if(logged == FALSE)
 		if(H.name)
-			log_hunted("[H.ckey] playing as [H.name] had the marked for death flaw by vice.")
+			log_hunted("[H.ckey] playing as [H.name] had the ASSASSIN'S MARK (MARKED FOR DEATH) flaw by vice (DnR, No-Esc).")
 			logged = TRUE
 
 /datum/charflaw/marked_for_death/apply_post_equipment(mob/user)

--- a/code/datums/character_flaw/_character_flaw.dm
+++ b/code/datums/character_flaw/_character_flaw.dm
@@ -392,27 +392,53 @@ GLOBAL_LIST_INIT(averse_factions, list(
 
 /datum/charflaw/hunted
 	name = "Hunted"
-	desc = "Something in my past has made me a target. I'm always looking over my shoulder.	\
-	\nTHIS IS A DIFFICULT FLAW, YOU WILL BE HUNTED BY GNOLLS. \
-	EXPECT A MORE DIFFICULT EXPERIENCE. PLAY AT YOUR OWN RISK. IT REQUIRES AN EXTRA VICE."
+	desc = "Something in my past has drawn the attention of Sinistar's champions. Gnolls have marked me as prey, and they may appear at any time to hunt me down. Their intent is to pursue, intimidate, capture, or otherwise harass me, but they are not automatically out for my death. \
+	\nTHIS IS A DIFFICULT FLAW. YOU WILL BE HUNTED BY GNOLLS. EXPECT A MORE DIFFICULT EXPERIENCE AND BE PREPARED TO PLAY ALONG WITH THEIR ATTENTION. \
+	\nThis is a NON-SERIOUS threat. Gnolls MUST ESCALATE before attempting to engage in combat against you. Having this flaw means accepting that you may be pursued or attacked, not that you have been given a death sentence, so expect roleplay over combat. \
+	\nPLAY AT YOUR OWN RISK. THIS FLAW REQUIRES AN EXTRA VICE."
 	ui_fa_icon = "tooth"
 	needs_extra_vice = TRUE
 	var/logged = FALSE
-
-/datum/charflaw/hunted/on_mob_creation(mob/user)
-	. = ..()
-	ADD_TRAIT(user, TRAIT_DNR, TRAIT_GENERIC)
 
 /datum/charflaw/hunted/flaw_on_life(mob/user)
 	if(!ishuman(user))
 		return
 	var/mob/living/carbon/human/H = user
 	if(logged == FALSE)
-		if(H.name) // If you don't check this, the log entry wont have a name as flaw_on_life is checked at least once before the name is set.
+		if(H.name)
 			log_hunted("[H.ckey] playing as [H.name] had the hunted flaw by vice.")
 			logged = TRUE
 
 /datum/charflaw/hunted/apply_post_equipment(mob/user)
+	..()
+
+	if(!ishuman(user))
+		return
+
+/datum/charflaw/bloodprice
+	name = "Blood Price"
+	desc = "Something in my past has earned me the hatred of Sinistar's champions. Gnolls have placed a price upon my blood, and they do not merely wish to frighten or drive me away — they want me dead. I am a marked enemy, and their hunters may pursue me wherever I go. \
+	\nTHIS IS A DIFFICULT FLAW. YOU WILL BE HUNTED BY GNOLLS WHO ACTIVELY SEEK YOUR DEATH. EXPECT A MORE DIFFICULT EXPERIENCE AND BE PREPARED FOR DEADLY ATTACKS. \
+	\nThis is a SERIOUS threat. Gnolls hunting you have NO ESCALATION REQUIREMENT and may immediately resort to deadly violence against you. They hate you, and killing you is the purpose of their hunt. \
+	\nPLAY AT YOUR OWN RISK. THIS FLAW REQUIRES AN EXTRA VICE."
+	ui_fa_icon = "tooth"
+	needs_extra_vice = TRUE
+	var/logged = FALSE
+
+/datum/charflaw/bloodprice/on_mob_creation(mob/user)
+	. = ..()
+	ADD_TRAIT(user, TRAIT_DNR, TRAIT_GENERIC)
+
+/datum/charflaw/bloodprice/flaw_on_life(mob/user)
+	if(!ishuman(user))
+		return
+	var/mob/living/carbon/human/H = user
+	if(logged == FALSE)
+		if(H.name)
+			log_hunted("[H.ckey] playing as [H.name] had the blood price flaw by vice.")
+			logged = TRUE
+
+/datum/charflaw/bloodprice/apply_post_equipment(mob/user)
 	..()
 	if(!ishuman(user))
 		return
@@ -428,20 +454,45 @@ GLOBAL_LIST_INIT(averse_factions, list(
 	needs_extra_vice = TRUE
 	var/logged = FALSE
 
-/datum/charflaw/targeted/on_mob_creation(mob/user)
-	. = ..()
-	ADD_TRAIT(user, TRAIT_DNR, TRAIT_GENERIC)
-
 /datum/charflaw/targeted/flaw_on_life(mob/user)
 	if(!ishuman(user))
 		return
 	var/mob/living/carbon/human/H = user
 	if(logged == FALSE)
-		if(H.name) // If you don't check this, the log entry wont have a name as flaw_on_life is checked at least once before the name is set.
-			log_hunted("[H.ckey] playing as [H.name] had the targeted flaw by vice.") // we log this in the same place as hunted because making a seperate log for it would be silly
+		if(H.name)
+			log_hunted("[H.ckey] playing as [H.name] had the targeted flaw by vice.")
 			logged = TRUE
 
 /datum/charflaw/targeted/apply_post_equipment(mob/user)
+	..()
+	if(!ishuman(user))
+		return
+
+/datum/charflaw/marked_for_death
+	name = "Marked for Death"
+	desc = "Someone, somewhere, has offered up my name to the Bloodsworn of Graggar, and sacrificed themselves to further curse the end of your existence. \
+	Assassins may seek my skin-and-soul to steal-and-bind." + span_artery("\nHaving this vice will add you to a list of targets hunted by a powerful \
+	class. If they are successful in killing you, you may be round-removed for a time, though you will be recoverable if the assassin is slain and \
+	their dagger is broken.") + span_danger("\nAssassins DO-NOT NEED to ESCALATE against you if you have this vice. To reiterate: please expect \
+	random attacks and guaranteed round removal. You are still granted ERP protection.")
+	ui_fa_icon = "crosshairs"
+	needs_extra_vice = TRUE
+	var/logged = FALSE
+
+/datum/charflaw/marked_for_death/on_mob_creation(mob/user)
+	. = ..()
+	ADD_TRAIT(user, TRAIT_DNR, TRAIT_GENERIC)
+
+/datum/charflaw/marked_for_death/flaw_on_life(mob/user)
+	if(!ishuman(user))
+		return
+	var/mob/living/carbon/human/H = user
+	if(logged == FALSE)
+		if(H.name)
+			log_hunted("[H.ckey] playing as [H.name] had the marked for death flaw by vice.")
+			logged = TRUE
+
+/datum/charflaw/marked_for_death/apply_post_equipment(mob/user)
 	..()
 	if(!ishuman(user))
 		return

--- a/code/datums/character_flaw/_character_flaw.dm
+++ b/code/datums/character_flaw/_character_flaw.dm
@@ -392,7 +392,7 @@ GLOBAL_LIST_INIT(averse_factions, list(
 
 /datum/charflaw/stalked
 	name = "Gnoll Prey (Lamb)"
-	desc = "I have been marked as leisure prey by Sinistar's champions. But I have a phobia of these creachers, leaving me helpless against them and expected to fear, flee, hide, or submit rather than fight back. THIS VICE IS PURELY FOR ROLEPLAY, DO NOT EXPECT COMBAT. YOU ARE SIGNING UP TO BE THE VICTIM."
+	desc = "I have been marked as leisure prey by Sinistar's champions. But I have a phobia of these creachers, leaving me helpless against them and expected to fear, flee, hide, or submit rather than fight back. YOU ARE SIGNING UP TO BE A VICTIM. EXPECT TO BE STALKED RANDOMLY AND MECHANICALLY INTERACTED WITH VERY LITTLE ESCALATION OR REASON. (Please, use some common sense and try not to get into 'private scenes' while having this vice)"
 	ui_fa_icon = "tooth"
 	needs_extra_vice = TRUE
 	var/logged = FALSE
@@ -417,7 +417,7 @@ GLOBAL_LIST_INIT(averse_factions, list(
 
 /datum/charflaw/hunted
 	name = "Gnoll Prey (Hunted)"
-	desc = "I have been marked for the hunt by Sinistar's champions for one reason or another. I can try to fight back and escape, but they will actively pursue me. YOU ARE SIGNING UP TO BE HUNTED, EXPECT LOW ESCALATION. (THIS REMOVES ANY SCENE PROTECTION FOR BOTH YOU AND YOUR PARTNER)."
+	desc = "I have been marked for the hunt by Sinistar's champions for one reason or another. I can try to fight back and escape, but they will actively pursue me. YOU ARE SIGNING UP TO BE A MARKED TARGET. EXPECT TO BE ATTACKED RANDOMLY WITH VERY LITTLE ESCALATION OR REASON. (Please, use some common sense and try not to get into 'private scenes' while having this vice)."
 	ui_fa_icon = "tooth"
 	needs_extra_vice = TRUE
 	var/logged = FALSE
@@ -438,7 +438,7 @@ GLOBAL_LIST_INIT(averse_factions, list(
 
 /datum/charflaw/bloodprice
 	name = "Gnoll Prey (Blood Price)"
-	desc = "I have a price on my blood, and Sinistar's champions want me DEAD and GONE. My death is their priority above capture, intimidation, or sport. YOU ARE SIGNING UP TO BE A MARKED TARGET FOR DEATH. EXPECT NO ESCALATION. (THIS REMOVES ANY SCENE PROTECTION FOR BOTH YOU AND YOUR PARTNER)."
+	desc = "I have a fatal price on my blood, and Sinistar's champions want me DEAD and GONE. My death is their top priority above capture, intimidation, or sport. YOU ARE SIGNING UP TO BE A MARKED TARGET. EXPECT TO BE ATTACKED RANDOMLY WITH VERY LITTLE ESCALATION OR REASON. YOU WILL BE PERMANENTLY KILLED IF YOU DIE. (Please, use some common sense and try not to get into 'private scenes' while having this vice)."
 	ui_fa_icon = "tooth"
 	needs_extra_vice = TRUE
 	var/logged = FALSE
@@ -463,7 +463,7 @@ GLOBAL_LIST_INIT(averse_factions, list(
 
 /datum/charflaw/targeted
 	name = "Assassin's Mark (Targeted)"
-	desc = "Someone has offered my name to the Bloodsworn of Graggar. Their assassins may hunt me at any time, and if they kill me, I will be temporarily removed from the round, until their cursed is broken. THIS VICE ALLOWS ASSASSINS TO ATTACK WITHOUT ESCALATION. EXPECT RANDOM ATTACKS AND POSSIBLE ROUND REMOVAL. (THIS REMOVES ANY SCENE PROTECTION FOR BOTH YOU AND YOUR PARTNER)."
+	desc = "Someone has offered my name to the Bloodsworn of Graggar. Their assassins may hunt me at any time, and if they kill me, I will be temporarily removed from the round, until their cursed blade is broken. YOU ARE SIGNING UP TO BE A MARKED TARGET. EXPECT TO BE ATTACKED RANDOMLY WITH VERY LITTLE ESCALATION OR REASON. (Please, use some common sense and try not to get into 'private scenes' while having this vice)."
 	ui_fa_icon = "crosshairs"
 	needs_extra_vice = TRUE
 	var/logged = FALSE
@@ -484,7 +484,7 @@ GLOBAL_LIST_INIT(averse_factions, list(
 
 /datum/charflaw/marked_for_death
 	name = "Assassin's Mark (Marked for Death)"
-	desc = "Someone has offered my name to the Bloodsworn of Graggar, and sacrificed themselves to curse my Lux. Their assassins will hunt me relentlessly, and if they kill me, I'm done for. THIS VICE ALLOWS ASSASSINS TO HUNT AND ATTACK WITHOUT ESCALATION. EXPECT RANDOM ATTACKS AND GUARANTEED ROUND REMOVAL ON DEATH. (THIS REMOVES ANY SCENE PROTECTION FOR BOTH YOU AND YOUR PARTNER)"
+	desc = "Someone has offered my name to the Bloodsworn of Graggar, and sacrificed themselves to curse my Lux. Their assassins will hunt me relentlessly, and if they kill me, I'm done for. YOU ARE SIGNING UP TO BE A MARKED TARGET. EXPECT TO BE ATTACKED RANDOMLY WITH VERY LITTLE ESCALATION OR REASON. YOU WILL BE PERMANENTLY KILLED IF YOU DIE. (Please, use some common sense and try not to get into 'private scenes' while having this vice)."
 	ui_fa_icon = "crosshairs"
 	needs_extra_vice = TRUE
 	var/logged = FALSE
@@ -509,7 +509,7 @@ GLOBAL_LIST_INIT(averse_factions, list(
 
 /datum/charflaw/low_profile
 	name = "Assassin's Mark (Low Profile)"
-	desc = "Someone has offered my name to the Bloodsworn of Graggar, but I was deemed unworthy. I have received a disturbing letter from them about it, and that I'll be under watch, and to cooperate, or else. THIS VICE IS PURELY FOR ROLEPLAY. ENCOUNTERS ARE LIKELY NOT GOING TO BE LETHAL, BUT CAN BE. EXPECT THEM TO ALWAYS KNOW WHERE YOU ARE."
+	desc = "Someone has offered my name to the Bloodsworn of Graggar, but I was deemed unworthy. I have received a disturbing letter from them about it, and that I'll be under watch, and to cooperate, or else. YOU ARE SIGNING UP TO BE A VICTIM. EXPECT TO BE STALKED RANDOMLY AND MECHANICALLY INTERACTED WITH VERY LITTLE ESCALATION OR REASON. (Please, use some common sense and try not to get into 'private scenes' while having this vice)"
 	ui_fa_icon = "crosshairs"
 	needs_extra_vice = TRUE
 	var/logged = FALSE

--- a/code/datums/character_flaw/_character_flaw.dm
+++ b/code/datums/character_flaw/_character_flaw.dm
@@ -389,6 +389,7 @@ GLOBAL_LIST_INIT(averse_factions, list(
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
 		ADD_TRAIT(H, TRAIT_ARMOR_BREAK, TRAIT_GENERIC)
+
 /datum/charflaw/hunted
 	name = "Hunted"
 	desc = "Something in my past has made me a target. I'm always looking over my shoulder.	\
@@ -397,6 +398,10 @@ GLOBAL_LIST_INIT(averse_factions, list(
 	ui_fa_icon = "tooth"
 	needs_extra_vice = TRUE
 	var/logged = FALSE
+
+/datum/charflaw/hunted/on_mob_creation(mob/user)
+	. = ..()
+	ADD_TRAIT(user, TRAIT_DNR, TRAIT_GENERIC)
 
 /datum/charflaw/hunted/flaw_on_life(mob/user)
 	if(!ishuman(user))
@@ -422,6 +427,10 @@ GLOBAL_LIST_INIT(averse_factions, list(
 	ui_fa_icon = "crosshairs"
 	needs_extra_vice = TRUE
 	var/logged = FALSE
+
+/datum/charflaw/targeted/on_mob_creation(mob/user)
+	. = ..()
+	ADD_TRAIT(user, TRAIT_DNR, TRAIT_GENERIC)
 
 /datum/charflaw/targeted/flaw_on_life(mob/user)
 	if(!ishuman(user))

--- a/code/game/objects/items/rogueweapons/mmb/bite.dm
+++ b/code/game/objects/items/rogueweapons/mmb/bite.dm
@@ -67,6 +67,14 @@
 	if(HAS_TRAIT(user, TRAIT_PACIFISM))
 		to_chat(user, span_warning("I don't want to harm [src]!"))
 		return FALSE
+
+	if(HAS_TRAIT(user, TRAIT_GNOLLPHOBIA) && isgnoll(src))
+		if(prob(50))
+			user.emote("scream")
+			user.Stun(2 SECONDS)
+			user.OffBalance(5 SECONDS)
+			return FALSE
+
 	if(user.has_status_effect(/datum/status_effect/debuff/deadite_grace) && src.mind)
 		to_chat(user, span_warning("Ah, Lux... I calm down considerably, but my hunger only increases."))
 		user.remove_status_effect(/datum/status_effect/debuff/deadite_grace)

--- a/code/game/objects/items/rogueweapons/mmb/bite.dm
+++ b/code/game/objects/items/rogueweapons/mmb/bite.dm
@@ -75,6 +75,13 @@
 			user.OffBalance(5 SECONDS)
 			return FALSE
 
+	if(HAS_TRAIT(user, TRAIT_STALKPHOBIA) && src.mind?.has_antag_datum(/datum/antagonist/assassin))
+		if(prob(50))
+			user.emote("scream")
+			user.Stun(2 SECONDS)
+			user.OffBalance(5 SECONDS)
+			return FALSE
+
 	if(user.has_status_effect(/datum/status_effect/debuff/deadite_grace) && src.mind)
 		to_chat(user, span_warning("Ah, Lux... I calm down considerably, but my hunger only increases."))
 		user.remove_status_effect(/datum/status_effect/debuff/deadite_grace)

--- a/code/modules/antagonists/roguetown/villain/gnoll/gnoll_spells.dm
+++ b/code/modules/antagonists/roguetown/villain/gnoll/gnoll_spells.dm
@@ -62,6 +62,11 @@
 /obj/effect/proc_holder/spell/invoked/gnoll_sniff/proc/select_new_target(mob/user)
 	var/list/possible_targets = list()
 
+	to_chat(user, span_artery("You focus on the possible targets... You instinctively consider what each of them may be."))
+	to_chat(user, span_artery("BLOOD PRICE - They are not prey, but death-marked who have done something worth of you and your entire brethen's ire. You must kill them. No escalation is required. If you kill them, they won't come back."))
+	to_chat(user, span_artery("HUNTED - They are prey worth chasing, and you're guaranteed to have a good fight. You may kill them with low escalation, but it is not a must. You're in for the thrill of the hunt, or your own personal objectives."))
+	to_chat(user, span_artery("LAMBS - They are easy pickings not worth your attention for the most part, yet their scent crosses your nose. You don't need to kill them at all, but you may hunt, stalk or harrass them for fun. They cannot fight back and fear you."))
+
 	for(var/mob/living/L in GLOB.player_list)
 		if(L == user || istype(L, /mob/living/carbon/human/dummy) || !L.mind)
 			continue
@@ -76,10 +81,12 @@
 		//		is_valid_prey = TRUE
 		if(is_valid_prey)
 			var/entry_name = "[L.real_name]"
+			if(is_hunted)
+				entry_name += " (Hunted)"
 			if(is_lamb)
-				entry_name += " (Non-Lethal, Lamb)"
+				entry_name += " (Lamb)"
 			if(is_bloodmarked)
-				entry_name += " (Kill On Sight, DnR)"
+				entry_name += " (Blood Price)"
 			possible_targets[entry_name] = L
 
 	if(!length(possible_targets))

--- a/code/modules/antagonists/roguetown/villain/gnoll/gnoll_spells.dm
+++ b/code/modules/antagonists/roguetown/villain/gnoll/gnoll_spells.dm
@@ -66,14 +66,19 @@
 		if(L == user || istype(L, /mob/living/carbon/human/dummy) || !L.mind)
 			continue
 		var/is_hunted = L.has_flaw(/datum/charflaw/hunted)
+		var/is_bloodmarked = L.has_flaw(/datum/charflaw/bloodprice)
 		// Don't uncomment for now
 		// var/target_role = L.job
-		var/is_valid_prey = is_hunted
+		var/is_valid_prey = (is_hunted || is_bloodmarked)
 		// if(!is_valid_prey)
 		//	if(target_role in combat_roles)
 		//		is_valid_prey = TRUE
 		if(is_valid_prey)
 			var/entry_name = "[L.real_name]"
+			if(is_hunted)
+				entry_name += " (Non-Lethal)"
+			if(is_bloodmarked)
+				entry_name += " (Lethal, DnR)"
 			possible_targets[entry_name] = L
 
 	if(!length(possible_targets))

--- a/code/modules/antagonists/roguetown/villain/gnoll/gnoll_spells.dm
+++ b/code/modules/antagonists/roguetown/villain/gnoll/gnoll_spells.dm
@@ -66,19 +66,20 @@
 		if(L == user || istype(L, /mob/living/carbon/human/dummy) || !L.mind)
 			continue
 		var/is_hunted = L.has_flaw(/datum/charflaw/hunted)
+		var/is_lamb = L.has_flaw(/datum/charflaw/stalked)
 		var/is_bloodmarked = L.has_flaw(/datum/charflaw/bloodprice)
 		// Don't uncomment for now
 		// var/target_role = L.job
-		var/is_valid_prey = (is_hunted || is_bloodmarked)
+		var/is_valid_prey = (is_hunted || is_bloodmarked || is_lamb)
 		// if(!is_valid_prey)
 		//	if(target_role in combat_roles)
 		//		is_valid_prey = TRUE
 		if(is_valid_prey)
 			var/entry_name = "[L.real_name]"
-			if(is_hunted)
-				entry_name += " (Non-Lethal)"
+			if(is_lamb)
+				entry_name += " (Non-Lethal, Lamb)"
 			if(is_bloodmarked)
-				entry_name += " (Lethal, DnR)"
+				entry_name += " (Kill On Sight, DnR)"
 			possible_targets[entry_name] = L
 
 	if(!length(possible_targets))
@@ -181,8 +182,10 @@
 	var/channel_time = 15 SECONDS
 	if(target.has_flaw(/datum/charflaw/hunted))
 		channel_time = 6 SECONDS
+	if(target.has_flaw(/datum/charflaw/stalked))
+		channel_time = 2 SECONDS
 
-	to_chat(user, span_notice("You begin pulling [target] into graggar's plane"))
+	to_chat(user, span_notice("You begin pulling [target] into Gragger's plane"))
 	to_chat(target, span_userdanger("The world around you begins to dissolve into a blood scented nightmare!"))
 	user.visible_message(span_userdanger("[user] tears a blood red rift into space with a claw, and begins dragging [target] into it!"))
 	tracker.channeling_abduction = TRUE

--- a/code/modules/antagonists/roguetown/villain/minor_antags/assassin/assassin_gear.dm
+++ b/code/modules/antagonists/roguetown/villain/minor_antags/assassin/assassin_gear.dm
@@ -188,7 +188,7 @@
 /obj/item/rogueweapon/huntingknife/idagger/steel/profane/pre_attack(mob/living/carbon/human/target, mob/living/user = usr, params)
 	if(!istype(target))
 		return FALSE
-	if(target.has_flaw(/datum/charflaw/targeted)) // dagger deals more dmg to ppl who r targeted
+	if(target.has_flaw(/datum/charflaw/targeted) || target.has_flaw(/datum/charflaw/marked_for_death)) // dagger deals more dmg to ppl who r targeted
 		force = 40	//vs trait havers, 2x damage over a steel knife
 		update_force_dynamic()
 	else
@@ -264,7 +264,7 @@
 		die_motherfucker_die(target, get_last = face_flag)
 
 		// they get yoinked either way
-		if(target.has_flaw(/datum/charflaw/targeted)) // The profane dagger only thirsts for those who are targeted, by flaw or by zizoid curse.
+		if(target.has_flaw(/datum/charflaw/targeted) || target.has_flaw(/datum/charflaw/marked_for_death)) // The profane dagger only thirsts for those who are targeted, by flaw or by zizoid curse.
 			if(HAS_TRAIT(target, TRAIT_CLAIMED_BY_DARKSTAR)) // no doubling up if theyre already claimed
 				return FALSE
 			init_profane_soul(target, user)

--- a/code/modules/antagonists/roguetown/villain/minor_antags/assassin/assassin_gear.dm
+++ b/code/modules/antagonists/roguetown/villain/minor_antags/assassin/assassin_gear.dm
@@ -188,7 +188,7 @@
 /obj/item/rogueweapon/huntingknife/idagger/steel/profane/pre_attack(mob/living/carbon/human/target, mob/living/user = usr, params)
 	if(!istype(target))
 		return FALSE
-	if(target.has_flaw(/datum/charflaw/targeted) || target.has_flaw(/datum/charflaw/marked_for_death)) // dagger deals more dmg to ppl who r targeted
+	if(target.has_flaw(/datum/charflaw/targeted) || target.has_flaw(/datum/charflaw/marked_for_death) || target.has_flaw(/datum/charflaw/low_profile)) // dagger deals more dmg to ppl who r targeted
 		force = 40	//vs trait havers, 2x damage over a steel knife
 		update_force_dynamic()
 	else
@@ -264,7 +264,7 @@
 		die_motherfucker_die(target, get_last = face_flag)
 
 		// they get yoinked either way
-		if(target.has_flaw(/datum/charflaw/targeted) || target.has_flaw(/datum/charflaw/marked_for_death)) // The profane dagger only thirsts for those who are targeted, by flaw or by zizoid curse.
+		if(target.has_flaw(/datum/charflaw/targeted) || target.has_flaw(/datum/charflaw/marked_for_death) || target.has_flaw(/datum/charflaw/low_profile)) // The profane dagger only thirsts for those who are targeted, by flaw or by zizoid curse.
 			if(HAS_TRAIT(target, TRAIT_CLAIMED_BY_DARKSTAR)) // no doubling up if theyre already claimed
 				return FALSE
 			init_profane_soul(target, user)

--- a/code/modules/antagonists/roguetown/villain/minor_antags/assassin/assassin_spells.dm
+++ b/code/modules/antagonists/roguetown/villain/minor_antags/assassin/assassin_spells.dm
@@ -32,11 +32,14 @@
 		if(L == assassin || istype(L, /mob/living/carbon/human/dummy))
 			continue
 		var/is_hunted = L.has_flaw(/datum/charflaw/targeted)
+		var/is_deathmarked = L.has_flaw(/datum/charflaw/marked_for_death)
 		var/is_trapped = HAS_TRAIT(L, TRAIT_CLAIMED_BY_DARKSTAR)
-		var/is_valid_prey = is_hunted && !is_trapped
+		var/is_valid_prey = (is_hunted || is_deathmarked) && !is_trapped
 
 		if(is_valid_prey)
 			var/entry_name = "[L.real_name]"
+			if(is_deathmarked)
+				entry_name += " (DnR)"
 			var/target_job = L.get_role_title()
 			if(target_job)
 				entry_name += " - [target_job]"

--- a/code/modules/antagonists/roguetown/villain/minor_antags/assassin/assassin_spells.dm
+++ b/code/modules/antagonists/roguetown/villain/minor_antags/assassin/assassin_spells.dm
@@ -28,18 +28,28 @@
 	// hotwired gnoll sniff code
 	var/list/possible_targets = list()
 
+	to_chat(assassin, span_artery("You focus on the possible targets... You remember very clear and quick instructions about your possible targets."))
+	to_chat(assassin, span_artery("HIGH PRIORITY TARGETS - You can kill them without escalation. If you kill them, they won't come back, as they are Do Not Resurrect."))
+	to_chat(assassin, span_artery("MEDIUM PRIORITY TARGETS - You can kill them with low escalation. If you kill them, they will be trapped in your dagger, until it is broken."))
+	to_chat(assassin, span_artery("LOW PRIORITY TARGETS - You don't need to kill them. They are still under investigation, and you're free to use them for your own goals. If you find a reason to kill them, do so; otherwise, leave them be. They cannot fight back."))
+
 	for(var/mob/living/L in GLOB.player_list)
 		if(L == assassin || istype(L, /mob/living/carbon/human/dummy))
 			continue
+		var/is_watched = L.has_flaw(/datum/charflaw/low_profile)
 		var/is_hunted = L.has_flaw(/datum/charflaw/targeted)
 		var/is_deathmarked = L.has_flaw(/datum/charflaw/marked_for_death)
 		var/is_trapped = HAS_TRAIT(L, TRAIT_CLAIMED_BY_DARKSTAR)
-		var/is_valid_prey = (is_hunted || is_deathmarked) && !is_trapped
+		var/is_valid_prey = (is_hunted || is_deathmarked || is_watched) && !is_trapped
 
 		if(is_valid_prey)
 			var/entry_name = "[L.real_name]"
 			if(is_deathmarked)
-				entry_name += " (DnR)"
+				entry_name += " (High Priority)"
+			if(is_hunted)
+				entry_name += " (Medium Priority)"
+			if(is_watched)
+				entry_name += " (Low Priority)"
 			var/target_job = L.get_role_title()
 			if(target_job)
 				entry_name += " - [target_job]"

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1204,6 +1204,14 @@ GLOBAL_LIST_EMPTY(roundstart_races_paths)
 	if(HAS_TRAIT(user, TRAIT_PACIFISM))
 		to_chat(user, span_warning("I don't want to harm [target]!"))
 		return FALSE
+
+	if(HAS_TRAIT(user, TRAIT_GNOLLPHOBIA) && isgnoll(target))
+		if(prob(50))
+			user.emote("scream")
+			user.Stun(2 SECONDS)
+			user.OffBalance(5 SECONDS)
+			return FALSE
+
 	if(user.has_status_effect(/datum/status_effect/debuff/deadite_grace) && target.mind)
 		to_chat(user, span_warning("Ah, Lux... I calm down considerably, but my hunger only increases."))
 		user.remove_status_effect(/datum/status_effect/debuff/deadite_grace)
@@ -1578,6 +1586,14 @@ GLOBAL_LIST_EMPTY(roundstart_races_paths)
 	if(HAS_TRAIT(user, TRAIT_PACIFISM))
 		to_chat(user, span_warning("I don't want to harm [target]!"))
 		return FALSE
+
+	if(HAS_TRAIT(user, TRAIT_GNOLLPHOBIA) && isgnoll(target))
+		if(prob(50))
+			user.emote("scream")
+			user.Stun(2 SECONDS)
+			user.OffBalance(5 SECONDS)
+			return FALSE
+
 	if(user.has_status_effect(/datum/status_effect/debuff/deadite_grace) && target.mind)
 		to_chat(user, span_warning("Ah, Lux... I calm down considerably, but my hunger only increases."))
 		user.remove_status_effect(/datum/status_effect/debuff/deadite_grace)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1212,6 +1212,13 @@ GLOBAL_LIST_EMPTY(roundstart_races_paths)
 			user.OffBalance(5 SECONDS)
 			return FALSE
 
+	if(HAS_TRAIT(user, TRAIT_STALKPHOBIA) && target.mind?.has_antag_datum(/datum/antagonist/assassin))
+		if(prob(50))
+			user.emote("scream")
+			user.Stun(2 SECONDS)
+			user.OffBalance(5 SECONDS)
+			return FALSE
+
 	if(user.has_status_effect(/datum/status_effect/debuff/deadite_grace) && target.mind)
 		to_chat(user, span_warning("Ah, Lux... I calm down considerably, but my hunger only increases."))
 		user.remove_status_effect(/datum/status_effect/debuff/deadite_grace)
@@ -1588,6 +1595,13 @@ GLOBAL_LIST_EMPTY(roundstart_races_paths)
 		return FALSE
 
 	if(HAS_TRAIT(user, TRAIT_GNOLLPHOBIA) && isgnoll(target))
+		if(prob(50))
+			user.emote("scream")
+			user.Stun(2 SECONDS)
+			user.OffBalance(5 SECONDS)
+			return FALSE
+
+	if(HAS_TRAIT(user, TRAIT_STALKPHOBIA) && target.mind?.has_antag_datum(/datum/antagonist/assassin))
 		if(prob(50))
 			user.emote("scream")
 			user.Stun(2 SECONDS)


### PR DESCRIPTION
## About The Pull Request

- Adds different tiers of Hunted and Targeted.
- Hunted (Blood Price) and Targeted (Marked for Death) means no-esc, permadeath. Hardcore survival challenge between two players and whatever's between them.
- Hunted (Default) and Targeted (Default) is as it is. Requiring escalation but letting you be more lax about if they die or not. The default experience we have at the present.
- Hunted (Lamb) and Targeted (Easy Pick) puts you on a massive handicap against the assailant, due to a phobia of them. This should encourage roleplay over leaping on each other to frag, since the assailant will always have the advantage and control of the situation.

## Testing Evidence

See discord. Works.

## Why It's Good For The Game

It should help a little more on letting Assassins and Gnolls plan how they want to deal with their targets. Knowing that they're DnR could for example, let them using that information as leverage for how precious that life is, add a bit more horror to their stalking, yadda yadda. 

On Gnoll's side, mostly so they can have an expectation of how they want to deal with their marked targets, same lane as assassin, but less professional, as these tend to be.

I can only hold hope this is not used for other mischievous purposes, as Tea has put the fear of the grave on me about it.

## Changelog
:cl:
qol: Tiered Hunted and Targeted, it should now be more detailed for the hunter what their victims expect of them, vice versa.
/:cl: