### PR TITLE
Cosmetics coverage revamp

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -677,6 +677,9 @@ GLOBAL_LIST_EMPTY(species_list)
 	for(var/obj/item/thing as anything in equipped_items)
 		if (thing.flags_inv)
 			new_flags |= thing.flags_inv
+		for(var/obj/item/cosmetic in thing.contents)
+			if(cosmetic.flags_inv)
+				new_flags |= cosmetic.flags_inv
 
 	if(new_flags == obscured_flags)
 		return

--- a/code/datums/mob_descriptors/descriptors/other.dm
+++ b/code/datums/mob_descriptors/descriptors/other.dm
@@ -32,7 +32,7 @@
 		return FALSE
 	if(H.underwear)
 		return FALSE
-	if(!get_location_accessible(H, BODY_ZONE_PRECISE_GROIN))
+	if(!get_location_accessible(H, BODY_ZONE_PRECISE_GROIN, check_cosmetics = TRUE))
 		return FALSE
 	return TRUE
 
@@ -88,7 +88,7 @@
 		return FALSE
 	if(H.underwear)
 		return FALSE
-	if(!get_location_accessible(H, BODY_ZONE_PRECISE_GROIN))
+	if(!get_location_accessible(H, BODY_ZONE_PRECISE_GROIN, check_cosmetics = TRUE))
 		return FALSE
 	var/obj/item/organ/penis/penis = H.getorganslot(ORGAN_SLOT_PENIS)
 	if(penis && penis.sheath_type == SHEATH_TYPE_SLIT) //If our penis hides in a slit, dont describe testicles
@@ -123,7 +123,7 @@
 		return FALSE
 	if(H.underwear)
 		return FALSE
-	if(!get_location_accessible(H, BODY_ZONE_PRECISE_GROIN))
+	if(!get_location_accessible(H, BODY_ZONE_PRECISE_GROIN, check_cosmetics = TRUE))
 		return FALSE
 	return TRUE
 
@@ -171,7 +171,7 @@
 		return FALSE
 	if(H.underwear && H.underwear.covers_breasts)
 		return FALSE
-	if(!get_location_accessible(H, BODY_ZONE_CHEST))
+	if(!get_location_accessible(H, BODY_ZONE_CHEST, check_cosmetics = TRUE))
 		return FALSE
 	return TRUE
 

--- a/code/modules/surgery/surgery_helpers.dm
+++ b/code/modules/surgery/surgery_helpers.dm
@@ -107,7 +107,7 @@
 			to_chat(user, span_warning("I need to hold a [is_robotic ? "screwdriver" : "cautery"] in your inactive hand to stop [M]'s surgery!"))
 */
 
-/proc/get_location_accessible(mob/victim, location = BODY_ZONE_CHEST, grabs = FALSE, skipundies = TRUE)
+/proc/get_location_accessible(mob/victim, location = BODY_ZONE_CHEST, grabs = FALSE, skipundies = TRUE, check_cosmetics = FALSE)
 	var/covered_locations = NONE	//based on body_parts_covered
 	if(iscarbon(victim))
 		var/mob/living/carbon/carbon_victim = victim
@@ -118,6 +118,10 @@
 		for(var/obj/item/equipped_item in carbon_victim.get_equipped_items(include_pockets = FALSE, include_beltslots = FALSE))
 			if(zone2covered(location, equipped_item.body_parts_covered_dynamic) && equipped_item.surgery_cover)
 				return FALSE
+			if(check_cosmetics)
+				for(var/obj/item/cosmetic_item in equipped_item.contents)
+					if(zone2covered(location, cosmetic_item.body_parts_covered_dynamic) && cosmetic_item.surgery_cover)
+						return FALSE
 		if(ishuman(carbon_victim))
 			var/mob/living/carbon/human/human_victim = carbon_victim
 			if(!skipundies)


### PR DESCRIPTION
## About The Pull Request

Items in cosmetic slot now will cover private bodyparts and their descripitors even when actual worn item does not. Example - barbarian now can hide his/her chest behind dress despite having skin armor. Does not cover body from surgery, it's still can be performed based on actual armor coverage

## Testing Evidence

Tested on local, didnt find any issues 

## Why It's Good For The Game

Some classes have their chest completely exposed with no actual way to cover it aside of underwear, which is very limited in choice. Now you can hide your stuff properly and not be half-nudist all the time

## Changelog
:cl:
qol: Items in cosmetic clots properly cover your body now
/:cl: