### PR TITLE
loadout followup

### DIFF
--- a/code/modules/client/loadout_menu.dm
+++ b/code/modules/client/loadout_menu.dm
@@ -186,6 +186,8 @@
 			if(custom_name)
 				meta["custom_name"] = copytext(custom_name, 1, MAX_NAME_LEN)
 				meta["custom_name_parsed"] = parsemarkdown_basic(html_encode(meta["custom_name"]))
+				if(findtext(meta["custom_name_parsed"], "\\improper") == 1) // \improper at the start of a string - convert it to a byond macro
+					meta["custom_name_parsed"] = ("\improper"+copytext(meta["custom_name_parsed"], 10)) // this is useful for when you have lowercase text encased in markdown tags
 			else
 				meta -= "custom_name"
 				meta -= "custom_name_parsed"


### PR DESCRIPTION
## About The Pull Request
Allows adding `\improper` at the beginning of a loadout item name to make it improper, because colored names become proper by default. This basically just means you would never have "a" or "the" inserted before your item name even if it wasn't a proper noun, so now you can force it to be treated as an improper noun.

## Testing Evidence
<img width="349" height="103" alt="image" src="https://github.com/user-attachments/assets/2cba617b-16aa-40de-b191-0b5f3c26b095" />
<img width="291" height="83" alt="image" src="https://github.com/user-attachments/assets/0f2cd10b-e398-4c5e-abb3-01dcfa833c9a" />
<img width="512" height="246" alt="image" src="https://github.com/user-attachments/assets/70b4890b-a257-45bf-8210-ad21859064fd" />
Yes that should be "an" no there is no way to make it that, byond's text macros are VERY inflexible. It's a miracle i was able to achieve this much.

## Why It's Good For The Game
slightly less grammar breakage

## Changelog

:cl:
add: You can now preface a loadout item's name with \improper to make it an improper noun: i.e. it is treated like it starts with a lowercase letter. You will need to do this if your loadout item name has colors, as formatting characters make things proper nouns in byondland.
/:cl:

