### PR TITLE
[hotfix] Fixes a cosmetic runtime that wasn't affecting anything but was spamming logs

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -529,7 +529,7 @@ GLOBAL_LIST_EMPTY(roundstart_races_paths)
 			add_verb(H, /mob/living/carbon/human/verb/choose_cosmetic_claws)
 
 	SEND_SIGNAL(C, COMSIG_SPECIES_GAIN, src, old_species)
-	RegisterSignal(C, COMSIG_MOB_SAY, PROC_REF(handle_speech))
+	RegisterSignal(C, COMSIG_MOB_SAY, PROC_REF(handle_speech), TRUE)
 
 
 /datum/species/proc/on_species_loss(mob/living/carbon/human/C, datum/species/new_species, pref_load)

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/dullahan/dullahan.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/dullahan/dullahan.dm
@@ -259,7 +259,6 @@
 // I don't know if that is possible, may have some cases relating to eye signals.
 /datum/species/dullahan/on_species_gain(mob/living/carbon/user, datum/species/old_species)
 	..()
-	RegisterSignal(user, COMSIG_MOB_SAY, PROC_REF(handle_speech))
 	RegisterSignal(user, COMSIG_MOB_SAY_POSTPROCESS, PROC_REF(on_say_postprocess))
 	// TODO SEXCON2: Re-enable Dullahan detached head ERP support
 	//RegisterSignal(user, COMSIG_ERP_LOCATION_ACCESSIBLE, PROC_REF(on_erp_location_accessible))

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/other/orc.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/other/orc.dm
@@ -92,10 +92,6 @@
 		/datum/language/orcish
 	)
 
-/datum/species/orc/on_species_gain(mob/living/carbon/C, datum/species/old_species)
-	..()
-	RegisterSignal(C, COMSIG_MOB_SAY, PROC_REF(handle_speech), override = TRUE)
-
 /datum/species/orc/after_creation(mob/living/carbon/C)
 	..()
 	to_chat(C, "<span class='info'>I can speak Orcish with ,o before my speech.</span>")

--- a/code/modules/mob/living/carbon/human/species_types/wildshape/cabbit.dm
+++ b/code/modules/mob/living/carbon/human/species_types/wildshape/cabbit.dm
@@ -71,10 +71,6 @@
 	human.update_damage_overlays()
 	return TRUE
 
-/datum/species/shapecabbit/on_species_gain(mob/living/carbon/carbon, datum/species/old_species)
-	. = ..()
-	RegisterSignal(carbon, COMSIG_MOB_SAY, PROC_REF(handle_speech))
-
 /datum/species/shapecabbit/update_damage_overlays(mob/living/carbon/human/human)
 	human.remove_overlay(DAMAGE_LAYER)
 	return TRUE

--- a/code/modules/mob/living/carbon/human/species_types/wildshape/direbear.dm
+++ b/code/modules/mob/living/carbon/human/species_types/wildshape/direbear.dm
@@ -77,10 +77,6 @@
 	human.update_damage_overlays()
 	return TRUE
 
-/datum/species/shapebear/on_species_gain(mob/living/carbon/carbon, datum/species/old_species)
-	. = ..()
-	RegisterSignal(carbon, COMSIG_MOB_SAY, PROC_REF(handle_speech))
-
 /datum/species/shapebear/update_damage_overlays(mob/living/carbon/human/human)
 	human.remove_overlay(DAMAGE_LAYER)
 	return TRUE

--- a/code/modules/mob/living/carbon/human/species_types/wildshape/vernard.dm
+++ b/code/modules/mob/living/carbon/human/species_types/wildshape/vernard.dm
@@ -73,10 +73,6 @@
 	human.update_damage_overlays()
 	return TRUE
 
-/datum/species/shapefox/on_species_gain(mob/living/carbon/carbon, datum/species/old_species)
-	. = ..()
-	RegisterSignal(carbon, COMSIG_MOB_SAY, PROC_REF(handle_speech))
-
 /datum/species/shapefox/update_damage_overlays(mob/living/carbon/human/human)
 	human.remove_overlay(DAMAGE_LAYER)
 	return TRUE


### PR DESCRIPTION
## About The Pull Request
Adds override=TRUE to the accent code's handle_speech and removes redundant species handle_speech registration. Was causing a runtime, which didn't seem to make anything nonfunctional it was just redundant code trying to do the same thing twice.

## Testing Evidence
<img width="1008" height="199" alt="image" src="https://github.com/user-attachments/assets/88e0285e-253f-4751-bed9-ae628c986482" />

## Why It's Good For The Game
Runtime spam bad