### PR TITLE
Standardizes (most) Silver Weapons, Alt Title: "I Got Isekai'd Into A Fantasy World Where Silver Is Denser Than Steel And Now I Must PR A Fix?!"

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/blunt.dm
+++ b/code/game/objects/items/rogueweapons/melee/blunt.dm
@@ -750,6 +750,9 @@
 	desc = "An ornate mace, plated in a ceremonial veneer of silver. Do not go quietly into the darkness; shatter your chains, roar with all your might, and bring the whole damndable temple down with you. </br>Even the unholy aren't immune to discombobulation."
 	icon_state = "psymace"
 	minstr = 12
+	force = 15
+	force_wielded = 35
+	wdefense_wbonus = 5
 	wbalance = WBALANCE_HEAVY
 	smelt_bar_num = 2
 	is_silver = TRUE

--- a/code/game/objects/items/rogueweapons/melee/blunt.dm
+++ b/code/game/objects/items/rogueweapons/melee/blunt.dm
@@ -1069,7 +1069,7 @@
 		silver_type = SILVER_PSYDONIAN,\
 		added_force = 0,\
 		added_blade_int = 100,\
-		added_int = 50,\ //Voila, extra integrity for your wall breakage.
+		added_int = 50,\
 		added_def = 2,\
 	)
 

--- a/code/game/objects/items/rogueweapons/melee/blunt.dm
+++ b/code/game/objects/items/rogueweapons/melee/blunt.dm
@@ -280,14 +280,12 @@
 	smeltresult = /obj/item/ingot/aaslag
 
 /obj/item/rogueweapon/mace/steel/silver
-	force = 30
-	force_wielded = 35
 	name = "silver mace"
 	desc = "A long and heavy flanged mace, forged from pure silver. For a lord, it's the perfect symbol of authority; a decorative piece for the courts. For a paladin, however, there's no better implement for shattering avantyne-maille into a putrid pile of debris."
 	icon_state = "silvermace"
 	smeltresult = /obj/item/ingot/silver
 	minstr = 10
-	wdefense = 5
+	wdefense = 3
 	smelt_bar_num = 2
 	swingsound = BLUNTWOOSH_LARGE
 	is_silver = TRUE
@@ -465,9 +463,7 @@
 	for the world you love. </br>'Please do not wait for me..' \ </br>'For though I depart, my magic will never die..' </br>'Listen to my laughter in the babbling brook..' \
 	</br>'Hear my song being sung by the bards..' </br>'Feel my warmth in the rays of the morning sun..' </br>'See my light in the twinkling stars at night..' \
 	</br>'..and know that my spirit will always be with you..' </br>'..woven into the very fabric of the world we cherished together.'"
-	force = 30
 	minstr = 9
-	wdefense = 5
 	resistance_flags = FIRE_PROOF
 	icon_state = "psyflangedmace"
 	swingsound = BLUNTWOOSH_LARGE
@@ -498,9 +494,7 @@
 	no matter the weather nor odds. </br>'Please do not wait for me..' \ </br>'For though I depart, my magic will never die..' </br>'Listen to my laughter in the babbling brook..' \
 	</br>'Hear my song being sung by the bards..' </br>'Feel my warmth in the rays of the morning sun..' </br>'See my light in the twinkling stars at night..' \
 	</br>'..and know that my spirit will always be with you..' </br>'..woven into the very fabric of the world we cherished together.'"
-	force = 30
 	minstr = 9
-	wdefense = 5
 	resistance_flags = FIRE_PROOF
 	icon_state = "psyflangedmace"
 	swingsound = BLUNTWOOSH_LARGE
@@ -544,7 +538,6 @@
 	</br>'For though I depart, my magic will never die..' </br>'Listen to my laughter in the babbling brook..' </br>'Hear my song being sung by the bards..' \
 	</br>'Feel my warmth in the rays of the morning sun..' </br>'See my light in the twinkling stars at night..' </br>'..and know that my spirit will always be with you..' \
 	</br>'..woven into the very fabric of the world we cherished together.'"
-	force_wielded = 25
 	wbalance = WBALANCE_NORMAL
 	icon_state = "opsyflangedmace"
 	smeltresult = /obj/item/ingot/iron
@@ -559,11 +552,8 @@
 	desc = "A shorter variant of the flanged silver mace, rebalanced for one-handed usage. It isn't uncommon for these sidearms to mysteriously 'vanish' from an Adjudicator's belt, only to be 'rediscovered' - and subsequently kept - by a Confessor."
 	possible_item_intents = list(/datum/intent/mace/strike, /datum/intent/mace/strike/wallop)
 	gripped_intents = list(/datum/intent/mace/strike, /datum/intent/mace/strike/wallop, /datum/intent/mace/smash, /datum/intent/effect/daze)
-	force = 25
-	force_wielded = 30
 	minstr = 7
-	wdefense = 5
-	wbalance = WBALANCE_SWIFT
+	wbalance = WBALANCE_SWIFT //We keep this for the confessors (weasels)
 	resistance_flags = FIRE_PROOF
 	icon_state = "psycudgel"
 	is_silver = TRUE
@@ -594,8 +584,6 @@
 /obj/item/rogueweapon/mace/cudgel/psy/old
 	name = "enduring handmace"
 	desc = "A flanged mace, well-balanced for usage in one hand. It radiates with a strange energy: familiar, yet ever-so-distant."
-	force = 20
-	force_wielded = 25
 	wbalance = WBALANCE_NORMAL
 	icon_state = "opsycudgel"
 	is_silver = FALSE
@@ -761,10 +749,7 @@
 	name = "psydonic mace"
 	desc = "An ornate mace, plated in a ceremonial veneer of silver. Do not go quietly into the darkness; shatter your chains, roar with all your might, and bring the whole damndable temple down with you. </br>Even the unholy aren't immune to discombobulation."
 	icon_state = "psymace"
-	force = 30
-	force_wielded = 35
 	minstr = 12
-	wdefense = 6
 	wbalance = WBALANCE_HEAVY
 	smelt_bar_num = 2
 	is_silver = TRUE
@@ -814,7 +799,7 @@
 	max_integrity = 200
 
 /obj/item/rogueweapon/mace/warhammer/bronze
-	force = 25
+	force = 25 //Same damage as steel, better throw force, can apparently fucking embed. I'm not tweaking this too much beyond standardizing the damage.
 	possible_item_intents = list(/datum/intent/mace/strike, /datum/intent/sword/cut, /datum/intent/mace/warhammer/pick, /datum/intent/mace/smash/lesser)
 	name = "bronze warclub"
 	desc = "The warhammer's ancestral link, carved from a weightsome log and studded with bronze. Elven natureguards carry it to both honor their forefathers, and as a way to sunder those who'd ravage Dendor's bounties without thought-or-restraint; a toss from afar turns into a sundering hurlbat."
@@ -824,7 +809,6 @@
 	throwforce = 25
 	embedding = list("embedded_pain_multiplier" = 4, "embed_chance" = 50, "embedded_fall_chance" = 20)
 	smeltresult = /obj/item/ingot/bronze
-	wdefense = 3
 	max_integrity = 180
 	sharpness = IS_SHARP
 
@@ -840,14 +824,13 @@
 	max_integrity = 120
 
 /obj/item/rogueweapon/mace/warhammer/bronze/steel
-	force = 28 //just a little better than the bronze club but barely
+	force = 25 //Same damage as the steel warhammer, better drip.
 	name = "steel warclub"
 	desc = "The warhammer's ancestral link, carved from a weightsome log and studded with steel. Elven natureguards carry it to both honor their forefathers, and as a way to sunder those who'd ravage Dendor's bounties without thought-or-restraint; a toss from afar turns into a sundering hurlbat."
 	icon_state = "steelclub"
 	max_blade_int = 175
 	throwforce = 25
 	smeltresult = /obj/item/ingot/steel
-	wdefense = 3
 	max_integrity = 200
 
 /obj/item/rogueweapon/mace/warhammer/bronze/silver
@@ -860,9 +843,9 @@
 	is_silver = TRUE
 
 /obj/item/rogueweapon/mace/warhammer/bronze/decorated
-	force = 30 // this requires GOLD to make, its going to be a bit more heavy.
+	force = 25 //All the drip in the world cannot buy you more damage. Blacksteel exists for that.
 	name = "decorated bronze warclub"
-	desc = "beads, silk, and gold caress this carved-and-spiked log; a honored totem who's roots trace back to the daes before Syon's impact. Myths speak of ancient elve-and-humen alike, wielding such bronzen bludgeons against the Archdevil's rampaging hordes."
+	desc = "Beads, silk, and gold caress this carved-and-spiked log; a honored totem who's roots trace back to the daes before Syon's impact. Myths speak of ancient elve-and-humen alike, wielding such bronzen bludgeons against the Archdevil's rampaging hordes."
 	icon_state = "bronzeclubdec"
 	smeltresult = /obj/item/ingot/gold
 	wdefense = 5
@@ -922,10 +905,7 @@
 	name = "silver warhammer"
 	desc = "A heavy warhammer, forged from pure silver. It follows the Otavan design of a 'lucerene'; a shortened polehammer with a pronounced spike, rebalanced for one-handed usage. Resplendent in presentation, righteous in purpose."
 	icon_state = "silverhammer"
-	force = 30
-	force_wielded = 30
 	minstr = 10
-	wdefense = 5
 	smeltresult = /obj/item/ingot/silver
 	smelt_bar_num = 2
 	is_silver = TRUE
@@ -1023,6 +1003,7 @@
 	smeltresult = /obj/item/ingot/steel
 	wdefense_wbonus = 4 // from 6
 	smelt_bar_num = 3
+	max_integrity = 370 //Up from 350 inherited from mace.
 
 //Malumite maul. Intended for Templars.
 /obj/item/rogueweapon/mace/maul/grand/malum
@@ -1065,14 +1046,12 @@
 //Psydonite reliquary maul. Intended for FUCKING SHIT UP.
 /obj/item/rogueweapon/mace/maul/grand/psy
 	name = "psydonic maul"
-	gripped_intents = list(/datum/intent/mace/strike/reach, /datum/intent/mace/sweep, /datum/intent/mace/demolish, /datum/intent/effect/hobble)
+	gripped_intents = list(/datum/intent/mace/strike/grand, /datum/intent/mace/sweep, /datum/intent/mace/demolish, /datum/intent/effect/hobble) //This has to use its own intents instead of inheriting because of the special demolish intent. I'm not touching it, beyond making the strike the same as the normal maul.
 	desc = "A rune-forged maul inspired by dwarven rock-hammers. Created as the faithful's answer to heretics hiding behind walls, it provides the impure with a sermon of exceptional concussive clarity. A good hit with this is guaranteed to give even the most peppy of heretics some deserved 'respite', and in best scenarios, send them to confess directly to HIM."
 	icon_state = "psyhammer"
 	smeltresult = /obj/item/ingot/silverblessed
 	minstr = 8
-	wdefense_wbonus = 8
 	is_silver = TRUE
-	max_integrity = 600 // need a lil more cause destroying walls takes a bit of this
 
 /obj/item/rogueweapon/mace/maul/grand/psy/pickup(mob/living/user)
 	if(HAS_TRAIT(user, TRAIT_PSYDONITE))
@@ -1088,7 +1067,7 @@
 		silver_type = SILVER_PSYDONIAN,\
 		added_force = 0,\
 		added_blade_int = 100,\
-		added_int = 50,\
+		added_int = 50,\ //Voila, extra integrity for your wall breakage.
 		added_def = 2,\
 	)
 

--- a/code/game/objects/items/rogueweapons/melee/blunt.dm
+++ b/code/game/objects/items/rogueweapons/melee/blunt.dm
@@ -285,7 +285,6 @@
 	icon_state = "silvermace"
 	smeltresult = /obj/item/ingot/silver
 	minstr = 10
-	wdefense = 3
 	smelt_bar_num = 2
 	swingsound = BLUNTWOOSH_LARGE
 	is_silver = TRUE

--- a/code/game/objects/items/rogueweapons/melee/flail.dm
+++ b/code/game/objects/items/rogueweapons/melee/flail.dm
@@ -197,14 +197,10 @@
 	minstr = 5
 
 /obj/item/rogueweapon/flail/sflail/silver
-	force = 35
 	icon_state = "silverflail"
 	name = "silver morningstar"
-	possible_item_intents = list(/datum/intent/flail/strike, /datum/intent/flail/smash/ranged, /datum/intent/flail/bash)
 	desc = "A heavy, silver flail. It follows the Grenzelhoftian design of a 'morning star', utilizing a longer chain to extend its reach. While stronger than a steel flail, it requires far more strength to effectively swing."
 	smeltresult = /obj/item/ingot/silver
-	max_integrity = 200 //Same value as before, for reference.
-	minstr = 12
 	is_silver = TRUE
 
 /obj/item/rogueweapon/flail/sflail/silver/ComponentInitialize()
@@ -222,7 +218,6 @@
 	name = "swift journey"
 	desc = "The striking head is full of teeth, rattling viciously with every strike, with every rotation. Each set coming from one the wielder has laid to rest. Carried alongside them as a great show of respect."
 	icon_state = "necraflail"
-	force = 35
 	is_silver = TRUE
 
 /obj/item/rogueweapon/flail/sflail/necraflail/ComponentInitialize()
@@ -240,9 +235,6 @@
 	name = "psydonic flail"
 	desc = "An ornate flail, plated in a ceremonial veneer of silver. Its flanged head can crumple even the toughest of darksteel-maille."
 	icon_state = "psyflail"
-	force = 35
-	minstr = 11
-	wdefense = 0
 	is_silver = TRUE
 	smeltresult = /obj/item/ingot/silverblessed
 
@@ -272,7 +264,6 @@
 	name = "\"Consecratia\""
 	desc = "The weight of His anguish, His pain, His hope and His love for humenkind - all hanging on the ornamental silver-steel head chained to this arm. <br><br>A declaration of love for all that Psydon lives for, and a crushing reminder to the arch-nemesis that they will not triumph as long as He endures."
 	icon_state = "psymorningstar"
-	possible_item_intents = list(/datum/intent/flail/strike, /datum/intent/flail/smash/ranged, /datum/intent/flail/bash)
 
 /obj/item/rogueweapon/flail/sflail/psyflail/relic/ComponentInitialize()
 	AddComponent(\

--- a/code/game/objects/items/rogueweapons/melee/flail.dm
+++ b/code/game/objects/items/rogueweapons/melee/flail.dm
@@ -199,8 +199,10 @@
 /obj/item/rogueweapon/flail/sflail/silver
 	icon_state = "silverflail"
 	name = "silver morningstar"
+	possible_item_intents = list(/datum/intent/flail/strike, /datum/intent/flail/smash/ranged, /datum/intent/flail/bash)
 	desc = "A heavy, silver flail. It follows the Grenzelhoftian design of a 'morning star', utilizing a longer chain to extend its reach. While stronger than a steel flail, it requires far more strength to effectively swing."
 	smeltresult = /obj/item/ingot/silver
+	minstr = 9
 	is_silver = TRUE
 
 /obj/item/rogueweapon/flail/sflail/silver/ComponentInitialize()
@@ -234,6 +236,8 @@
 /obj/item/rogueweapon/flail/sflail/psyflail
 	name = "psydonic flail"
 	desc = "An ornate flail, plated in a ceremonial veneer of silver. Its flanged head can crumple even the toughest of darksteel-maille."
+	possible_item_intents = list(/datum/intent/flail/strike, /datum/intent/flail/smash/ranged, /datum/intent/flail/bash)
+	minstr = 9
 	icon_state = "psyflail"
 	is_silver = TRUE
 	smeltresult = /obj/item/ingot/silverblessed
@@ -264,6 +268,8 @@
 	name = "\"Consecratia\""
 	desc = "The weight of His anguish, His pain, His hope and His love for humenkind - all hanging on the ornamental silver-steel head chained to this arm. <br><br>A declaration of love for all that Psydon lives for, and a crushing reminder to the arch-nemesis that they will not triumph as long as He endures."
 	icon_state = "psymorningstar"
+	possible_item_intents = list(/datum/intent/flail/strike, /datum/intent/flail/smash/ranged, /datum/intent/flail/bash)
+	force = 35
 
 /obj/item/rogueweapon/flail/sflail/psyflail/relic/ComponentInitialize()
 	AddComponent(\

--- a/code/game/objects/items/rogueweapons/melee/knives.dm
+++ b/code/game/objects/items/rogueweapons/melee/knives.dm
@@ -897,6 +897,7 @@
 	desc = "A branch that has been broken off of a boswellia tree, sharpened to a fine point and tipped with blessed silver. It can lay most unholy creechers to rest, but only by piercing their hearts."
 	icon_state = "heavystake_silver"
 	possible_item_intents = list(/datum/intent/dagger/thrust/pick, /datum/intent/dagger/thrust/quick, /datum/intent/dagger/cut, /datum/intent/dagger/sucker_punch)
+	force = 20
 	throwforce = 20
 	wdefense = 0
 	max_integrity = 50

--- a/code/game/objects/items/rogueweapons/melee/knives.dm
+++ b/code/game/objects/items/rogueweapons/melee/knives.dm
@@ -968,6 +968,7 @@
 /obj/item/rogueweapon/huntingknife/idagger/stake/inq
 	name = "otavan stake"
 	desc = "A smaller branch that has been broken off of an Otavan boswellia tree, sharpened to a fine point. It can lay most unholy creechers to rest, but only by piercing their hearts."
+	force = 15
 	throwforce = 15
 	icon_state = "stake_otavan"
 

--- a/code/game/objects/items/rogueweapons/melee/knives.dm
+++ b/code/game/objects/items/rogueweapons/melee/knives.dm
@@ -897,7 +897,6 @@
 	desc = "A branch that has been broken off of a boswellia tree, sharpened to a fine point and tipped with blessed silver. It can lay most unholy creechers to rest, but only by piercing their hearts."
 	icon_state = "heavystake_silver"
 	possible_item_intents = list(/datum/intent/dagger/thrust/pick, /datum/intent/dagger/thrust/quick, /datum/intent/dagger/cut, /datum/intent/dagger/sucker_punch)
-	force = 20
 	throwforce = 20
 	wdefense = 0
 	max_integrity = 50
@@ -969,7 +968,6 @@
 /obj/item/rogueweapon/huntingknife/idagger/stake/inq
 	name = "otavan stake"
 	desc = "A smaller branch that has been broken off of an Otavan boswellia tree, sharpened to a fine point. It can lay most unholy creechers to rest, but only by piercing their hearts."
-	force = 15
 	throwforce = 15
 	icon_state = "stake_otavan"
 
@@ -1215,7 +1213,7 @@
 	max_integrity = 150
 	wdefense = 3
 	icon_state = "throw_knifesil"
-	embedding = list("embedded_pain_multiplier" = 4, "embed_chance" = 50, "embedded_fall_chance" = 0)
+	embedding = list("embedded_pain_multiplier" = 4, "embed_chance" = 50, "embedded_fall_chance" = 0) //Higher embed chance, doesn't fall.
 	is_silver = TRUE
 
 /obj/item/rogueweapon/huntingknife/throwingknife/silver/ComponentInitialize()

--- a/code/game/objects/items/rogueweapons/melee/polearms/staff.dm
+++ b/code/game/objects/items/rogueweapons/melee/polearms/staff.dm
@@ -331,10 +331,10 @@
 	name = "silver quarterstaff"
 	desc = "A quarterstaff reinforced with silver tips. A relatively new design, purportedly inspired by the warstaffs oft-carried by Naledian \
 	warscholars. Durable enough to catch-and-disarm avantyne to the shaft, without so much as a splinter - or so, they say."
-	force = 20
-	force_wielded = 27
+	force = 18
+	force_wielded = 25
 	icon_state = "quarterstaff_silver"
-	max_integrity = 250
+	max_integrity = 200
 	is_silver = TRUE
 	smeltresult = /obj/item/ingot/silver
 
@@ -353,9 +353,9 @@
 	name = "psydonic quarterstaff"
 	desc = "A quarterstaff reinforced with silver tips. A relatively new design, purportedly inspired by the warstaffs \
 	oft-carried by Naledian warscholars. Durable enough to catch avantyne to the shaft, without so much as a splinter - or so, they say."
-	force_wielded = 27
+	force_wielded = 25
 	icon_state = "quarterstaff_silver"
-	max_integrity = 250
+	max_integrity = 200
 	is_silver = TRUE
 	smeltresult = /obj/item/ingot/silverblessed
 

--- a/code/game/objects/items/rogueweapons/melee/special.dm
+++ b/code/game/objects/items/rogueweapons/melee/special.dm
@@ -563,14 +563,8 @@
 	icon_state = "silvershovelwaraxe"
 	possible_item_intents = list(/datum/intent/axe/cut, /datum/intent/axe/chop, SPEAR_BASH) //bash is for nonlethal takedowns, only targets limbs
 	gripped_intents = list(/datum/intent/rend/reach, /datum/intent/axe/chop/long, SPEAR_BASH)
-	force = 15
-	force_wielded = 25
-	minstr = 11
-	max_blade_int = 200
 	anvilrepair = /datum/skill/craft/carpentry
 	smeltresult = /obj/item/ingot/silver
-	wdefense = 6
-	wbalance = WBALANCE_HEAVY
 	is_silver = TRUE
 
 /obj/item/rogueweapon/greataxe/militia/silver/ComponentInitialize()
@@ -979,9 +973,6 @@
 			</br>'Here we stand, to turn and face the odds; sacrifice yourself, or bow to lesser gods!'"
 	smeltresult = /obj/item/ingot/silver
 	icon_state = "silverclaws"
-	wdefense = 5
-	max_blade_int = 300
-	max_integrity = 225
 	is_silver = TRUE
 
 /obj/item/rogueweapon/handclaw/gronn/silver/ComponentInitialize()

--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -1288,10 +1288,8 @@
 	in favor of a hollow beak to hook and draw harm away from its user. Short in length, yet lethally light in weight."
 	icon_state = "psyswordshort"
 	sheathe_icon = "psyswordshort"
-	force = 20
-	force_wielded = 20
+	force = 20 //Doakes.gif
 	minstr = 7
-	wdefense = 3
 	wbalance = WBALANCE_SWIFT
 	is_silver = TRUE
 	smeltresult = /obj/item/ingot/silverblessed
@@ -1325,10 +1323,8 @@
 	icon = 'icons/roguetown/weapons/daggers32.dmi'
 	icon_state = "silverswordshort"
 	sheathe_icon = "psyswordshort"
-	force = 20
-	force_wielded = 20
+	force = 20 //Doakes.gif
 	minstr = 7
-	wdefense = 3
 	wbalance = WBALANCE_SWIFT
 	is_silver = TRUE
 	smeltresult = /obj/item/ingot/silver
@@ -1811,14 +1807,10 @@
 	in an untrained hand - is surprisingly adept at both parrying and riposting."
 	icon_state = "silverrapier"
 	sheathe_icon = "silverrapier"
-	max_integrity = 225
-	max_blade_int = 225
 	force = 20
-	force_wielded = 20
 	minstr = 8
-	wdefense = 8
 	smeltresult = /obj/item/ingot/silver
-	is_silver = TRUE
+	is_silver = TRUE //Blessing component covers extra wdef and integrity, don't give it snowflake values.
 
 /obj/item/rogueweapon/sword/rapier/silver/ComponentInitialize()
 	AddComponent(\
@@ -1837,12 +1829,8 @@
 	maille, but also serves as the symbol of an Otavan diplomat's authority."
 	icon_state = "silverrapier"
 	sheathe_icon = "silverrapier"
-	max_integrity = 225
-	max_blade_int = 225
 	force = 20
-	force_wielded = 20
 	minstr = 8
-	wdefense = 8
 	smeltresult = /obj/item/ingot/silverblessed
 	is_silver = TRUE
 
@@ -1875,12 +1863,11 @@
 	crowned upon a basket hilt that keeps righteous hands safe from harm.</b>"
 	icon_state = "psyrapier"
 	sheathe_icon = "psyrapier"
-	max_integrity = 300
+	max_integrity = 300 //Keeps extra integ/blade integ because its a relic.
 	max_blade_int = 300
 	force = 20
-	force_wielded = 20
 	minstr = 8
-	wdefense = 8
+	wdefense = 8 //This keeps its special wdefense since its a relic.
 	smeltresult = /obj/item/ingot/silver
 	is_silver = TRUE
 
@@ -1985,14 +1972,11 @@
 	icon_state = "silversword"
 	sheathe_icon = "silversword"
 	force = 20
-	force_wielded = 25
+	force_wielded = 25 //Doakes.gif
 	minstr = 9
-	wdefense = 5
-	is_silver = TRUE
+	is_silver = TRUE //Silver blessing component covers extra wdef and integrity. Don't give it snowflake values for those.
 	smeltresult = /obj/item/ingot/silver
 	smelt_bar_num = 2
-	max_blade_int = 230
-	max_integrity = 200
 
 /obj/item/rogueweapon/sword/silver/ComponentInitialize()
 	AddComponent(\
@@ -2012,14 +1996,11 @@
 	icon_state = "silversword"
 	sheathe_icon = "silversword"
 	force = 20
-	force_wielded = 25
+	force_wielded = 25 //Doakes.gif
 	minstr = 9
-	wdefense = 5
 	is_silver = TRUE
 	smeltresult = /obj/item/ingot/silverblessed
 	smelt_bar_num = 2
-	max_blade_int = 230
-	max_integrity = 200
 	smelt_bar_num = 1
 
 /obj/item/rogueweapon/sword/psy/ComponentInitialize()
@@ -2050,7 +2031,7 @@
 	sword, better known as a 'ram-dao', now serves to satiate the spite of vengeful spirits - not through bloodshed, but through sunderance."
 	icon_state = "ram_dao"
 	sheathe_icon = "scabbard_decsword3"
-	force = 25
+	force = 25 //Comparable to the silver war axe, given the intents. This gets a pass.
 	no_loot_taint = TRUE
 	possible_item_intents = list(/datum/intent/axe/cut, /datum/intent/axe/chop, /datum/intent/axe/bash/battle)
 	gripped_intents = null

--- a/code/game/objects/items/rogueweapons/melee/whip.dm
+++ b/code/game/objects/items/rogueweapons/melee/whip.dm
@@ -86,7 +86,7 @@
 /datum/intent/flail/smash/ranged/psywhip //It is a small blessing this is allowed on a one-handed weapon.
 	name = "Meteor Strike"
 	desc = "Swing the weight of your whip around your body, using the angular momentum to deliver a devastating strike, propelling your enemy back and savaging them at the same time."
-	chargedrain = 0
+	chargedrain = 0 //The charge time is indicative of a warmup, not a hold.
 	chargedloop = /datum/looping_sound/flailswing
 	keep_looping = FALSE
 

--- a/code/game/objects/items/rogueweapons/melee/whip.dm
+++ b/code/game/objects/items/rogueweapons/melee/whip.dm
@@ -163,7 +163,7 @@
 	desc = "A chain-linked whip, meticulously assembled from a hundred pieces of blessed silver. Its origins are steeped in mythos: most believe it to originate from an ancient bloodline of vampyre-killers, which once saved Psydonia from a powerful lyckerlorde. Whether it was happenstance or fate itself that eventually led it into your grasp, however, is better left unspoken. </br>'There, upon the Cathedral's ceiling, was painted a scene-most-beautiful: of a robed Psydon standing before the Archdevil, parting the nite's sky with a crack from His fiery whip. Just as He had done prior, so too must you bring daelight to the darkness.'"
 	icon_state = "psywhip"
 	is_silver = TRUE
-	force = 22
+	force = 25
 	possible_item_intents = list(/datum/intent/whip/lash/master, /datum/intent/whip/crack, /datum/intent/whip/punish, /datum/intent/flail/smash/ranged/psywhip)
 	minstr = 9
 	anvilrepair = /datum/skill/craft/weaponsmithing

--- a/code/game/objects/items/rogueweapons/melee/whip.dm
+++ b/code/game/objects/items/rogueweapons/melee/whip.dm
@@ -82,10 +82,10 @@
 	icon_state = "instrike"
 	item_d_type = "blunt"
 	intent_intdamage_factor = BLUNT_DEFAULT_INT_DAMAGEFACTOR
-/datum/intent/flail/smash/ranged/psywhip
+
+/datum/intent/flail/smash/ranged/psywhip //It is a small blessing this is allowed on a one-handed weapon.
 	name = "Meteor Strike"
 	desc = "Swing the weight of your whip around your body, using the angular momentum to deliver a devastating strike, propelling your enemy back and savaging them at the same time."
-	chargedrain = 0 //The charge time is indicative of a warmup, not a hold.
 	chargedloop = /datum/looping_sound/flailswing
 	keep_looping = FALSE
 
@@ -162,10 +162,9 @@
 	desc = "A chain-linked whip, meticulously assembled from a hundred pieces of blessed silver. Its origins are steeped in mythos: most believe it to originate from an ancient bloodline of vampyre-killers, which once saved Psydonia from a powerful lyckerlorde. Whether it was happenstance or fate itself that eventually led it into your grasp, however, is better left unspoken. </br>'There, upon the Cathedral's ceiling, was painted a scene-most-beautiful: of a robed Psydon standing before the Archdevil, parting the nite's sky with a crack from His fiery whip. Just as He had done prior, so too must you bring daelight to the darkness.'"
 	icon_state = "psywhip"
 	is_silver = TRUE
-	force = 25
+	force = 22
 	possible_item_intents = list(/datum/intent/whip/lash/master, /datum/intent/whip/crack, /datum/intent/whip/punish, /datum/intent/flail/smash/ranged/psywhip)
-	minstr = 11
-	wdefense = 0
+	minstr = 9
 	anvilrepair = /datum/skill/craft/weaponsmithing
 	smeltresult = /obj/item/ingot/silver
 
@@ -184,10 +183,8 @@
 	name = "silver whip"
 	desc = "A hefty, silver whip. The uncoiled leather is tipped with a silver barb, which can sunder the blighted from a remarkable distance. </br>'Die, monster! You don't belong in this world!'"
 	icon_state = "silverwhip"
-	force = 23 //Experimental change - adds a +2 to force, as a bridge between handweapons and blunt weapons. Higher strength minimum. Do not raise above 25, unless you want to resurrect maille-shatterers.
 	possible_item_intents = list(/datum/intent/whip/lash/master, /datum/intent/whip/crack, /datum/intent/whip/punish)
-	minstr = 11
-	wdefense = 0
+	minstr = 9
 	is_silver = TRUE
 	smeltresult = /obj/item/ingot/silver
 
@@ -207,9 +204,7 @@
 	desc = "An ornate whip, plated in a ceremonial veneer of silver. Crack the leather and watch as the apostates clammer aside."
 	icon_state = "psywhip_lesser"
 	possible_item_intents = list(/datum/intent/whip/lash/master, /datum/intent/whip/crack, /datum/intent/whip/punish)
-	force = 23
-	minstr = 11
-	wdefense = 0
+	minstr = 9
 	is_silver = TRUE
 	smeltresult = /obj/item/ingot/silverblessed
 

--- a/code/game/objects/items/rogueweapons/melee/whip.dm
+++ b/code/game/objects/items/rogueweapons/melee/whip.dm
@@ -86,6 +86,7 @@
 /datum/intent/flail/smash/ranged/psywhip //It is a small blessing this is allowed on a one-handed weapon.
 	name = "Meteor Strike"
 	desc = "Swing the weight of your whip around your body, using the angular momentum to deliver a devastating strike, propelling your enemy back and savaging them at the same time."
+	chargedrain = 0
 	chargedloop = /datum/looping_sound/flailswing
 	keep_looping = FALSE
 


### PR DESCRIPTION
## About The Pull Request
It's been a long time coming.
I'll try to document all changes, but the general rationale is this:

- Silver weapons have been all over the place for some time now. Snowflake values, values that could be inherited from parent type without change, inconsistent application of balancing guidelines.
- Silver weapons are supposed to have -3 to -5 force compared to steel weapons to make up for efficacy VS undead or heresy, and extra integrity/defense from being blessed.
- Instead, only some sharp weapons were subject to this, while blunt weapons actually had blacksteel-tier damage. In addition, most silver weapons had buffed base integrities and sometimes defense on top of their blessing bonus.

This PR aims to fix these incongruences using the following standards:

- Silver blunt weapons go back to doing steel-tier damage. Base integrity and defense always default to parent type where possible. Blessing values are untouched. Consecratia and Daybreak are spared as their blessing stats are normally useless and they are unique weapons.
- Silver sharp weapons retain their nerfed damage, although a few currently have steel-tier damage. This PR will not touch that. Base integrity and defense always default to parent type where possible, save for the Inquisitor's relics. Blessing values are untouched.




## Big List of Changes
A (P) next to a value refers to the value now being inherited from parent type; In most cases, the parent type is a steel version of the weapon. 
Note that wdefense refers to one-handed, base defense. It does not account for silver blessing. Wdefense Bonus refers to the added two-handed defense value.

Once again: **This does not touch any of these weapon's blessing values. Add their blessing values when calculating blade integrity, defense and integrity. Thank you.**

### Maces:

- Silver Mace | Damage: 30/35 -> 25/30 (P) | Wdefense: 5 -> 3 (P)
- Silver Flanged Mace & Psydonian Flanged Mace | Damage: 30 -> 27 (P) | Wdefense: 5 -> 3 (P)
- Enduring Flanged Mace | Damage: 25 -> 27 (P) | Wdefense: 5 -> 3 (P)
- Psydonic Handmace | Damage: 25/30 -> 23/30 (P) | Wdefense: 5 -> 1 (P) [Author's Note: This thing has gripped intents, unlike the normal cudgel. I kept them. It's also inheriting the parent type's wielded damage. It's also swift. Fixing these is out of scope, who knows if a 30 damage swift blunt weapon is balanced, but I'm trying to stick to the standards I set.]
- Enduring Handmace | Inherits from Psydonic Handmace, with the exception of wbalance.
- Psydonic Mace (Goden) | Damage: 30/35 -> 15/35 | Wdefense Bonus: 6 -> 5 
- Silver Warhammer | Damage: 30 -> 25 (P) | Wdefense: 5 -> 4 (P)
- Psydonic Maul | Strike intent is now inherited from its parent type | Wdefense Bonus: 8 -> 4 (P) | Base Integrity: 600 -> 370 (P) [Author's Note: This thing's worst crimes were its snowflake strike intent, which was better than its steel variant, and the inexplicable 4 (6 with blessing) extra defense. Even looking at it gave me a headache. Mauls as a whole get a tiny 20 max integrity bump, and thus the base integrity is now inherited as well.]

### Flails and Whips

- Silver Morningstar (Silver Flail) | Damage: 35 -> 30 | Base Integrity: 200 -> 150 (P) | Min. Strength: 12 - > 9
- Swift Journey | Damage: 35 -> 30 (P)
- Psydonic Flail | Damage: 35 -> 30 (P) | Min. Strength: 11 -> 9
- Silver Whip & Psydonian Whip | Damage: 23 -> 21 (P) | Min. Strength: 11 -> 9
- Daybreak | Min. Strength: 11 -> 9 [Author's Note: This has 25 force and a special, arguably questionable intent compared to other whips. Still, because it doesn't benefit from any of the stats that the blessing normally affects, while being a relic, I'm willing to let it slide.]
- Consecratia | Min. Strength 11 -> 9 [Author's Note: Same rationale as Daybreak. It is a flail, it doesn't benefit from any of its blessing stats.]

### Quarterstaves, Axes & Handclaws

- Silver Quarterstaff & Psydonic Quarterstaff | Damage: 20/27 -> 18/25 | Base Integrity: 250 -> 200 [Author's Note: Same stats as steel quarterstaff pre-blessing.]
- Silver Militia Shovelaxe | Min. Strength: 11 -> 10 (P) | Base Blade Int.: 200 -> 130 (P) | Wdefense: 6 -> 4 (P)
- Silver Ravager Claws | Base Blade Int.: 300 -> 200 (P) | Base Integrity: 225 -> 200 (P) | Wdefense: 5 -> 3 (P) [Author's Note: Whose idea was it to take the best handclaws, a class unique, and make it craftable while buffing it? Seriously?]

### Swords

- Psydonic Shortsword & Silver Shortsword | Wdefense: 3 -> 4 (P) [Author's Note: Weird case where the base wdefense was lower than steel parent type.]
- Psydonic Rapier & Silver Rapier | Base Blade Int.: 225 -> 230 (P) | Base Integrity: 225 -> 150 (P) | Wdefense: 8 -> 7 (P)
- Silver Arming Sword & Psydonic Arming Sword | Base Blade Int.: 230 -> 200 | Base Integrity: 200 -> 150 | Wdefense: 5 -> 4 (P)


### Other

- Mildly out of scope, but set the damage of the "bronze warclub" line of weapons back to steel warhammer baseline. They still retain some snowflake properties such as higher throw damage and integrity, but I can't see why they should have consistently higher-than-steel damage.












## Changelog

:cl:
balance: rebalances most silver weapons to revert powercreep and return to steel baselines, blessings aside
/:cl:

