### PR TITLE
Munitioneer wit da Bolts and Berserker wit da Punchdagger

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/special.dm
+++ b/code/game/objects/items/rogueweapons/melee/special.dm
@@ -357,7 +357,7 @@
 /obj/item/rogueweapon/katar/punchdagger
 	name = "punch dagger"
 	desc = "A weapon that combines the ergonomics of the Ranesheni katar with the capabilities of the Western Psydonian \"knight-killers\". It can be tied around the wrist."
-	slot_flags = ITEM_SLOT_WRISTS
+	slot_flags = ITEM_SLOT_WRISTS|ITEM_SLOT_HIP
 	max_integrity = 120		//Steel dagger -30
 	force = 15		//Steel dagger -5
 	throwforce = 8

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/berserker.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/berserker.dm
@@ -85,7 +85,7 @@
 					if("Knuckledusters")
 						gloves = /obj/item/clothing/gloves/roguetown/knuckles
 					if("Punch Dagger")
-						r_hand = /obj/item/rogueweapon/katar/punchdagger
+						beltr = /obj/item/rogueweapon/katar/punchdagger
 			if("Martial Expert") // designed to compete with unarmed by giving you alternatives to approaching fights- only expert
 				var/list/martial_options = list("Greatsword", "Battle Axe", "Grand Mace", "Longsword")
 				var/weapon_choice = input(H, "Choose your WEAPONS of WAR!", "SPILL THEIR ENTRAILS.") as anything in martial_options

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/munitioneer.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/munitioneer.dm
@@ -88,7 +88,7 @@
 		if("Path of the Crossbow - Crossbow and Bolts")
 			H.adjust_skillrank_up_to(/datum/skill/combat/crossbows, SKILL_LEVEL_EXPERT, TRUE)
 			H.put_in_hands(new /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow)
-			H.equip_to_slot_or_del(new /obj/item/quiver/bolt/standard, SLOT_BELT_L, TRUE)
+			H.put_in_hands(new /obj/item/quiver/bolt/standard)
 		if("Path of the Pick - Pulaski Axe")
 			H.adjust_skillrank_up_to(/datum/skill/combat/axes, SKILL_LEVEL_EXPERT, TRUE)
 			H.put_in_hands(new /obj/item/rogueweapon/stoneaxe/woodcut/pick)


### PR DESCRIPTION
## About The Pull Request

Fixes issue #9007, where Munitioneers choosing the "Crossbow + Bolts" option did not actually get bolts, since their belt was occupied with other items already.

Also fixes a problem with Berserkers not getting their Punchdagger if they chose to start with it.

For the sake of consistency with Katars, I allowed non-freifechter punchdaggers to be worn on your left or right beltslots, maybe it makes sense to include the Freifechter version here, but I figured there is/was a reason to it being able to be worn on the ring slot, and it seems kind of cool.

Not sure why these were limited to the wrist slot either though, they're not even bracers, no?

## Testing Evidence

Spawned in to check if the spawning works correctly for both changes.

## Why It's Good For The Game

Uhhh, it's consistent with what says would happen.

## Changelog

:cl:
add: Non-Frei Punchdaggers can be worn on beltr or beltr, so your hip slots.
fix: Berserker spawns with Punchdagger if chosen.
fix:Munitioneer spawns with ammo for crossbow if chosen.
/:cl: