### PR TITLE
Banishes the Public Warden Outpost Scom to the Depths to Hell from Whense it Came.

### DIFF
--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -15906,12 +15906,10 @@
 /area/rogue/indoors/town)
 "cZB" = (
 /obj/structure/fluff/railing/border/west,
-/obj/structure/roguemachine/scomm{
+/obj/structure/roguemachine/scomm/receive_only{
 	scom_tag = "Wardens' Outpost"
 	},
-/turf/open/floor/rogue/metal{
-	icon_state = "plating2"
-	},
+/turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
 "cZE" = (
 /obj/structure/bars/pipe{
@@ -110246,14 +110244,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
-"uuk" = (
-/obj/structure/roguemachine/scomm/r{
-	scom_tag = "Outpost Watchtower - Ground Floor"
-	},
-/turf/open/floor/rogue/metal{
-	dir = 4
-	},
-/area/rogue/indoors/shelter/woods)
 "uul" = (
 /obj/structure/mineral_door/wood/violet,
 /turf/open/floor/rogue/concrete,
@@ -320432,7 +320422,7 @@ dpy
 nTq
 iaB
 fiq
-uuk
+bWg
 lGG
 jaH
 jaH


### PR DESCRIPTION
## About The Pull Request
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

https://github.com/Azure-Peak/Azure-Peak/pull/8990 was far too heavy handed so I present to you a lesser evil, that'll probably actually save your sanity tbh.

removes (1) scom from the lower level of the warden tower and turns the public scom into an rcomm. That's the one of the left sire. The excessive scom t'was on the right side. (there's still 2 more in your tower, don't worry you aren't running out of scoms as a warden since your houndstone is also one.)

<img width="1312" height="396" alt="Screenshot 2026-09-09 231204" src="https://github.com/user-attachments/assets/a66674c1-e7ac-48d8-8114-9e121bd2fbb7" />

Yeah that's it sire. What else do you need of me, there's still some inside of the outpost on the higher floors so wardens can do their job without a random adventurer easily dropping the entire retinue and garrison and inquisition and a random bored Templar for one naked vagabond with a club and a zcross just a screen away for sprite-shifting over a warden menacingly.

If you need a scom over there, you can just ask the wardens, they'll probably let you use theirs.

## Testing Evidence

It works. Sire. - Its got a scomtag and its the right thing - Trust the Plan.

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

Nerfs the metastrat of asking a warden a random, ominious question and spriteshifting over them to summon 30 players to speedrun how fast you get gutspilled and DNR'd.

People that signed up for the 3 warden slots should probably have more control over what fight they get instead of having it constantly stolen from them by the town factions over a heretic army (one, adventurer missionary on the bridge with a skeleton.) because someone decided to instinctively and reasonably use the scom that was and probably shouldn't be a public one there.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
map: The Warden Outpost Public-Scom is Now an Rcomm.
map: The Warden Watchtower no longer has a ground level scom, you need to risk going up the stairs now, either to the first level or the top of it.
balance: You can no longer sprite-shift over a warden and ask an ominious question to make adventurers use the public warden outpost scom to summon 30 players to kill you because its gone.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
