### PR TITLE
Familiar fixes

### DIFF
--- a/code/modules/roguetown/roguejobs/mages/ritualrunes.dm
+++ b/code/modules/roguetown/roguejobs/mages/ritualrunes.dm
@@ -584,7 +584,7 @@ GLOBAL_LIST_INIT(t4rune_types, generate_t4rune_types())
 	if(summoned_mob && (input(user,"Would you like to cancel this summoning attempt?","Fallback","No") as anything in list("Yes","No") | null)=="Yes")
 		busy = FALSE
 		if(istype(summoned_mob,/mob/living/carbon/human/species/familiar/void))
-			var/list/refund_costs = list(/obj/item/magic/artifact = 1, /obj/item/magic/voidstone = 2, /obj/item/magic/leyline = 1)
+			var/static/list/refund_costs = list(/obj/item/magic/artifact = 1, /obj/item/magic/voidstone = 2, /obj/item/magic/leyline = 1)
 			for(var/index in refund_costs)
 				for(var/i in 1 to refund_costs[index])
 					new index(loc)

--- a/code/modules/roguetown/roguejobs/mages/rituals/binding.dm
+++ b/code/modules/roguetown/roguejobs/mages/rituals/binding.dm
@@ -183,7 +183,7 @@
 				. = TRUE
 
 /datum/runeritual/binding/release_familiar
-	name = "Free Familiar"
+	name = " iar"
 	desc = "Terminate your contract with a familiar, sending them back from whence they came unharmed."
 	blacklisted = FALSE
 	invocation = "Exsolvo spiritus!" // "release spirit." very creative
@@ -208,6 +208,12 @@
 	user.mind?.RemoveSpell(/datum/action/cooldown/spell/message_familiar)
 	fam.mind?.RemoveSpell(/datum/action/cooldown/spell/message_summoner)
 	fam.mind?.unknow_all_people()
+
+	if(istype(fam, /mob/living/carbon/human/species/familiar/void))
+		var/static/list/refund_costs = list(/obj/item/magic/artifact = 1, /obj/item/magic/voidstone = 2, /obj/item/magic/leyline = 1)
+		for(var/index in refund_costs)
+			for(var/i in 1 to refund_costs[index])
+				new index(loc)
 
 	var/exit_msg
 	if(isdead(fam))

--- a/code/modules/spells/components/conjured_item.dm
+++ b/code/modules/spells/components/conjured_item.dm
@@ -9,8 +9,9 @@ by Arcyne user after a duration
 	var/noglow = FALSE
 	var/dispelling = FALSE
 	var/decay_timer
+	var/nodecay = FALSE
 
-/datum/component/conjured_item/Initialize(outline_color_override, no_glow = FALSE, mob/caster, datum/conjure_source)
+/datum/component/conjured_item/Initialize(outline_color_override, no_glow = FALSE, mob/caster, datum/conjure_source, do_not_decay = FALSE)
 	if(!isitem(parent))
 		return COMPONENT_INCOMPATIBLE
 
@@ -34,7 +35,7 @@ by Arcyne user after a duration
 	I.craft_blocked = TRUE
 	I.sellprice = 0
 	I.static_price = TRUE
-
+	nodecay = do_not_decay
 	update_decay_timer()
 
 /datum/component/conjured_item/Destroy()
@@ -52,6 +53,8 @@ by Arcyne user after a duration
 	update_decay_timer()
 
 /datum/component/conjured_item/proc/update_decay_timer()
+	if(nodecay)
+		return
 	if(dispelling)
 		return
 	var/obj/item/I = parent

--- a/code/modules/spells/spell_types/familiar_abilities.dm
+++ b/code/modules/spells/spell_types/familiar_abilities.dm
@@ -456,7 +456,7 @@
 		I.fiber_salvage = FALSE
 
 		// Conjured glow
-		I.AddComponent(/datum/component/conjured_item, GLOW_COLOR_EARTHEN)
+		I.AddComponent(/datum/component/conjured_item, GLOW_COLOR_EARTHEN, do_not_decay = TRUE)
 	RegisterSignal(R, COMSIG_ITEM_BROKEN, PROC_REF(revert))
 	RegisterSignal(H, COMSIG_LIVING_RESIST, PROC_REF(revert))
 	RegisterSignal(R, COMSIG_ITEM_DROPPED, PROC_REF(revert_perspective))


### PR DESCRIPTION
## About The Pull Request
Stops qdeling familiars with abandonment issues, and refunds you when performing the FT rite on a void drakeling 

## Testing Evidence
i had to vv this shit to make sure the variables and timers were properly set i don't have screenshots because it's kinda incomprehensible

## Why It's Good For The Game
qdeling players is bad. punishing people for effectively fartravelling is also bad

## Changelog

:cl:
fix: Elemental familiars no longer qdel themselves if you abandon them for too long. You monster.
fix: Void drakelings being dismissed via the free familiar ritual will now refund the resources used to summon them.
/:cl:
