### PR TITLE
nerfs ignition

### DIFF
--- a/code/modules/spells/roguetown/acolyte/general.dm
+++ b/code/modules/spells/roguetown/acolyte/general.dm
@@ -438,8 +438,7 @@
 	sparks_amt = 2
 
 	click_to_activate = TRUE
-	cast_range = SPELL_RANGE_AURA
-	self_cast_possible = FALSE //Why are you trying to set YOURSELF on fire.
+	cast_range = 2
 
 	primary_resource_cost = SPELLCOST_MIRACLE_MINOR
 
@@ -447,8 +446,11 @@
 
 	invocation_type = INVOCATION_NONE //It has seperate message ON USE
 
-	charge_required = FALSE
-	cooldown_time = 10 SECONDS
+	charge_required = TRUE
+	charge_time = CHARGETIME_POKE
+	charge_slowdown = CHARGING_SLOWDOWN_SMALL
+	charge_sound = 'sound/magic/holycharging.ogg'
+	cooldown_time = 15 SECONDS
 
 	spell_flags = SPELL_PSYDON
 	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC | SPELL_REQUIRES_HUMAN | SPELL_REQUIRES_SAME_Z
@@ -477,7 +479,7 @@
 			spelltarget.visible_message(span_warning("[spelltarget] shields against the divine flame!"))
 			return TRUE
 		if(spelltarget.fire_stacks < 1)
-			spelltarget.adjust_fire_stacks(2)
+			spelltarget.adjust_fire_stacks(1)
 			spelltarget.ignite_mob()
 			log_combat(owner, spelltarget, "ignited", addition="with the miracle [name]", zone=owner.zone_selected)
 			return TRUE


### PR DESCRIPTION
## About The Pull Request

1. It's now a 0.5s chargeup miracle (like most poke spells), instead of being instant.
2. It does 1 firestack (40~ damage over 10 seconds) instead of 2 (80~ over 20s)
3. 2 tile range instead of 4 tiles
4. Increases CD to 15s

## Testing Evidence

just a jak soo

## Why It's Good For The Game

an insta-cast 20s burn that does both bleed and armour damage is no longer really balanced after fire changes. nothing sets you on fire earnestly anymore other than literally standing on fire turfs (not even pyro arrows/mage spells)

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: lowers range and firestack on ignition. gives it a 0.5s chargeup. increases CD to 15s.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
