### PR TITLE
minor artificer descope

### DIFF
--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -611,19 +611,6 @@
 	},
 /turf/open/floor/rogue/tile/brick,
 /area/rogue/indoors/town)
-"afU" = (
-/obj/structure/closet/crate/roguecloset/inn,
-/obj/item/rogueore/cinnabar,
-/obj/item/rogueore/cinnabar,
-/obj/item/rogueore/cinnabar,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town/dwarfin)
 "afY" = (
 /turf/open/floor/rogue/cobblerock{
 	smooth = 0
@@ -6678,10 +6665,6 @@
 "bnL" = (
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/beach/forest/north)
-"bnM" = (
-/obj/effect/decal/cleanable/roguerune/arcyne/summoning/mid,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town/dwarfin)
 "bnN" = (
 /obj/structure/fluff/railing/corner,
 /turf/open/floor/rogue/ruinedwood,
@@ -30122,10 +30105,6 @@
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/church/chapel)
-"fEx" = (
-/obj/effect/decal/cleanable/roguerune/arcyne/enchantment,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town/dwarfin)
 "fEz" = (
 /obj/structure/flora/roguetree/burnt,
 /turf/open/floor/rogue/grass,
@@ -53461,10 +53440,6 @@
 	},
 /turf/open/floor/rogue/tile/brick,
 /area/rogue/outdoors/town/roofs)
-"jSi" = (
-/obj/structure/leyline/tamed,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town/dwarfin)
 "jSl" = (
 /obj/effect/decal/cleanable/blood,
 /obj/structure/roguemachine/bounty,
@@ -64906,22 +64881,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/druidsgrove)
-"lTj" = (
-/obj/structure/closet/crate/roguecloset/inn,
-/obj/item/magic/manacrystal,
-/obj/item/magic/manacrystal,
-/obj/item/magic/manacrystal,
-/obj/item/magic/manacrystal,
-/obj/item/reagent_containers/food/snacks/grown/manabloom,
-/obj/item/reagent_containers/food/snacks/grown/manabloom,
-/obj/item/reagent_containers/food/snacks/grown/manabloom,
-/obj/item/magic/obsidian,
-/obj/item/magic/obsidian,
-/obj/item/magic/obsidian,
-/obj/item/chalk,
-/obj/item/chalk,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town/dwarfin)
 "lTl" = (
 /obj/structure/fluff/railing/wood/west{
 	pixel_y = -1
@@ -90131,12 +90090,6 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/magician)
-"qyP" = (
-/obj/structure/closet/crate/roguecloset/inn,
-/obj/item/magic/artifact,
-/obj/item/magic/artifact,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town/dwarfin)
 "qyR" = (
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/town)
@@ -177812,7 +177765,7 @@ qFt
 vGa
 vGa
 cqm
-lTj
+tNJ
 aUD
 tNJ
 tNJ
@@ -177820,7 +177773,7 @@ rGX
 tNJ
 tNJ
 aUD
-qyP
+tNJ
 lGX
 cqm
 cHC
@@ -178264,15 +178217,15 @@ qFt
 vGa
 vGa
 cqm
-jSi
 tNJ
-bnM
+tNJ
+tNJ
 tNJ
 rGX
 tNJ
-fEx
 tNJ
-afU
+tNJ
+tNJ
 lGX
 cqm
 ksA

--- a/code/modules/jobs/job_types/roguetown/burghers/guildsman.dm
+++ b/code/modules/jobs/job_types/roguetown/burghers/guildsman.dm
@@ -107,11 +107,10 @@
 
 /datum/advclass/guildsman/artificer
 	name = "Artificer"
-	tutorial = "You are an Artificer, oft known by the longer name of Artificer-Enchanter. You have basic training in the arts of smithing, and can substitute for a blacksmith's work if needed.\
-	But your true calling is the creation and enchantment of magical items, alongside feats of engineering, creating mechanical and magical wonders whose art of creation has been passed down\
+	tutorial = "You are an Artificer. You have basic training in the arts of smithing, and can substitute for a blacksmith's work if needed.\
+	But your true calling is the creation of magical items, alongside feats of engineering, creating mechanical and magical wonders whose art of creation has been passed down\
 	from a certain elven Artificer..."
 	outfit = /datum/outfit/job/roguetown/guildsman/artificer
-	subclass_mage_aspects = list("mastery" = FALSE, "major" = 1, "minor" = 2, "utilities" = 4, "locked_aspects" = list(/datum/magic_aspect/battlewardry, /datum/magic_aspect/artifice), "post_aspect_spells" = list(/obj/effect/proc_holder/spell/invoked/takeapprentice), "ward" = TRUE)
 
 	category_tags = list(CTAG_GUILDSMEN)
 	traits_applied = list(TRAIT_ARCYNE, TRAIT_ALCHEMY_EXPERT)
@@ -168,7 +167,6 @@
 						/obj/item/clothing/mask/rogue/spectacles/golden = 1, //putting them in the bag because bad eye sight virtue strips these
 						/obj/item/rogueweapon/contraption/linker = 1,
 						/obj/item/mini_flagpole/artificer = 1,
-						/obj/item/rogueweapon/spellbook = 1,
 						)
 	// Not a real mage, no free spell point. Take Arcyne Potential if you want it.
 	if(H.mind)

--- a/code/modules/roguetown/roguejobs/engineer/anvil_recipes/mechanical.dm
+++ b/code/modules/roguetown/roguejobs/engineer/anvil_recipes/mechanical.dm
@@ -243,14 +243,14 @@
 	craftdiff = 4
 	display_category = ITEM_CAT_TOOLS_FIELD
 
-/datum/anvil_recipe/engineering/bronze/metalizer
-	name = "Wood Metalizer (+2 Gears)"
-	category = "Engineering"
-	req_bar= /obj/item/ingot/bronze
-	additional_items = list( /obj/item/roguegear, /obj/item/roguegear)
-	created_item = /obj/item/rogueweapon/contraption/wood_metalizer
-	craftdiff = 4
-	display_category = ITEM_CAT_TOOLS_WORKSHOP
+// /datum/anvil_recipe/engineering/bronze/metalizer
+// 	name = "Wood Metalizer (+2 Gears)"
+// 	category = "Engineering"
+// 	req_bar= /obj/item/ingot/bronze
+// 	additional_items = list( /obj/item/roguegear, /obj/item/roguegear)
+// 	created_item = /obj/item/rogueweapon/contraption/wood_metalizer
+// 	craftdiff = 4
+// 	display_category = ITEM_CAT_TOOLS_WORKSHOP
 
 /datum/anvil_recipe/engineering/bronze/lockimprover
 	name = "Lock Improver (1 bronze, +1 Gear"


### PR DESCRIPTION
## About The Pull Request
- removes the wood metalizer's recipe, as it was incredibly outsized in convenience for something that bypasses a massive swathe of ansari's economy mechanics. it had FAR better yields than anything transmutation could do, which is itself a contested system under careful balancing consideration. if you want metal, you have a ton of ways to achieve that - we have scrapping, guild quests, imports, and now transmutation as well
- removes the enchanting setup from the guild. enchanting is a mage thing, and the uni should be the one producing them - but let's be real, nobody buys enchantments much anyways, because anyone with a virtue can mass produce them. that downstairs guild area hadn't been properly updated since, uh, mage gameplay loop 2 anyway 
- removes mage aspects from artificer, as they were initially not meant to have any, but were then added later because "we need to frag summoning mobs". now that they're not doing that, they don't need it, and we don't like excessive townroles with major aspects

## Testing Evidence
<img width="860" height="201" alt="image" src="https://github.com/user-attachments/assets/33fef8d0-93c5-42c6-be99-c9712ba86e32" />
it's all var edits and map changes if it compiles it'll work

## Why It's Good For The Game
Most of this stuff I imagine has only "not become a problem" because nobody really noticed it.
- the wood metalizer lets you turn a 3-mammon-value item that's basically in infinite supply always into a spread of 4-8 mammon items that are often in shortage (NOTABLY in infinite quantity, a self-sustaining loop, and "3 mammon to 4-8" is actually an understatement because you will never sell at/above 100% value and buy at/below 100% value), thus removing the need for the several mechanics ansari added specifically to make guild create opportunities for engagement for other players (towner quests, the scrapping system, etc) while also bypassing shortages and leading to even more reclusive gameplay on an inherently reclusive role. it had returns miles better than transmutation
- enchanting being an artificer thing is strange, and there is simply not enough enchanting demand for two roles to do it. before mage 3, enchanting was the ONLY unique mechanic/gameplay loop uni had, and having a 9 statweight major aspect guildsman also doing it in a much more accessible location is - well, it's the same problem apothecary had. giving mages a unique form of alchemy (and, in the works, giving apothecary access to more medicines and ointments and thelike) resolved that issue; if i add a second form of enchanting to mage i will be shot dead. arti doesn't need it they have enough to do with their create mod rotational system on top of normal guild demands. like they genuinely HAVE unique content in spades they don't need to also be taking the uni's
- major aspect towners = contentious at best and artificer literally still has comments saying they're not meant to have mage aspects without arcpot 

## Changelog

:cl:
del: Removed mage aspects from artificer, including enchanting. The enchanting setup in their basement is now open space for them to put whatever contraptions in.
del: Removed the wood metalizer, as it was a balance nightmare that bypassed the economy at a far better rate than transmutation.
/:cl:
