### PR TITLE
Obsolutely Obfuscation

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -910,9 +910,9 @@ SUBSYSTEM_DEF(job)
 /datum/controller/subsystem/job/proc/JobDebug(message)
 	log_job_debug(message)
 
-/datum/controller/subsystem/job/proc/bitflag_to_department(department_flag, obsfuscated = FALSE)
+/datum/controller/subsystem/job/proc/bitflag_to_department(department_flag, obfuscated = FALSE)
 	var/key = "Wanderers"
-	if(obsfuscated)
+	if(obfuscated)
 		return key
 	switch(department_flag) // Omega tier slop.
 		if(NOBLEMEN)

--- a/code/game/objects/items/rogueitems/skillbooks.dm
+++ b/code/game/objects/items/rogueitems/skillbooks.dm
@@ -44,7 +44,7 @@
 		return
 	var/author_job = H.advjob ? H.advjob : "Adventurer"
 	var/datum/job/J = SSjob.GetJob(H.job)
-	if (J.obsfuscated_job || (J.wanderer_examine && !(HAS_TRAIT(H, TRAIT_RESIDENT))))
+	if (J.obfuscated_job || (J.wanderer_examine && !(HAS_TRAIT(H, TRAIT_RESIDENT))))
 		author_job = "Adventurer"
 	if(!(H.real_name in authors))
 		authors[H.real_name] = author_job

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -128,8 +128,8 @@
 	/// This job is immune to species-based swapped gender locks
 	var/immune_to_genderswap = FALSE
 
-	/// Jobs that are obsfuscated on actor screen
-	var/obsfuscated_job = FALSE
+	/// Jobs that are obfuscated on actor screen
+	var/obfuscated_job = FALSE
 
 	///Jobs that are hidden from actor screen
 	var/hidden_job = FALSE
@@ -341,7 +341,7 @@
 	if (!hidden_job)
 		var/mob_name = H.real_name
 		var/mob_rank
-		if (obsfuscated_job)
+		if (obfuscated_job)
 			mob_rank = "Adventurer"
 		else
 			mob_rank = H.mind.assigned_role

--- a/code/modules/jobs/job_types/roguetown/adventurer/assassin.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/assassin.dm
@@ -19,7 +19,7 @@
 	outfit = null
 	outfit_female = null
 
-	obsfuscated_job = TRUE
+	obfuscated_job = TRUE
 	give_bank_account = FALSE
 
 	display_order = JDO_ASSASSIN

--- a/code/modules/jobs/job_types/roguetown/adventurer/bandit.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/bandit.dm
@@ -12,7 +12,7 @@
 	outfit = null
 	outfit_female = null
 
-	obsfuscated_job = TRUE
+	obfuscated_job = TRUE
 
 	display_order = JDO_BANDIT
 	announce_latejoin = FALSE

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/gnoll.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/gnoll.dm
@@ -16,7 +16,7 @@
 	max_pq = null
 	allowed_patrons = list(/datum/patron/inhumen/graggar)
 
-	obsfuscated_job = TRUE
+	obfuscated_job = TRUE
 
 	advclass_cat_rolls = list(CTAG_GNOLL = 20)
 	PQ_boost_divider = 10

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hag.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hag.dm
@@ -16,7 +16,7 @@
 	min_pq = 50
 	max_pq = null
 
-	obsfuscated_job = TRUE
+	obfuscated_job = TRUE
 
 	advclass_cat_rolls = list(CTAG_HAG = 20)
 	PQ_boost_divider = 10

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/special/courtagent.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/special/courtagent.dm
@@ -13,7 +13,7 @@
 	always_show_on_latechoices = TRUE
 	show_in_credits = TRUE
 	advclass_cat_rolls = list(CTAG_COURTAGENT = 20)
-	obsfuscated_job = TRUE
+	obfuscated_job = TRUE
 	townie_contract_gate_exempt = TRUE
 	class_setup_examine = FALSE
 	has_subprefs = TRUE

--- a/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
@@ -15,7 +15,7 @@
 	min_pq = 10
 	max_pq = null
 
-	obsfuscated_job = TRUE
+	obfuscated_job = TRUE
 	class_categories = TRUE
 
 	advclass_cat_rolls = list(CTAG_WRETCH = 20)

--- a/code/modules/jobs/job_types/roguetown/other/vampire_guard.dm
+++ b/code/modules/jobs/job_types/roguetown/other/vampire_guard.dm
@@ -16,7 +16,7 @@
 	give_bank_account = FALSE
 	announce_latejoin = FALSE
 
-	obsfuscated_job = TRUE //future coders if you ever ADD an antag-job that's not supposed to be immedately obvious like lich skele, please add these. Otherwise the job title will show on examine + actors menu
+	obfuscated_job = TRUE //future coders if you ever ADD an antag-job that's not supposed to be immedately obvious like lich skele, please add these. Otherwise the job title will show on examine + actors menu
 	wanderer_examine = TRUE
 	advjob_examine = TRUE
 	cmode_music = 'sound/music/combat_weird.ogg'

--- a/code/modules/jobs/job_types/roguetown/other/vampire_servant.dm
+++ b/code/modules/jobs/job_types/roguetown/other/vampire_servant.dm
@@ -16,7 +16,7 @@
 	give_bank_account = FALSE
 	announce_latejoin = FALSE
 
-	obsfuscated_job = TRUE //future coders if you ever ADD an antag-job that's not supposed to be immedately obvious like lich skele, please add these. Otherwise the job title will show on examine + actors menu
+	obfuscated_job = TRUE //future coders if you ever ADD an antag-job that's not supposed to be immedately obvious like lich skele, please add these. Otherwise the job title will show on examine + actors menu
 	wanderer_examine = TRUE
 	advjob_examine = TRUE
 	cmode_music = 'sound/music/combat_weird.ogg'

--- a/code/modules/jobs/job_types/roguetown/other/vampire_spawn.dm
+++ b/code/modules/jobs/job_types/roguetown/other/vampire_spawn.dm
@@ -16,7 +16,7 @@
 	give_bank_account = FALSE
 	announce_latejoin = FALSE
 
-	obsfuscated_job = TRUE //future coders if you ever ADD an antag-job that's not supposed to be immedately obvious like lich skele, please add these. Otherwise the job title will show on examine + actors menu.
+	obfuscated_job = TRUE //future coders if you ever ADD an antag-job that's not supposed to be immedately obvious like lich skele, please add these. Otherwise the job title will show on examine + actors menu.
 	wanderer_examine = TRUE
 	advjob_examine = TRUE
 	cmode_music = 'sound/music/combat_weird.ogg'

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -1028,7 +1028,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	if(!J)
 		J = SSjob.GetJob(assigned_role)
 	if(J)
-		var/department = SSjob.bitflag_to_department(J.department_flag, J.obsfuscated_job)
+		var/department = SSjob.bitflag_to_department(J.department_flag, J.obfuscated_job)
 		var/list/department_colors = JCOLOR_BY_DEPARTMENT
 		if(department_colors[department])
 			resolved_color = department_colors[department]
@@ -1220,7 +1220,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 			entry["role"] = assigned_role
 			var/datum/job/J = SSjob.GetJob(assigned_role)
 			if(J)
-				var/job_department = SSjob.bitflag_to_department(J.department_flag, J.obsfuscated_job)
+				var/job_department = SSjob.bitflag_to_department(J.department_flag, J.obfuscated_job)
 				if(job_department)
 					entry["department"] = job_department
 			var/selection_color = get_role_selection_color(assigned_role, role_color_cache, J)


### PR DESCRIPTION
## About The Pull Request

Corrected a handful of misspellings of the word "obfuscated" in the code.

## Testing Evidence

Shouldn't really require testing when the misspellings now align with the correctly spelled word that make up the majority of the code.

## Why It's Good For The Game

This will prevent inconsistencies in the code later causing problems when more and more people see the incorrect spelling and assume it is the "correct" spelling, and it will make those keys easier to search instead of being omitted due to not being among the correct spelling of the word (which was the problem I experienced).

## Changelog

:cl:Fi
spellcheck: Corrected typos of the word "obfuscated" in the code.
/:cl: