### PR TITLE
Lich and Vampire Lord Title Revision

### DIFF
--- a/code/controllers/subsystem/communications.dm
+++ b/code/controllers/subsystem/communications.dm
@@ -20,15 +20,31 @@ SUBSYSTEM_DEF(communications)
 	if(is_silicon)
 		if(user.job)
 			var/used_title = user.get_role_title()
-			if(SSticker.regentmob == user)
-				used_title = "[used_title]" + " Regent"
+			if(SSticker.rulermob != user)
+				if(SSticker.regentmob == user)
+					if(user.mind?.has_antag_datum(/datum/antagonist/vampire/lord))
+						used_title = "Ancient Lord Regent"
+					else
+						used_title = "[used_title]" + " Regent"
+				else if(user.mind?.has_antag_datum(/datum/antagonist/lich))
+					used_title = "Lich"
+				else if(user.mind?.has_antag_datum(/datum/antagonist/vampire/lord))
+					used_title = "Ancient Lord"
 			priority_announce(html_decode(user.treat_message(input)), "The [used_title] Decrees", pick('sound/misc/royal_decree.ogg', 'sound/misc/royal_decree2.ogg'), sender = user)
 			silicon_message_cooldown = world.time + 5 SECONDS
 	else
 		if(user.job)
 			var/used_title = user.get_role_title()
-			if(SSticker.regentmob == user)
-				used_title = "[used_title]" + " Regent"
+			if(SSticker.rulermob != user)
+				if(SSticker.regentmob == user)
+					if(user.mind?.has_antag_datum(/datum/antagonist/vampire/lord))
+						used_title = "Ancient Lord Regent"
+					else
+						used_title = "[used_title]" + " Regent"
+				else if(user.mind?.has_antag_datum(/datum/antagonist/lich))
+					used_title = "Lich"
+				else if(user.mind?.has_antag_datum(/datum/antagonist/vampire/lord))
+					used_title = "Ancient Lord"
 			priority_announce(html_decode(user.treat_message(input)), "The [used_title] Speaks", 'sound/misc/bell.ogg', sender = user)
 			nonsilicon_message_cooldown = world.time + 5 SECONDS
 		else

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -782,8 +782,16 @@
 		var/used_title = get_role_title()
 		if(HAS_TRAIT(src, TRAIT_RESIDENT) && used_title == "Licker" && licker_subclass)
 			used_title = licker_subclass.name
-		if(SSticker.regentmob == src)
-			used_title = "[used_title]" + " Regent"
+		if(SSticker.rulermob != src)
+			if(SSticker.regentmob == src)
+				if(src.mind?.has_antag_datum(/datum/antagonist/vampire/lord))
+					used_title = "Ancient Lord Regent"
+				else
+					used_title = "[used_title] Regent"
+			else if(src.mind?.has_antag_datum(/datum/antagonist/lich))
+				used_title = "Lich"
+			else if(src.mind?.has_antag_datum(/datum/antagonist/vampire/lord))
+				used_title = "Ancient Lord"
 		var/display_as_wanderer = FALSE
 		if(observer_privilege)
 			used_name = real_name
@@ -795,6 +803,10 @@
 			var/datum/job/J = SSjob.GetJob(job)
 			if(!J || (J.wanderer_examine && !(HAS_TRAIT(src, TRAIT_RESIDENT))))
 				display_as_wanderer = TRUE
+		if(src.mind?.has_antag_datum(/datum/antagonist/lich))
+			display_as_wanderer = FALSE
+		if(src.mind?.has_antag_datum(/datum/antagonist/vampire/lord) && SSticker.rulermob != src && SSticker.regentmob != src)
+			display_as_wanderer = TRUE
 		var/displayed_headshot
 		var/datum/antagonist/vampire/vampireplayer = src.mind?.has_antag_datum(/datum/antagonist/vampire)
 		var/datum/antagonist/lich/lichplayer = src.mind?.has_antag_datum(/datum/antagonist/lich)

--- a/code/modules/roguetown/roguemachine/titan.dm
+++ b/code/modules/roguetown/roguemachine/titan.dm
@@ -449,7 +449,12 @@ GLOBAL_VAR_INIT(last_crown_announcement_time, -1000)
 	priority_announce("All of the land's prior decrees have been purged!", "DECREES PURGED", pick('sound/misc/royal_decree.ogg', 'sound/misc/royal_decree2.ogg'), "Captain")
 
 /proc/become_regent(mob/living/carbon/human/H)
-	priority_announce("[H.real_name], the [H.get_role_title()], sits as the regent of the realm.", "A New Regent Resides", pick('sound/misc/royal_decree.ogg', 'sound/misc/royal_decree2.ogg'), "Captain")
+	var/used_title = H.get_role_title()
+	if(H.mind?.has_antag_datum(/datum/antagonist/vampire/lord))
+		used_title = "Ancient Lord Regent"
+	else
+		used_title = "[used_title] Regent"
+	priority_announce("[H.real_name], the [used_title], sits as the regent of the realm.", "A New Regent Resides", pick('sound/misc/royal_decree.ogg', 'sound/misc/royal_decree2.ogg'), "Captain")
 	SSticker.regentmob = H
 	SSticker.regentday = GLOB.dayspassed
 


### PR DESCRIPTION
## About The Pull Request

A lil' changes to two major antagonists' titles based on an idea I accepted in #dev-general:

- The Lich's true title is known to all upon examination and when making announcements from the Throne of Azuria.

- The Vampire Lord's true title, now **"Ancient Lord"**, is completely obfuscated (ignores Residency) but is revealed when making announcements from the Throne of Azuria and upon examination when made a regent ("**Ancient Lord Regent**").

Their titles still appropriately change to any of the respective Rites of Usurpation titles when they usurp the throne, and this does not change the behavior of the other menus. (Known People, Orbit, View Actors, et cetera.)

## Testing Evidence

### <summary>Announcement:</summary>
<details>

- <img width="1084" height="688" alt="Ir2mLBFGjh" src="https://github.com/user-attachments/assets/706789b7-463c-4f3b-a42a-8cf30e7ce54c" />
- <img width="1083" height="876" alt="GprAPycJrU" src="https://github.com/user-attachments/assets/6a26822e-6fa8-4524-92e8-ead53668d1ce" />
</details>

### <summary> Regency & Usurpation:</summary>
_(The latter is unchanged.)_
<details>

- <img width="1089" height="1008" alt="ZTVEqAx2BR" src="https://github.com/user-attachments/assets/fc9de484-cfea-42db-b511-50703f586793" />
- <img width="1087" height="982" alt="jaEaT2dR6v" src="https://github.com/user-attachments/assets/5de6ecfd-1300-41cd-9f08-1e31003a256e" />
- <img width="1092" height="996" alt="2F9q9ZCQGO" src="https://github.com/user-attachments/assets/86eef124-289c-4014-a7a1-6c51a52aac9f" />
</details>

## Why It's Good For The Game

Going by the idea, which I agree with, the Lich is one of the more blatantly obvious humanoid major antagonists due to their equipment, their combat and arcane prowess, and their skeletal visage most of all like the other skeletons. Their arrogance and hubris call for all eyes upon them. 

The Vampire Lord has tells, but they aren't immediately obvious like the Lich's unless kept under careful scrutiny (their speed, strength, abilities/vitaemancy, and endurance under extreme injuries). They're subtler and "Ancient Lord" gives them a hook that could be met with disbelief or curiosity by those that learn of the title, if the Vampire Lord or throat happens to share it.

As for the throat itself, if they managed to claim the Crown of Azuria, reach the throne, and speak from it, whatever they have to say will obviously be of great import that the current system of the throat acknowledging their "title" doesn't do justice. A Lich or Vampire Lord shouldn't be called a "Homesteader" or "Sorcerer" in that scenario. The throat should acknowledge and proclaim to all their true title with their announcement.

It is the fault of the garrison, retinue, magicians, and _maaaybe_ clergy if either of these major antagonists manage to snatch the crown and reach the throne anyway.

## Changelog

:cl:Fi
balance: Revised the examination titles of the Lich and the Vampire Lord. The Lich's true title is always revealed unless masked, and the Vampire Lord's title is always obfuscated but is now "Ancient Lord" when revealed by the throat or regency ("Ancient Lord Regent").
/:cl: