### PR TITLE
Half-Plate is ARMOR_CLASS_HEAVY

### DIFF
--- a/code/modules/clothing/rogueclothes/armor/plate.dm
+++ b/code/modules/clothing/rogueclothes/armor/plate.dm
@@ -18,7 +18,7 @@
 	smeltresult = /obj/item/ingot/steel
 	equip_delay_self = 4 SECONDS
 	unequip_delay_self = 4 SECONDS
-	armor_class = ARMOR_CLASS_MEDIUM
+	armor_class = ARMOR_CLASS_HEAVY
 	smelt_bar_num = 3
 	chunkcolor = "#a9c1ca"
 	material_category = ARMOR_MAT_PLATE
@@ -37,7 +37,6 @@
 	item_state = "ihalfplate"
 	boobed = FALSE	//the armor just looks better with this, makes sense and is 8 sprites less
 	max_integrity = ARMOR_INT_CHEST_PLATE_IRON
-	armor_class = ARMOR_CLASS_MEDIUM
 	smeltresult = /obj/item/ingot/iron
 
 /obj/item/clothing/suit/roguetown/armor/plate/iron/bikini
@@ -47,7 +46,7 @@
 	icon_state = "ihalfplatekini"
 	item_state = "ihalfplatekini"
 	max_integrity = ARMOR_INT_CHEST_MEDIUM_IRON
-	armor_class = ARMOR_CLASS_MEDIUM
+	armor_class = ARMOR_CLASS_MEDIUM // This is a cuirass' durability
 	smelt_bar_num = 2
 
 /obj/item/clothing/suit/roguetown/armor/plate/iron/banded
@@ -286,7 +285,6 @@
 
 	max_integrity = ARMOR_INT_CHEST_PLATE_STEEL
 	body_parts_covered = CHEST | VITALS | LEGS // Less durability than proper plate, more expensive to manufacture, and accurate to the sprite.
-	armor_class = ARMOR_CLASS_MEDIUM
 
 // Heretic Graggar Plate
 /obj/item/clothing/suit/roguetown/armor/plate/fluted/graggar
@@ -883,7 +881,6 @@
 	allowed_sex = list(MALE, FEMALE)
 	anvilrepair = /datum/skill/craft/armorsmithing
 	smeltresult = /obj/item/ingot/steel
-	armor_class = ARMOR_CLASS_MEDIUM
 	smelt_bar_num = 3
 
 //Coats of Plates

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/deserter.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/deserter.dm
@@ -297,7 +297,6 @@
 		var/armors = list(
 			"Cuirass"			= /obj/item/clothing/suit/roguetown/armor/plate/cuirass,
 			"Brigandine"		= /obj/item/clothing/suit/roguetown/armor/brigandine,
-			"Half-Plate"		= /obj/item/clothing/suit/roguetown/armor/plate/iron,
 			"Scalemail"			= /obj/item/clothing/suit/roguetown/armor/plate/scale,
 		)
 		var/armorchoice = input(H, "Choose your armor.", "TAKE UP ARMOR") as anything in armors


### PR DESCRIPTION
## About The Pull Request

Most Half-Plate is ARMOR_CLASS_HEAVY

This does not include class specific equipment (Drow mercenary) or heretical armor (Zizo/Graggar medium plate).

## Testing Evidence

<img width="430" height="390" alt="image" src="https://github.com/user-attachments/assets/ff83b30b-1b40-4e77-8c4b-743a9565ea23" />


## Why It's Good For The Game

#8273 reduced the integrity range of light armor. Medium armor is quite often interchangeable with heavy armor though - and the main culprit is half-plate. The best of these items are cheaper than "heavy" armor, share the 500 durability, and in the case of items like fluted half-plate, cover almost as much.

I thought about doing something about fluted half-plate in particular, but I thought about it longer and **honestly what is the difference between medium and heavy armor?**

The answer is often just limb protection. Which is already not a very easy place to hit and generally lower priority for people to armor up. With even just a regular halfplate, hauberk, and chain legs, you're already Basically Just a Knight except your arms have 1 less layer. I don't know why you would go for someone's 3 arm layers when 2 of those are chest layers, though.

This is probably going to be very unpopular and I understand that but in the interest of pushing the divide between Light, Medium, and Heavy further so that there's less overlap, I think this' the better long-term solution than removing fluted half-plate specifically.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: All normal half-plate objects are ARMOR_CLASS_HEAVY
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
