### PR TITLE
[Fix] Rekindled Action Cooldown

### DIFF
--- a/code/datums/gods/patrons/inhumen/matthios.dm
+++ b/code/datums/gods/patrons/inhumen/matthios.dm
@@ -13,7 +13,7 @@
 					/datum/action/cooldown/spell/matthios/transact				= CLERIC_T2,
 					/datum/action/cooldown/spell/matthios/barter				= CLERIC_T2,
 					/datum/action/cooldown/spell/matthios/equalize				= CLERIC_T3,
-					/obj/effect/proc_holder/spell/invoked/resurrect/matthios	= CLERIC_T3,
+					/datum/action/cooldown/spell/matthios/anastasis				= CLERIC_T3,
 					/datum/action/cooldown/spell/matthios/churn					= CLERIC_T4
 	)
 	confess_lines = list(

--- a/code/datums/gods/patrons/inhumen/resurrect_inhumen.dm
+++ b/code/datums/gods/patrons/inhumen/resurrect_inhumen.dm
@@ -8,6 +8,9 @@
 	if(!key && !get_ghost(FALSE, TRUE))
 		to_chat(user, span_warning("[src]'s soul has departed."))
 		return FALSE
+	if(src.has_status_effect(/datum/status_effect/debuff/rotted_zombie))
+		to_chat(user, span_warning("[src] is rotting. They can't be brought back like this!"))
+		return FALSE
 	var/choice = tgui_alert(src, "[user] is attempting to bring you back to life. Do you wish to return?", "Resurrection", list("Accept", "Decline"), timeout = 15 SECONDS)
 	if(choice == "Accept")
 		return TRUE
@@ -19,39 +22,47 @@
 
 /// SPELL DATUMS
 
-/obj/effect/proc_holder/spell/invoked/resurrect/matthios
+/datum/action/cooldown/spell/matthios/anastasis
 	name = "Rekindled Exchange"
-	desc = "Uses primordial fyre to revive the target and reenact the Free God's First Transaction, putting them in a long-lasting debt to Him. The debt is periodically paid with their mammon."
-	debuff_type = null
-	alt_required_items = list()
-	required_items = list()
-	sound = 'sound/magic/slimesquish.ogg'
-	chargedloop = /datum/looping_sound/invokeascendant
-	harms_undead = FALSE
-	recharge_time = 2 MINUTES //Anastasis Equivalent
-	overlay_icon = 'icons/mob/actions/matthiosmiracles.dmi'
-	overlay_state = "revival"
-	action_icon_state = "revival"
-	action_icon = 'icons/mob/actions/matthiosmiracles.dmi'
-	required_structure = /obj/structure/fluff/psycross/matthios
-	matthios = TRUE // is this true?!
+	desc = "Uses primordial fyre to revive a target that is free of rot and decay, and reenact the Free God's First Transaction, putting them in a long-lasting debt to Him. The debt is periodically paid with their mammon."
+	fluff_desc = "The Free God once traded fire for the betterment of mortals. Now, His servants reenact that first exchange, purchasing a soul's return from death at a price to be paid later."
+	button_icon_state = "revival"
+	sound = 'sound/magic/astrata_choir.ogg'
+	glow_intensity = GLOW_INTENSITY_VERY_HIGH
+	click_to_activate = TRUE
+	cast_range = SPELL_RANGE_ADJACENT
+	self_cast_possible = FALSE
+	primary_resource_cost = SPELLCOST_MIRACLE_LEGENDARY
+	secondary_resource_cost = SPELLCOST_MIRACLE_MAJOR
+	invocation_type = INVOCATION_NONE
+	charge_required = TRUE
+	charge_time = 5 SECONDS
+	charge_sound = 'sound/magic/chargingold.ogg'
+	charge_swingdelay_type = SWINGDELAY_CANCEL
+	cooldown_time = 2 MINUTES
+	spell_flags = SPELL_PSYDON
+	spell_requirements = SPELL_REQUIRES_MIND | SPELL_REQUIRES_HUMAN | SPELL_REQUIRES_SAME_Z | SPELL_REQUIRES_NO_MOVE
 
 #define MATTHIOS_DEBT_MIN 150
 #define MATTHIOS_DEBT_MAX 250
 
-/obj/effect/proc_holder/spell/invoked/resurrect/matthios/cast(list/targets, mob/living/carbon/human/user)
-	var/mob/living/carbon/human/target = targets[1]
+/datum/action/cooldown/spell/matthios/anastasis/cast(atom/cast_on)
+	. = ..()
+	if(!isliving(cast_on))
+		return FALSE
+	var/mob/living/carbon/human/user = owner
+	var/mob/living/carbon/human/target = cast_on
 	// Find any nearby cross.
 	var/obj/structure/fluff/psycross/found_cross
-	for(var/obj/structure/fluff/psycross/C in view(1, target))
-		found_cross = C
+	for(var/obj/structure/fluff/psycross/S in oview(1, target))
+		found_cross = S
 		break
 	if(!found_cross)
-		to_chat(user, span_warning("You see no holy nor profane cross through which to work this exchange."))
+		to_chat(owner, span_warning("You see no holy nor profane cross through which to work this exchange."))
 		return FALSE
 
 	// Check whether the soul can actually be revived, cos i revived someone who was pmuch departed lol oops!!
-	if(!target.revive_check(user))
+	if(!target.revive_check(owner))
 		return FALSE
 
 	var/is_matthios = istype(found_cross, /obj/structure/fluff/psycross/matthios)
@@ -93,7 +104,30 @@
 			user.apply_status_effect(/datum/status_effect/debuff/matthios_debt, debt, user)
 		else if(choice == "Debt") // they shoulder the L, part of the mammon goes to caster
 			target.apply_status_effect(/datum/status_effect/debuff/matthios_debt, debt, user)
-	// the flavortext goes here
+
+	// the ACTUAL revive goes here
+	target.adjustOxyLoss(-target.getOxyLoss())
+
+	if(!target.revive(full_heal = FALSE))
+		to_chat(owner, span_warning("Nothing happens."))
+		return FALSE
+
+	var/mob/living/carbon/spirit/underworld_spirit = target.get_spirit()
+	if(underworld_spirit)
+		var/mob/dead/observer/ghost = underworld_spirit.ghostize()
+		qdel(underworld_spirit)
+		ghost.mind.transfer_to(target, TRUE)
+
+	target.grab_ghost(force = TRUE)
+	target.emote("breathgasp")
+	target.Jitter(100)
+	target.update_body()
+	target.visible_message(span_astrata("[target] is revived by holy light!"), span_green("I awake from the void."))
+	target.mind.remove_antag_datum(/datum/antagonist/zombie)
+	target.remove_status_effect(/datum/status_effect/debuff/rotted_zombie)
+	target.apply_status_effect(/datum/status_effect/debuff/revived)
+
+	// any additional flavortext goes here
 	if(choice == "Waiver")
 		to_chat(user, span_nicegreen("The Lux is consumed for this exchange, accounting no debts with Him!"))
 		to_chat(target, span_nicegreen("Warm sanctity wraps around your rekindled soul. Someone else has paid your toll."))
@@ -103,9 +137,10 @@
 	else if(choice == "Debt")
 		to_chat(user, span_nicegreen("You leave the burden where it belongs. Matthios smiles upon your bargain."))
 		to_chat(target, span_userdanger("Your soul returns, but it feels as if your Patron demands compensation..?"))
-	. = ..()
-	if(!.)
-		return FALSE
+	if(HAS_TRAIT(target, TRAIT_IRONMAN))
+		target.apply_status_effect(/datum/status_effect/debuff/integrity_rig, 11 MINUTES)
+		target.visible_message(span_danger("[target] is looking on the verge of exploding again! Their core may need an extra whack from a hammer."))
+
 	return TRUE
 
 /atom/movable/screen/alert/status_effect/debuff/matthios_debt

--- a/code/datums/status_effects/rogue/debuff.dm
+++ b/code/datums/status_effects/rogue/debuff.dm
@@ -526,7 +526,7 @@
 	alert_type = /atom/movable/screen/alert/status_effect/debuff/rotted
 	effectedstats = list(STATKEY_STR = -2, STATKEY_PER = -2, STATKEY_INT = -2, STATKEY_WIL = -2, STATKEY_CON = -2, STATKEY_SPD = -2, STATKEY_LCK = -2)
 	duration = 30 MINUTES	// Back to a temporary 30 minute duration. It hurts.
-	examine_text = "<font color='#2c8b00'>SUBJECTPRONOUN looks frail and unnaturally pale, moving with the hesitant stiffness of one whose body has only recently remembered how to live.</font>"
+	examine_text = "<font color='#008b56'>SUBJECTPRONOUN looks frail and unnaturally pale, as if they recently got brought back from death.</font>"
 
 /atom/movable/screen/alert/status_effect/debuff/rotted
 	name = "Atrophia"
@@ -548,7 +548,7 @@
 	id = "permadeath"
 	alert_type = /atom/movable/screen/alert/status_effect/debuff/permadeath
 	duration = PERMADEATH_DURATION //Effectively determines how long a character is threatened with permadeath. Kicks into gear once the initial deathmark-imposed grace period completes. Timed to match Revival Sickness.
-	examine_text = "<font color='#b40000'>SUBJECTPRONOUN appears haunted by an unseen burden. It feels as though their spirit hangs by the thinnest of threads. Another death may well be their last.</font>"
+	examine_text = "<font color='#b40000'>SUBJECTPRONOUN seems mentally and spiritually unstable. Another death could well be their last.</font>"
 
 /atom/movable/screen/alert/status_effect/debuff/permadeath
 	name = "Death's Door"


### PR DESCRIPTION
## About The Pull Request

- Rekindled Exchange seems to be double-proccing and reviving rotten people, all thanks to proc_holder being stupid. Turned it into action/cooldown and made it run its own revival sequence, no longer dependent of Anastasis or any other foreign proc.

## Testing Evidence

hiss

## Why It's Good For The Game

Fug Bixes n Update 

N lowkey apology for so many oversights, cause I can't find those little quirks in solo testing. I'm actively trying to use this live and that's why I'm finding (and fixing) these problems.

## Changelog
:cl:
fix: Fixed more things with Rekindled Exchange
/:cl: