### PR TITLE
[Heartbeast] hoarder obfuscation for heartbeast

### DIFF
--- a/code/modules/roguetown/roguemachine/heartbeast/heart_quirks/quirk_hoarder.dm
+++ b/code/modules/roguetown/roguemachine/heartbeast/heart_quirks/quirk_hoarder.dm
@@ -30,7 +30,8 @@
 		return
 
 	var/withdrawal_amount = calculate_withdrawal_amount(beast.language_tier)
-	var/success = SStreasury.withdraw_money_treasury(withdrawal_amount, beast.heart_beast)
+	var/thief_alias = pick("a bunch of tendrils in a longcoat", "a foreign monarch", "a greedy goblin", "a corrupt magistrate", "the tentacular menace", "the tendril of evil")
+	var/success = SStreasury.withdraw_money_treasury(withdrawal_amount, thief_alias)
 
 	if(success)
 		convert_mammon_to_coins(withdrawal_amount, beast)


### PR DESCRIPTION
## About The Pull Request
Hoarders will now make it slightly less obvious it's a weird basement beast draining the treasury. (and funnier!)

## Testing Evidence
<img width="840" height="80" alt="image" src="https://github.com/user-attachments/assets/2181da9a-33bc-4fe4-b1fb-4e15a9445ee8" />

## Why It's Good For The Game
Someone downstream mentioned how it's weird for the secret basement creature to make itself so obvious. And ye.

## Changelog

:cl:
add: Heartbeast hoarder withdrawal messages changed.
/:cl:
