### PR TITLE
wretch_coast.dmm tweaks

### DIFF
--- a/_maps/map_files/otherz/wretch_coast.dmm
+++ b/_maps/map_files/otherz/wretch_coast.dmm
@@ -504,6 +504,12 @@
 /obj/machinery/light/rogue/firebowl/standing,
 /turf/open/floor/rogue/tile/masonic,
 /area/rogue/indoors/vampire_manor)
+"bU" = (
+/obj/structure/chair/bench/church/r{
+	dir = 1
+	},
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/under/cave/inhumen)
 "bV" = (
 /obj/structure/flora/hotspring_rocks/small,
 /obj/effect/decal/cobbleedge{
@@ -4062,6 +4068,10 @@
 	},
 /turf/open/floor/rogue/dirt/ambush,
 /area/rogue/outdoors/woods/vampire_lair)
+"rd" = (
+/obj/structure/roguemachine/mail/r,
+/turf/open/floor/rogue/tile/brick,
+/area/rogue/indoors/vampire_manor)
 "re" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -4267,8 +4277,10 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave/inhumen)
 "rV" = (
-/obj/structure/chair/bench/church/r,
 /obj/effect/landmark/start/wretch{
+	dir = 1
+	},
+/obj/structure/chair/bench/church/r{
 	dir = 1
 	},
 /turf/open/floor/rogue/churchbrick,
@@ -4284,6 +4296,9 @@
 /area/rogue/outdoors/woods/wretch_lair)
 "rZ" = (
 /obj/structure/fluff/railing/border/north,
+/obj/structure/roguemachine/talkstatue/mercenary{
+	pixel_y = 32
+	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/woods/vampire_lair)
 "sa" = (
@@ -4621,6 +4636,7 @@
 /obj/item/paper/scroll,
 /obj/item/paper/scroll,
 /obj/item/natural/feather,
+/obj/structure/roguemachine/mail/r,
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors/vampire_manor)
 "ti" = (
@@ -6423,8 +6439,10 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/woods/wretch_lair)
 "AO" = (
-/obj/structure/chair/bench/church/mid,
 /obj/effect/landmark/start/wretch{
+	dir = 1
+	},
+/obj/structure/chair/bench/church/mid{
 	dir = 1
 	},
 /turf/open/floor/rogue/churchbrick,
@@ -7695,8 +7713,10 @@
 "Gu" = (
 /obj/machinery/light/rogue/candle,
 /obj/effect/decal/cleanable/blood,
-/obj/structure/roguemachine/mail/r,
-/obj/structure/fluff/clock,
+/obj/structure/fluff/clock{
+	dir = 1;
+	pixel_x = 6
+	},
 /turf/open/floor/rogue/tile,
 /area/rogue/under/cave/inhumen)
 "Gv" = (
@@ -8626,7 +8646,9 @@
 /turf/open/floor/rogue/tile/brick,
 /area/rogue/indoors/vampire_manor)
 "Kx" = (
-/obj/structure/chair/bench/church/mid,
+/obj/structure/chair/bench/church/mid{
+	dir = 1
+	},
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/under/cave/inhumen)
 "Ky" = (
@@ -9807,6 +9829,10 @@
 /obj/machinery/light/rogue/candle/l,
 /turf/open/floor/rogue/tile/bath,
 /area/rogue/indoors/vampire_manor)
+"Pl" = (
+/obj/structure/roguemachine/mail/r,
+/turf/open/floor/rogue/tile,
+/area/rogue/under/cave/inhumen)
 "Pm" = (
 /obj/structure/fluff/railing/border/east,
 /turf/open/floor/rogue/twig,
@@ -10422,6 +10448,10 @@
 "St" = (
 /turf/closed/mineral/rogue/bedrock,
 /area/rogue/outdoors/woods/vampire_lair)
+"Su" = (
+/obj/structure/roguemachine/talkstatue/mercenary,
+/turf/closed/wall/mineral/rogue/wooddark/end/east,
+/area/rogue/indoors/banditcamp)
 "Sw" = (
 /obj/structure/fluff/railing/corner/north_east,
 /turf/open/floor/rogue/dirt,
@@ -10501,8 +10531,10 @@
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/vampire_manor)
 "SS" = (
-/obj/structure/chair/bench/church/mid,
 /obj/effect/decal/cleanable/debris/stony,
+/obj/structure/chair/bench/church/mid{
+	dir = 1
+	},
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/under/cave/inhumen)
 "ST" = (
@@ -11577,6 +11609,12 @@
 /area/rogue/indoors/banditcamp)
 "Xt" = (
 /turf/open/lava/acid,
+/area/rogue/outdoors/woods/wretch_lair)
+"Xu" = (
+/obj/structure/roguemachine/talkstatue/mercenary{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/grass,
 /area/rogue/outdoors/woods/wretch_lair)
 "Xv" = (
 /obj/structure/stairs{
@@ -13614,7 +13652,7 @@ JQ
 wV
 dh
 rV
-sa
+bU
 rV
 Mh
 IW
@@ -30764,7 +30802,7 @@ Ev
 lB
 jh
 Gu
-bK
+Pl
 bK
 Zl
 Zl
@@ -31670,7 +31708,7 @@ Dq
 qW
 qW
 UM
-Xm
+Xu
 Ev
 Ev
 Ev
@@ -33839,7 +33877,7 @@ nk
 iL
 iL
 eE
-DR
+Su
 DR
 Ux
 yI
@@ -43263,7 +43301,7 @@ or
 or
 jA
 Uj
-Xw
+rd
 Ue
 aF
 mU

--- a/_maps/map_files/otherz/wretch_coast.dmm
+++ b/_maps/map_files/otherz/wretch_coast.dmm
@@ -504,12 +504,6 @@
 /obj/machinery/light/rogue/firebowl/standing,
 /turf/open/floor/rogue/tile/masonic,
 /area/rogue/indoors/vampire_manor)
-"bU" = (
-/obj/structure/chair/bench/church/r{
-	dir = 1
-	},
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/under/cave/inhumen)
 "bV" = (
 /obj/structure/flora/hotspring_rocks/small,
 /obj/effect/decal/cobbleedge{
@@ -1435,6 +1429,12 @@
 /obj/structure/flora/roguegrass/bush,
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/woods/vampire_lair)
+"fY" = (
+/obj/structure/roguemachine/mail/r{
+	mailtag = "Old Manor"
+	},
+/turf/open/floor/rogue/tile/brick,
+/area/rogue/indoors/vampire_manor)
 "fZ" = (
 /obj/structure/bed/rogue/bedroll{
 	dir = 1
@@ -1979,6 +1979,10 @@
 /obj/machinery/light/rogue/candle/r,
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/vampire_manor)
+"iz" = (
+/obj/structure/roguemachine/mail/r,
+/turf/open/floor/rogue/tile,
+/area/rogue/under/cave/inhumen)
 "iA" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor5-old"
@@ -4018,6 +4022,12 @@
 /obj/machinery/light/rogue/candle/r,
 /turf/open/floor/carpet/red,
 /area/rogue/under/cave/inhumen)
+"qQ" = (
+/obj/structure/roguemachine/talkstatue/mercenary{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods/wretch_lair)
 "qR" = (
 /obj/effect/decal/carpet/square,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -4068,10 +4078,6 @@
 	},
 /turf/open/floor/rogue/dirt/ambush,
 /area/rogue/outdoors/woods/vampire_lair)
-"rd" = (
-/obj/structure/roguemachine/mail/r,
-/turf/open/floor/rogue/tile/brick,
-/area/rogue/indoors/vampire_manor)
 "re" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -4636,7 +4642,9 @@
 /obj/item/paper/scroll,
 /obj/item/paper/scroll,
 /obj/item/natural/feather,
-/obj/structure/roguemachine/mail/r,
+/obj/structure/roguemachine/mail/r{
+	mailtag = "Old Throne Room"
+	},
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors/vampire_manor)
 "ti" = (
@@ -7325,6 +7333,10 @@
 "EC" = (
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/outdoors/banditcamp)
+"ED" = (
+/obj/structure/roguemachine/talkstatue/mercenary,
+/turf/closed/wall/mineral/rogue/wooddark/end/east,
+/area/rogue/indoors/banditcamp)
 "EE" = (
 /obj/machinery/light/rogue/candle/floorcandle{
 	pixel_y = -9
@@ -7769,6 +7781,12 @@
 	dir = 10
 	},
 /turf/open/floor/rogue/cobble,
+/area/rogue/under/cave/inhumen)
+"GH" = (
+/obj/structure/chair/bench/church/r{
+	dir = 1
+	},
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/under/cave/inhumen)
 "GI" = (
 /obj/effect/decal/cobbleedge{
@@ -9829,10 +9847,6 @@
 /obj/machinery/light/rogue/candle/l,
 /turf/open/floor/rogue/tile/bath,
 /area/rogue/indoors/vampire_manor)
-"Pl" = (
-/obj/structure/roguemachine/mail/r,
-/turf/open/floor/rogue/tile,
-/area/rogue/under/cave/inhumen)
 "Pm" = (
 /obj/structure/fluff/railing/border/east,
 /turf/open/floor/rogue/twig,
@@ -10448,10 +10462,6 @@
 "St" = (
 /turf/closed/mineral/rogue/bedrock,
 /area/rogue/outdoors/woods/vampire_lair)
-"Su" = (
-/obj/structure/roguemachine/talkstatue/mercenary,
-/turf/closed/wall/mineral/rogue/wooddark/end/east,
-/area/rogue/indoors/banditcamp)
 "Sw" = (
 /obj/structure/fluff/railing/corner/north_east,
 /turf/open/floor/rogue/dirt,
@@ -11609,12 +11619,6 @@
 /area/rogue/indoors/banditcamp)
 "Xt" = (
 /turf/open/lava/acid,
-/area/rogue/outdoors/woods/wretch_lair)
-"Xu" = (
-/obj/structure/roguemachine/talkstatue/mercenary{
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/grass,
 /area/rogue/outdoors/woods/wretch_lair)
 "Xv" = (
 /obj/structure/stairs{
@@ -13652,7 +13656,7 @@ JQ
 wV
 dh
 rV
-bU
+GH
 rV
 Mh
 IW
@@ -30802,7 +30806,7 @@ Ev
 lB
 jh
 Gu
-Pl
+iz
 bK
 Zl
 Zl
@@ -31708,7 +31712,7 @@ Dq
 qW
 qW
 UM
-Xu
+qQ
 Ev
 Ev
 Ev
@@ -33877,7 +33881,7 @@ nk
 iL
 iL
 eE
-Su
+ED
 DR
 Ux
 yI
@@ -43301,7 +43305,7 @@ or
 or
 jA
 Uj
-rd
+fY
 Ue
 aF
 mU


### PR DESCRIPTION
## About The Pull Request

Makes some small tweaks to wretch_coast.dmm, affecting all antags that have a base there. (Compatible with Pilgrim--the maps are modular.)

Beyond a few minor things (like making the benches in the underground chapel not trap you and shifting some stuff around to not block you as much), the main additions and amenities are as follows:

- Mercenary stone by Vile Vheslie. This lets Wretches set their stone status at roundstart to get more gimmicks going with the bathmatron, as well as hire mercenaries/adventurers.

<img width="386" height="386" alt="image" src="https://github.com/user-attachments/assets/b20eb3be-07c0-4909-910f-bc083dd513bc" />


- Mercenary stone in the Bandit camp. This lets Bandits do fuckery with mercs/adventurers. I dunno. Why not?

<img width="373" height="373" alt="image" src="https://github.com/user-attachments/assets/7ce5b929-7aad-419c-b743-511df010c3ec" />

- Mercenary stone in front of the Vampire Lord's manor. Maybe you want to go hire some mercs to capture fresh blood. I don't know how this antag works so I have no idea if this breaks anything; I put it out in front of the manor by the old CASTIFICO/EXCIDIUM.


<img width="538" height="538" alt="image" src="https://github.com/user-attachments/assets/a84b4b5b-a496-44b5-8358-3f180fa8a3c0" />

- HERMES in the Vampire Lord's throne room by the chest of parchment, so that you can send foreboding letters to the Duke or whatever.

<img width="436" height="436" alt="image" src="https://github.com/user-attachments/assets/e4f963cb-b3a7-4033-b80f-8fdba6f629f4" />


- HERMES at the front door of the Vampire Lord's manor because the place is really big and you might not find the other one.

<img width="303" height="303" alt="image" src="https://github.com/user-attachments/assets/6b6bad36-f97e-4ae0-b870-948ffff41421" />


Also, as mentioned, the stupid chapel benches in the wretchbase basement now actually function and let you move north while on their tile.

## Testing Evidence

I booted dunworld up and spawned in as a wretch. Midway through typing this sentence I realized I hadn't tested the HERMES directory and realized it looked super immersion-breaking so I will fix that in a commit immediately.

## Why It's Good For The Game

As a Wretch I want to get more interaction with the baths, and I think there's no enormous downside to the mercenary stones placed in any of the bases.

Wretches get HERMES already, and I figure the VL should definitely be able to send mail, but I deliberately did not give a HERMES to the Bandits; their whole gimmick is robbing shit and getting it back home, so I imagine having a way to wirelessly send shit using magical zads is not good for the gamemode.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Wretchbase, Bandit base, and Vampire Lord manor all get Mercenary stones now. Godspeed and commission a merc to be evyl
add: Vampire Lord manor has HERMES spots now
fix: Wretchbase Zizo chapel benches no longer block you wrongly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
