### PR TITLE
let only discretion give the doborobe for zpellblade naginata

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/heretic_spellblade.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/heretic_spellblade.dm
@@ -206,7 +206,8 @@
 					backr = /obj/item/rogueweapon/shield/heater
 				if("Naginata")
 					r_hand = /obj/item/rogueweapon/spear/naginata
-					armor = /obj/item/clothing/suit/roguetown/armor/basiceast
+					if(armor_choice == "Discretion (Spellblade Disguise)")
+						armor = /obj/item/clothing/suit/roguetown/armor/basiceast
 			H.adjust_skillrank_up_to(/datum/skill/combat/polearms, SKILL_LEVEL_EXPERT, TRUE)
 		if("macebearer")
 			var/mace_weapons = list("Steel Mace", "Steel Warhammer", "Grand Mace", "Battle Axe", "Steel Greataxe")


### PR DESCRIPTION
## About The Pull Request

as it says on the tin

## Testing Evidence

no but it should be fine

## Why It's Good For The Game

selfish since im playing zpellblade but why does the medium armour option get a weaker light armour for just the naginata.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: confrontation zpellblade naginata gets the regular hauberk like everyone else.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
