### PR TITLE
(l)owercase - case-corrects most non-unique reagent names 

### DIFF
--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -4,7 +4,7 @@
 //////////////
 
 /datum/reagent/consumable/ethanol
-	name = "Ethanol"
+	name = "ethanol"
 	description = "A well-known alcohol with a variety of applications."
 	color = "#404030" // rgb: 64, 64, 48
 	nutriment_factor = 0

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -7,7 +7,7 @@
 /datum/reagent/consumable/acorn_powder
 	cuisine = CUISINE_NORTHERN
 	drink_type = DRINKTYPE_CAFFEINE
-	name = "Acorn Powder"
+	name = "acorn powder"
 	description = "A bitter fine powder."
 	color = "#dcb137"
 	quality = DRINK_VERYGOOD
@@ -20,7 +20,7 @@
 /datum/reagent/consumable/Acoffee
 	cuisine = CUISINE_NORTHERN
 	drink_type = DRINKTYPE_CAFFEINE
-	name = "Acorn Coffee"
+	name = "acorn coffee"
 	description = "A nice bitter stimulating brew"
 	color = "#800000"
 	quality = DRINK_VERYGOOD
@@ -83,7 +83,7 @@
 		container.reagents.del_reagent(/datum/reagent/water)
 
 /datum/reagent/consumable/milk
-	name = "Milk"
+	name = "milk"
 	description = "An opaque white liquid produced by the mammary glands of mammals."
 	color = "#DFDFDF" // rgb: 223, 223, 223
 	taste_description = "milk"

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -1,11 +1,11 @@
 /datum/reagent/drug
-	name = "Drug"
+	name = "drug"
 	metabolization_rate = 0.1
 	taste_description = "bitterness"
 	var/trippy = TRUE //Does this drug make you trip?
 
 /datum/reagent/drug/swampweed
-	name = "Swamp Oil"
+	name = "swampweed oil"
 	description = "The crushed or liquidated essence of the swampweed plant. Produces vivid hallucinations... and, some say, enhances the mentalisms."
 	color = "#388151" // rgb: 96, 165, 132
 	overdose_threshold = 30
@@ -62,7 +62,7 @@
 	..()
 
 /datum/reagent/drug/westleach
-	name = "Westleach Extract"
+	name = "extract of westleach"
 	description = "An extract of the westleach plant. Provides a stimulating effect pleasant to many."
 	reagent_state = LIQUID
 	color = "#d8e29e" // rgb: 96, 165, 132
@@ -94,7 +94,7 @@
 	. = 1
 
 /datum/reagent/drug/crank
-	name = "Crank"
+	name = "crank"
 	description = "Reduces stun times by about 200%. If overdosed or addicted it will deal significant Toxin, Brute and Brain damage."
 	reagent_state = LIQUID
 	color = "#FA00C8"
@@ -142,7 +142,7 @@
 	. = 1
 
 /datum/reagent/drug/methamphetamine
-	name = "Methamphetamine"
+	name = "methamphetamine"
 	description = "Reduces stun times by about 300%, speeds the user up, and allows the user to quickly recover stamina while dealing a small amount of Brain damage. If overdosed the subject will move randomly, laugh randomly, drop items and suffer from Toxin and Brain damage. If addicted the subject will constantly jitter and drool, before becoming dizzy and losing motor control and eventually suffer heavy toxin damage."
 	reagent_state = LIQUID
 	color = "#FAFAFA"
@@ -226,7 +226,7 @@
 	. = 1
 
 /datum/reagent/drug/aranesp
-	name = "Aranesp"
+	name = "aranesp"
 	description = "Amps you up, gets you going, and rapidly restores stamina damage. Side effects include breathlessness and toxicity."
 	reagent_state = LIQUID
 	color = "#78FFF0"
@@ -244,7 +244,7 @@
 	. = 1
 
 /datum/reagent/drug/happiness
-	name = "Happiness"
+	name = "happiness"
 	description = "Fills you with ecstasic numbness and causes minor brain damage. Highly addictive. If overdosed causes sudden mood swings."
 	reagent_state = LIQUID
 	color = "#FFF378"
@@ -308,7 +308,7 @@
 	. = 1
 
 /datum/reagent/drug/mentha // distinct from SS13 menthol, for the mentha zigs
-	name = "Mentha"
+	name = "extract of mentha"
 	description = "Extract from the mentha herb. Produces a cooling sensation."
 	reagent_state = LIQUID
 	color = "#3eb489"
@@ -337,7 +337,7 @@
 	. = 1
 
 /datum/reagent/drug/blackberry
-	name = "Blackberry"
+	name = "extract of blackberry"
 	description = "Extract from the blackberry. Produces a sweet-tart sensation."
 	reagent_state = LIQUID
 	color = "#4D0135"
@@ -366,7 +366,7 @@
 	. = 1
 
 /datum/reagent/drug/apple
-	name = "Apple"
+	name = "extract of apple"
 	description = "Extract from the apple. Produces both a sour and cooling sensation."
 	reagent_state = LIQUID
 	color = "#AF4D43"
@@ -395,7 +395,7 @@
 	. = 1
 
 /datum/reagent/drug/chocolate
-	name = "Chocolate"
+	name = "extract of chocolate"
 	description = "Extract from chocolate, often packed into a zig. Tastes like a bag of coins."
 	reagent_state = LIQUID
 	color = "#7B3F00"
@@ -424,7 +424,7 @@
 	. = 1
 
 /datum/reagent/drug/strawberry
-	name = "Strawberry"
+	name = "extract of strawberry"
 	description = "Extract from the strawberry. Produces a sourness and coolness sensation."
 	reagent_state = LIQUID
 	color = "#FC5A8D"
@@ -453,7 +453,7 @@
 	. = 1
 
 /datum/reagent/drug/carrot
-	name = "Carrot"
+	name = "extract of carrot"
 	description = "Extract from the carrot. Tastes... carroty..."
 	reagent_state = LIQUID
 	color = "#ED9121"
@@ -482,7 +482,7 @@
 	. = 1
 
 /datum/reagent/drug/lime
-	name = "Lime"
+	name = "extract of lime"
 	description = "Extract from the lime. Produces a sour and cool sensation."
 	reagent_state = LIQUID
 	color = "#BFFF00"
@@ -511,7 +511,7 @@
 	. = 1
 
 /datum/reagent/drug/salvia
-	name = "Salvia"
+	name = "extract of salvia"
 	description = "Extract from the salvia. Produces a spicy, earthy and bitter sensation."
 	reagent_state = LIQUID
 	color = "#FF33FF"
@@ -540,7 +540,7 @@
 	. = 1
 
 /datum/reagent/drug/valeriana
-	name = "Valeriana"
+	name = "extract of valeriana"
 	description = "Extract from the valeriana. Often used for aiding in slumber."
 	reagent_state = LIQUID
 	color = "#4a3c5f"
@@ -570,7 +570,7 @@
 	. = 1
 
 /datum/reagent/drug/calendula
-	name = "Calendula"
+	name = "extract of calendula"
 	description = "Extract from the calendula. Produces a bitter-spicy and tart sensation."
 	reagent_state = LIQUID
 	color = "#a57006"
@@ -605,7 +605,7 @@
 	. = 1
 
 /datum/reagent/drug/petun
-	name = "Petun"
+	name = "extract of petun"
 	description = "A highly concentrated form of nicotine. Produces a sore throat alongside a feeling of relaxation."
 	reagent_state = LIQUID
 	color = "#7ed9ad"
@@ -640,7 +640,7 @@
 	. = 1
 
 /datum/reagent/drug/jacksberries
-	name = "Jacksberries Essence"
+	name = "extract of jacksberries"
 	description = "Extract from the jacksberries. Produces a sore throat as well as mild relaxation."
 	reagent_state = LIQUID
 	color = "#57628C"
@@ -669,7 +669,7 @@
 	. = 1
 
 /datum/reagent/drug/abyss
-	name = "Abyssorick Jacksberries Essence"
+	name = "extract of abyssorick jacksberries"
 	description = "An odd form of narcotic found in abyssoric zigarettes. Perhaps the salt, or the fish, causes it to be so \
 	strange? Produces vivid hallucinations."
 	reagent_state = LIQUID

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -8,7 +8,7 @@
 
 
 /datum/reagent/consumable
-	name = "Consumable"
+	name = "consumable"
 	taste_description = "generic food"
 	taste_mult = 4
 	metabolization_rate = REAGENTS_METABOLISM
@@ -36,7 +36,7 @@
 	return ..()
 
 /datum/reagent/consumable/nutriment
-	name = "Nutriment"
+	name = "nutriment"
 	description = "All the vitamins, minerals, and carbohydrates the body needs in pure form."
 	reagent_state = SOLID
 	nutriment_factor = BASE_NUTRIMENT_NUTRITION //EVERY 1 NUTRIMENT RESTORES 35 NUTRITION
@@ -86,7 +86,7 @@
 	data = taste_amounts
 
 /datum/reagent/consumable/nutriment/vitamin
-	name = "Vitamin"
+	name = "vitamin"
 	description = "All the best vitamins, minerals, and carbohydrates the body needs in pure form."
 
 	brute_heal = 1
@@ -98,7 +98,7 @@
 	. = ..()
 
 /datum/reagent/consumable/sugar
-	name = "Sugar"
+	name = "sugar"
 	description = "The organic compound commonly known as table sugar and sometimes called saccharose. This white, odorless, crystalline powder has a pleasing, sweet taste."
 	reagent_state = SOLID
 	color = "#FFFFFF" // rgb: 255, 255, 255
@@ -119,11 +119,11 @@
 	. = 1
 
 /datum/reagent/consumable/sugar/molasses
-	name = "Molasses"
+	name = "molasses"
 	color = "#835c5c"
 
 /datum/reagent/consumable/sodiumchloride
-	name = "Table Salt"
+	name = "table salt"
 	description = "A salt made of sodium chloride. Commonly used to season food."
 	reagent_state = SOLID
 	color = "#FFFFFF" // rgb: 255,255,255
@@ -137,21 +137,21 @@
 	new/obj/effect/decal/cleanable/food/salt(T)
 
 /datum/reagent/consumable/blackpepper
-	name = "Black Pepper"
+	name = "black pepper"
 	description = "A powder ground from peppercorns. *AAAACHOOO*"
 	reagent_state = SOLID
 	// no color (ie, black)
 	taste_description = "pepper"
 
 /datum/reagent/consumable/allspice
-	name = "Allspice"
+	name = "allspice"
 	description = "A blend of various spices, used to liven food and stew."
 	reagent_state = SOLID
 	color = "#CE8C33"
 	taste_description = "a myriad of fragrant spices"
 
 /datum/reagent/drug/mushroomhallucinogen
-	name = "Mushroom Hallucinogen"
+	name = "mushroom hallucinogen"
 	description = "A strong hallucinogenic drug derived from certain species of mushroom."
 	color = "#E700E7" // rgb: 231, 0, 231
 	metabolization_rate = 0.2 * REAGENTS_METABOLISM
@@ -181,14 +181,14 @@
 	..()
 
 /datum/reagent/consumable/eggyolk
-	name = "Egg Yolk"
+	name = "egg yolk"
 	description = "It's full of protein."
 	nutriment_factor = 3 * REAGENTS_METABOLISM
 	color = "#FFB500"
 	taste_description = "egg"
 
 /datum/reagent/consumable/honey
-	name = "Honey"
+	name = "honey"
 	description = "Sweet sweet honey that decays into sugar. Has antibacterial and natural healing properties."
 	color = "#d3a308"
 	nutriment_factor = 15 * REAGENTS_METABOLISM
@@ -205,7 +205,7 @@
 	..()
 
 /datum/reagent/consumable/oil/tallow
-	name = "Tallow"
+	name = "tallow"
 	description = "Oil made from rendering animal fat. Used for deep frying."
 	nutriment_factor = 20
 	color = "#A6987B" // rgb: 48, 32, 0

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -5,7 +5,7 @@
 // where all the reagents related to medicine go.
 
 /datum/reagent/medicine
-	name = "Medicine"
+	name = "medicine"
 	taste_description = "bitterness"
 
 /datum/reagent/medicine/on_mob_life(mob/living/carbon/M)
@@ -13,7 +13,7 @@
 	. = ..()
 
 /datum/reagent/medicine/salglu_solution
-	name = "Saline-Glucose Solution"
+	name = "saline-glucose solution"
 	description = "Has a 33% chance per metabolism cycle to heal brute and burn damage. Can be used as a temporary blood substitute."
 	reagent_state = LIQUID
 	color = "#DCDCDC"

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1,6 +1,6 @@
 /datum/reagent/blood
 	data = list("donor"=null,"blood_DNA"=null,"blood_type"=null,"resistances"=null,"trace_chem"=null,"mind"=null,"ckey"=null,"gender"=null,"real_name"=null,"cloneable"=null,"factions"=null,"quirks"=null)
-	name = "Blood"
+	name = "blood"
 	color = BLOOD_COLOR_RED
 	metabolization_rate = 5 //fast rate so it disappears fast.
 	taste_description = "iron"
@@ -11,7 +11,7 @@
 	shot_glass_icon_state = "shotglassred"
 
 /datum/reagent/blood/shitty
-	name = "Dirty blood"
+	name = "dirty blood"
 	color = "#941010" // rgb: 148, 16, 16
 	taste_description = "rancid iron"
 	taste_mult = 1.5
@@ -86,14 +86,14 @@
 	color = "#05af01"
 
 /datum/reagent/liquidgibs // Editor's note: what the fuck
-	name = "Liquid gibs"
+	name = "liquid gibs"
 	color = "#CC4633"
 	description = "You don't even want to think about what's in here."
 	taste_description = "gross iron"
 	shot_glass_icon_state = "shotglassred"
 
 /datum/reagent/water
-	name = "Water"
+	name = "water"
 	description = "An ubiquitous chemical substance that is composed of hydrogen and oxygen."
 	color = "#6a9295"
 	taste_description = "water"
@@ -297,7 +297,7 @@
 	..()
 
 /datum/reagent/water/holywater
-	name = "Holy Water"
+	name = "holy water"
 	description = "Water blessed by some deity."
 	color = "#E0E8EF" // rgb: 224, 232, 239
 	glass_icon_state	= "glass_clear"
@@ -341,7 +341,7 @@
 	T.Bless()
 
 /datum/reagent/hydrogen_peroxide
-	name = "Hydrogen peroxide"
+	name = "hydrogen peroxide"
 	description = "An ubiquitous chemical substance that is composed of hydrogen and oxygen and oxygen." //intended intended
 	color = "#AAAAAA77" // rgb: 170, 170, 170, 77 (alpha)
 	taste_description = "burning water"
@@ -372,7 +372,7 @@
 	..()
 
 /datum/reagent/fuel/unholywater		//if you somehow managed to extract this from someone, dont splash it on myself and have a smoke
-	name = "Unholy Water"
+	name = "unholy water"
 	description = "Something that shouldn't exist on this plane of existence."
 	taste_description = "suffering"
 
@@ -392,7 +392,7 @@
 	return TRUE
 
 /datum/reagent/hellwater			//if someone has this in their system they've really pissed off an eldrich god
-	name = "Hell Water"
+	name = "hell water"
 	description = "YOUR FLESH! IT BURNS!"
 	taste_description = "burning"
 
@@ -405,13 +405,13 @@
 	holder.remove_reagent(type, 1)
 
 /datum/reagent/medicine/omnizine/godblood
-	name = "Godblood"
+	name = "godblood"
 	description = "Slowly heals all damage types. Has a rather high overdose threshold. Glows with mysterious power."
 	overdose_threshold = 150
 
 ///Used for clownery
 /datum/reagent/lube
-	name = "Space Lube"
+	name = "space lube"
 	description = "Lubricant is a substance introduced between two moving surfaces to reduce the friction and wear between them. giggity."
 	color = "#009CA8" // rgb: 0, 156, 168
 	taste_description = "cherry" // by popular demand
@@ -425,12 +425,12 @@
 
 ///Stronger kind of lube. Applies TURF_WET_SUPERLUBE.
 /datum/reagent/lube/superlube
-	name = "Super Duper Lube"
+	name = "super duper lube"
 	description = "This \[REDACTED\] has been outlawed after the incident on \[DATA EXPUNGED\]."
 	lube_kind = TURF_WET_SUPERLUBE
 
 /datum/reagent/spraytan
-	name = "Spray Tan"
+	name = "spray tan"
 	description = "A substance applied to the skin to darken the skin."
 	color = "#FFC080" // rgb: 255, 196, 128	Bright orange
 	metabolization_rate = 10 * REAGENTS_METABOLISM // very fast, so it can be applied rapidly.	But this changes on an overdose
@@ -529,7 +529,7 @@
 #define MUT_MSG_ABOUT2TURN 3
 
 /datum/reagent/mutationtoxin
-	name = "Stable Mutation Toxin"
+	name = "stable mutation toxin"
 	description = "A humanizing toxin."
 	color = "#5EFF3B" //RGB: 94, 255, 59
 	metabolization_rate = 0.2 //metabolizes to prevent micro-dosage
@@ -591,7 +591,7 @@
 	randomize_human(H)
 
 /datum/reagent/serotrotium
-	name = "Serotrotium"
+	name = "serotrotium"
 	description = "A chemical compound that promotes concentrated production of the serotonin neurotransmitter in humans."
 	color = "#202040" // rgb: 20, 20, 40
 	metabolization_rate = 0.25 * REAGENTS_METABOLISM
@@ -604,42 +604,42 @@
 	..()
 
 /datum/reagent/oxygen
-	name = "Oxygen"
+	name = "oxygen"
 	description = "A colorless, odorless gas. Grows on trees but is still pretty valuable."
 	reagent_state = GAS
 	color = "#808080" // rgb: 128, 128, 128
 	taste_mult = 0 // oderless and tasteless
 
 /datum/reagent/copper
-	name = "Copper"
+	name = "copper"
 	description = "A highly ductile metal. Things made out of copper aren't very durable, but it makes a decent material for electrical wiring."
 	reagent_state = SOLID
 	color = "#6E3B08" // rgb: 110, 59, 8
 	taste_description = "metal"
 
 /datum/reagent/nitrogen
-	name = "Nitrogen"
+	name = "nitrogen"
 	description = "A colorless, odorless, tasteless gas. A simple asphyxiant that can silently displace vital oxygen."
 	reagent_state = GAS
 	color = "#808080" // rgb: 128, 128, 128
 	taste_mult = 0
 
 /datum/reagent/hydrogen
-	name = "Hydrogen"
+	name = "hydrogen"
 	description = "A colorless, odorless, nonmetallic, tasteless, highly combustible diatomic gas."
 	reagent_state = GAS
 	color = "#808080" // rgb: 128, 128, 128
 	taste_mult = 0
 
 /datum/reagent/potassium
-	name = "Potassium"
+	name = "potassium"
 	description = "A soft, low-melting solid that can easily be cut with a knife. Reacts violently with water."
 	reagent_state = SOLID
 	color = "#A0A0A0" // rgb: 160, 160, 160
 	taste_description = "sweetness"
 
 /datum/reagent/mercury
-	name = "Mercury"
+	name = "mercury"
 	description = "A curious metal that's a liquid at room temperature. Neurodegenerative and very bad for the mind."
 	color = "#484848" // rgb: 72, 72, 72A
 	taste_mult = 0 // apparently tasteless.
@@ -653,14 +653,14 @@
 	..()
 
 /datum/reagent/sulfur
-	name = "Sulfur"
+	name = "sulfur"
 	description = "A sickly yellow solid mostly known for its nasty smell. It's actually much more helpful than it looks in biochemisty."
 	reagent_state = SOLID
 	color = "#BF8C00" // rgb: 191, 140, 0
 	taste_description = "rotten eggs"
 
 /datum/reagent/carbon
-	name = "Carbon"
+	name = "carbon"
 	description = "A crumbly black solid that, while unexciting on a physical level, forms the base of all known life. Kind of a big deal."
 	reagent_state = SOLID
 	color = "#1C1300" // rgb: 30, 20, 0
@@ -672,7 +672,7 @@
 		new /obj/effect/decal/cleanable/dirt(T)
 
 /datum/reagent/chlorine
-	name = "Chlorine"
+	name = "chlorine"
 	description = "A pale yellow gas that's well known as an oxidizer. While it forms many harmless molecules in its elemental form it is far from harmless."
 	reagent_state = GAS
 	color = "#FFFB89" //pale yellow? let's make it light gray
@@ -684,7 +684,7 @@
 	..()
 
 /datum/reagent/fluorine
-	name = "Fluorine"
+	name = "fluorine"
 	description = "A comically-reactive chemical element. The universe does not want this stuff to exist in this form in the slightest."
 	reagent_state = GAS
 	color = "#808080" // rgb: 128, 128, 128
@@ -696,21 +696,21 @@
 	..()
 
 /datum/reagent/sodium
-	name = "Sodium"
+	name = "sodium"
 	description = "A soft silver metal that can easily be cut with a knife. It's not salt just yet, so refrain from putting in on my chips."
 	reagent_state = SOLID
 	color = "#808080" // rgb: 128, 128, 128
 	taste_description = "salty metal"
 
 /datum/reagent/phosphorus
-	name = "Phosphorus"
+	name = "phosphorus"
 	description = "A ruddy red powder that burns readily. Though it comes in many colors, the general theme is always the same."
 	reagent_state = SOLID
 	color = "#832828" // rgb: 131, 40, 40
 	taste_description = "vinegar"
 
 /datum/reagent/lithium
-	name = "Lithium"
+	name = "lithium"
 	description = "A silver metal, its claim to fame is its remarkably low density. Using it is a bit too effective in calming oneself down."
 	reagent_state = SOLID
 	color = "#808080" // rgb: 128, 128, 128
@@ -724,19 +724,19 @@
 	..()
 
 /datum/reagent/glycerol
-	name = "Glycerol"
+	name = "glycerol"
 	description = "Glycerol is a simple polyol compound. Glycerol is sweet-tasting and of low toxicity."
 	color = "#D3B913"
 	taste_description = "sweetness"
 
 /datum/reagent/space_cleaner/sterilizine
-	name = "Sterilizine"
+	name = "sterilizine"
 	description = "Sterilizes wounds in preparation for surgery."
 	color = "#D0EFEE" // space cleaner but lighter
 	taste_description = "bitterness"
 
 /datum/reagent/iron
-	name = "Iron"
+	name = "iron"
 	description = "Pure iron is a metal."
 	reagent_state = SOLID
 	taste_description = "iron"
@@ -749,21 +749,21 @@
 	..()
 
 /datum/reagent/gold
-	name = "Gold"
+	name = "gold"
 	description = "Gold is a dense, soft, shiny metal and the most malleable and ductile metal known."
 	reagent_state = SOLID
 	color = "#F7C430" // rgb: 247, 196, 48
 	taste_description = "expensive metal"
 
 /datum/reagent/silver
-	name = "Silver"
+	name = "silver"
 	description = "A soft, white, lustrous transition metal, it has the highest electrical conductivity of any element and the highest thermal conductivity of any metal."
 	reagent_state = SOLID
 	color = "#D0D0D0" // rgb: 208, 208, 208
 	taste_description = "expensive yet reasonable metal"
 
 /datum/reagent/uranium
-	name ="Uranium"
+	name ="uranium"
 	description = "A jade-green metallic chemical element in the actinide series, weakly radioactive."
 	reagent_state = SOLID
 	color = "#5E9964" //this used to be silver, but liquid uranium can still be green and it's more easily noticeable as uranium like this so why bother?
@@ -777,14 +777,14 @@
 		GG.reagents.add_reagent(type, reac_volume)
 
 /datum/reagent/uranium/radium
-	name = "Radium"
+	name = "radium"
 	description = "Radium is an alkaline earth metal. It is extremely radioactive."
 	reagent_state = SOLID
 	color = "#00CC00" // ditto
 	taste_description = "the colour blue and regret"
 
 /datum/reagent/bluespace
-	name = "Bluespace Dust"
+	name = "bluespace dust"
 	description = "A dust composed of microscopic bluespace crystals, with minor space-warping properties."
 	reagent_state = SOLID
 	color = "#0000CC"
@@ -807,21 +807,21 @@
 	do_teleport(src, get_turf(src), 5, asoundin = 'sound/blank.ogg', channel = TELEPORT_CHANNEL_BLUESPACE)
 
 /datum/reagent/aluminium
-	name = "Aluminium"
+	name = "aluminium"
 	description = "A silvery white and ductile member of the boron group of chemical elements."
 	reagent_state = SOLID
 	color = "#A8A8A8" // rgb: 168, 168, 168
 	taste_description = "metal"
 
 /datum/reagent/silicon
-	name = "Silicon"
+	name = "silicon"
 	description = "A tetravalent metalloid, silicon is less reactive than its chemical analog carbon."
 	reagent_state = SOLID
 	color = "#A8A8A8" // rgb: 168, 168, 168
 	taste_mult = 0
 
 /datum/reagent/fuel
-	name = "Welding fuel"
+	name = "welding fuel"
 	description = "Required for welders. Flammable."
 	color = "#660000" // rgb: 102, 0, 0
 	taste_description = "gross metal"
@@ -841,7 +841,7 @@
 	return TRUE
 
 /datum/reagent/space_cleaner
-	name = "Space cleaner"
+	name = "space cleaner"
 	description = "A compound used to clean things. Now with 50% more sodium hypochlorite!"
 	color = "#A5F0EE" // rgb: 165, 240, 238
 	taste_description = "sourness"
@@ -912,7 +912,7 @@
 		M.adjustFireLoss(1.5)
 
 /datum/reagent/cryptobiolin
-	name = "Cryptobiolin"
+	name = "cryptobiolin"
 	description = "Cryptobiolin causes confusion and dizziness."
 	color = "#ADB5DB" //i hate default violets and 'crypto' keeps making me think of cryo so it's light blue now
 	metabolization_rate = 1.5 * REAGENTS_METABOLISM
@@ -926,7 +926,7 @@
 	..()
 
 /datum/reagent/impedrezene
-	name = "Impedrezene"
+	name = "impedrezene"
 	description = "Impedrezene is a narcotic that impedes one's ability by slowing down the higher brain cell functions."
 	color = "#E07DDD" // pink = happy = dumb
 	taste_description = "numbness"
@@ -942,47 +942,47 @@
 	..()
 
 /datum/reagent/fluorosurfactant//foam precursor
-	name = "Fluorosurfactant"
+	name = "fluorosurfactant"
 	description = "A perfluoronated sulfonic acid that forms a foam when mixed with water."
 	color = "#9E6B38" // rgb: 158, 107, 56
 	taste_description = "metal"
 
 /datum/reagent/foaming_agent// Metal foaming agent. This is lithium hydride. Add other recipes (e.g. LiH + H2O -> LiOH + H2) eventually.
-	name = "Foaming agent"
+	name = "foaming agent"
 	description = "An agent that yields metallic foam when mixed with light metal and a strong acid."
 	reagent_state = SOLID
 	color = "#664B63" // rgb: 102, 75, 99
 	taste_description = "metal"
 
 /datum/reagent/smart_foaming_agent //Smart foaming agent. Functions similarly to metal foam, but conforms to walls.
-	name = "Smart foaming agent"
+	name = "smart foaming agent"
 	description = "An agent that yields metallic foam which conforms to area boundaries when mixed with light metal and a strong acid."
 	reagent_state = SOLID
 	color = "#664B63" // rgb: 102, 75, 99
 	taste_description = "metal"
 
 /datum/reagent/ammonia
-	name = "Ammonia"
+	name = "ammonia"
 	description = "A caustic substance commonly used in fertilizer or household cleaners."
 	reagent_state = GAS
 	color = "#404030" // rgb: 64, 64, 48
 	taste_description = "mordant"
 
 /datum/reagent/diethylamine
-	name = "Diethylamine"
+	name = "diethylamine"
 	description = "A secondary amine, mildly corrosive."
 	color = "#604030" // rgb: 96, 64, 48
 	taste_description = "iron"
 
 /datum/reagent/carbondioxide
-	name = "Carbon Dioxide"
+	name = "carbon dioxide"
 	reagent_state = GAS
 	description = "A gas commonly produced by burning carbon fuels. You're constantly producing this in my lungs."
 	color = "#B0B0B0" // rgb : 192, 192, 192
 	taste_description = "something unknowable"
 
 /datum/reagent/nitrous_oxide
-	name = "Nitrous Oxide"
+	name = "nitrous oxide"
 	description = "A potent oxidizer used as fuel in rockets and as an anaesthetic during surgery."
 	reagent_state = LIQUID
 	metabolization_rate = 1.5 * REAGENTS_METABOLISM
@@ -1004,7 +1004,7 @@
 	..()
 
 /datum/reagent/stimulum
-	name = "Stimulum"
+	name = "stimulum"
 	description = "An unstable experimental gas that greatly increases the energy of those that inhale it, while dealing increasing toxin damage over time."
 	reagent_state = GAS
 	metabolization_rate = REAGENTS_METABOLISM * 0.5 // Because stimulum/nitryl are handled through gas breathing, metabolism must be lower for breathcode to keep up
@@ -1027,7 +1027,7 @@
 	..()
 
 /datum/reagent/nitryl
-	name = "Nitryl"
+	name = "nitryl"
 	description = "A highly reactive gas that makes you feel faster."
 	reagent_state = GAS
 	metabolization_rate = REAGENTS_METABOLISM * 0.5 // Because stimulum/nitryl are handled through gas breathing, metabolism must be lower for breathcode to keep up
@@ -1046,7 +1046,7 @@
 //For colouring in /proc/mix_color_from_reagents
 
 /datum/reagent/colorful_reagent/powder
-	name = "Mundane Powder" //the name's a bit similar to the name of colorful reagent, but hey, they're practically the same chem anyway
+	name = "mundane powder" //the name's a bit similar to the name of colorful reagent, but hey, they're practically the same chem anyway
 	var/colorname = "none"
 	description = "A powder that is used for coloring things."
 	reagent_state = SOLID
@@ -1062,55 +1062,55 @@
 		description = "\An [colorname] powder, used for coloring things [colorname]."
 
 /datum/reagent/colorful_reagent/powder/red
-	name = "Red Powder"
+	name = "red powder"
 	colorname = "red"
 	color = "#DA0000" // red
 	random_color_list = list("#FC7474")
 
 /datum/reagent/colorful_reagent/powder/orange
-	name = "Orange Powder"
+	name = "orange powder"
 	colorname = "orange"
 	color = "#FF9300" // orange
 	random_color_list = list("#FF9300")
 
 /datum/reagent/colorful_reagent/powder/yellow
-	name = "Yellow Powder"
+	name = "yellow powder"
 	colorname = "yellow"
 	color = "#FFF200" // yellow
 	random_color_list = list("#FFF200")
 
 /datum/reagent/colorful_reagent/powder/green
-	name = "Green Powder"
+	name = "green powder"
 	colorname = "green"
 	color = "#A8E61D" // green
 	random_color_list = list("#A8E61D")
 
 /datum/reagent/colorful_reagent/powder/blue
-	name = "Blue Powder"
+	name = "blue powder"
 	colorname = "blue"
 	color = "#00B7EF" // blue
 	random_color_list = list("#71CAE5")
 
 /datum/reagent/colorful_reagent/powder/purple
-	name = "Purple Powder"
+	name = "purple powder"
 	colorname = "purple"
 	color = "#DA00FF" // purple
 	random_color_list = list("#BD8FC4")
 
 /datum/reagent/colorful_reagent/powder/invisible
-	name = "Invisible Powder"
+	name = "invisible powder"
 	colorname = "invisible"
 	color = "#FFFFFF00" // white + no alpha
 	random_color_list = list(null)	//because using the powder color turns things invisible
 
 /datum/reagent/colorful_reagent/powder/black
-	name = "Black Powder"
+	name = "black powder"
 	colorname = "black"
 	color = "#1C1C1C" // not quite black
 	random_color_list = list("#8D8D8D")	//more grey than black, not enough to hide my true colors
 
 /datum/reagent/colorful_reagent/powder/white
-	name = "White Powder"
+	name = "white powder"
 	colorname = "white"
 	color = "#FFFFFF" // white
 	random_color_list = list("#FFFFFF") //doesn't actually change appearance at all
@@ -1118,43 +1118,43 @@
 // used by crayons, can't color living things but still used for stuff like food recipes
 
 /datum/reagent/colorful_reagent/powder/red/crayon
-	name = "Red Crayon Powder"
+	name = "red crayon powder"
 	can_colour_mobs = FALSE
 
 /datum/reagent/colorful_reagent/powder/orange/crayon
-	name = "Orange Crayon Powder"
+	name = "orange crayon powder"
 	can_colour_mobs = FALSE
 
 /datum/reagent/colorful_reagent/powder/yellow/crayon
-	name = "Yellow Crayon Powder"
+	name = "yellow crayon powder"
 	can_colour_mobs = FALSE
 
 /datum/reagent/colorful_reagent/powder/green/crayon
-	name = "Green Crayon Powder"
+	name = "green crayon powder"
 	can_colour_mobs = FALSE
 
 /datum/reagent/colorful_reagent/powder/blue/crayon
-	name = "Blue Crayon Powder"
+	name = "blue crayon powder"
 	can_colour_mobs = FALSE
 
 /datum/reagent/colorful_reagent/powder/purple/crayon
-	name = "Purple Crayon Powder"
+	name = "purple crayon powder"
 	can_colour_mobs = FALSE
 
 //datum/reagent/colorful_reagent/powder/invisible/crayon
 
 /datum/reagent/colorful_reagent/powder/black/crayon
-	name = "Black Crayon Powder"
+	name = "black crayon powder"
 	can_colour_mobs = FALSE
 
 /datum/reagent/colorful_reagent/powder/white/crayon
-	name = "White Crayon Powder"
+	name = "white crayon powder"
 	can_colour_mobs = FALSE
 
 //////////////////////////////////Hydroponics stuff///////////////////////////////
 
 /datum/reagent/plantnutriment
-	name = "Generic nutriment"
+	name = "generic nutriment"
 	description = "Some kind of nutriment. You can't really tell what it is. You should probably report it, along with how you obtained it."
 	color = "#000000" // RBG: 0, 0, 0
 	var/tox_prob = 0
@@ -1195,14 +1195,14 @@
 
 
 /datum/reagent/fuel/oil
-	name = "Oil"
+	name = "oil"
 	description = "Burns in a small smoky fire, can be used to get Ash."
 	reagent_state = LIQUID
 	color = "#2D2D2D"
 	taste_description = "oil"
 
 /datum/reagent/stable_plasma
-	name = "Stable Plasma"
+	name = "stable plasma"
 	description = "Non-flammable plasma locked into a liquid form that cannot ignite or become gaseous/solid."
 	reagent_state = LIQUID
 	color = "#2D2D2D"
@@ -1210,35 +1210,35 @@
 	taste_mult = 1.5
 
 /datum/reagent/iodine
-	name = "Iodine"
+	name = "iodine"
 	description = "Commonly added to table salt as a nutrient. On its own it tastes far less pleasing."
 	reagent_state = LIQUID
 	color = "#BC8A00"
 	taste_description = "metal"
 
 /datum/reagent/bromine
-	name = "Bromine"
+	name = "bromine"
 	description = "A brownish liquid that's highly reactive. Useful for stopping free radicals, but not intended for human consumption."
 	reagent_state = LIQUID
 	color = "#D35415"
 	taste_description = "chemicals"
 
 /datum/reagent/pentaerythritol
-	name = "Pentaerythritol"
+	name = "pentaerythritol"
 	description = "Slow down, it ain't no spelling bee!"
 	reagent_state = SOLID
 	color = "#E66FFF"
 	taste_description = "acid"
 
 /datum/reagent/acetaldehyde
-	name = "Acetaldehyde"
+	name = "acetaldehyde"
 	description = "Similar to plastic. Tastes like dead people."
 	reagent_state = SOLID
 	color = "#EEEEEF"
 	taste_description = "dead people" //made from formaldehyde, ya get da joke ?
 
 /datum/reagent/acetone_oxide
-	name = "Acetone oxide"
+	name = "acetone oxide"
 	description = "Enslaved oxygen"
 	reagent_state = LIQUID
 	color = "#C8A5DC"
@@ -1256,28 +1256,28 @@
 
 
 /datum/reagent/phenol
-	name = "Phenol"
+	name = "phenol"
 	description = "An aromatic ring of carbon with a hydroxyl group. A useful precursor to some medicines, but has no healing properties on its own."
 	reagent_state = LIQUID
 	color = "#E7EA91"
 	taste_description = "acid"
 
 /datum/reagent/ash
-	name = "Ash"
+	name = "ash"
 	description = "Supposedly phoenixes rise from these, but you've never seen it."
 	reagent_state = LIQUID
 	color = "#515151"
 	taste_description = "ash"
 
 /datum/reagent/acetone
-	name = "Acetone"
+	name = "acetone"
 	description = "A slick, slightly carcinogenic liquid. Has a multitude of mundane uses in everyday life."
 	reagent_state = LIQUID
 	color = "#AF14B7"
 	taste_description = "acid"
 
 /datum/reagent/colorful_reagent
-	name = "Colorful Reagent"
+	name = "colorful reagent"
 	description = "Thoroughly sample the rainbow."
 	reagent_state = LIQUID
 	var/list/random_color_list = list("#00aedb","#a200ff","#f47835","#d41243","#d11141","#00b159","#00aedb","#f37735","#ffc425","#008744","#0057e7","#d62d20","#ffa700")
@@ -1312,7 +1312,7 @@
 	..()
 
 /datum/reagent/hair_dye
-	name = "Quantum Hair Dye"
+	name = "quantum hair dye"
 	description = "Has a high chance of making you look like a mad scientist."
 	reagent_state = LIQUID
 	var/list/potential_colors = list("0ad","a0f","f73","d14","d14","0b5","0ad","f73","fc2","084","05e","d22","fa0") // fucking hair code
@@ -1341,35 +1341,35 @@
 	taste_description = "sourness"
 
 /datum/reagent/concentrated_barbers_aid
-	name = "Concentrated Barber's Aid"
+	name = "concentrated Barber's Aid"
 	description = "A concentrated solution to hair loss across the world."
 	reagent_state = LIQUID
 	color = "#7A4E33" //hair is dark browmn
 	taste_description = "sourness"
 
 /datum/reagent/saltpetre
-	name = "Saltpetre"
+	name = "saltpetre"
 	description = "Volatile. Controversial. Third Thing."
 	reagent_state = LIQUID
 	color = "#60A584" // rgb: 96, 165, 132
 	taste_description = "cool salt"
 
 /datum/reagent/charcoal
-	name = "Charcoal"
+	name = "charcoal"
 	description = "Burnt wood."
 	reagent_state = SOLID
 	color = "#020202" // rgb: 96, 165, 132
 	taste_description = "ash"
 
 /datum/reagent/lye
-	name = "Lye"
+	name = "lye"
 	description = "Also known as sodium hydroxide. As a profession making this is somewhat underwhelming."
 	reagent_state = LIQUID
 	color = "#FFFFD6" // very very light yellow
 	taste_description = "acid"
 
 /datum/reagent/drying_agent
-	name = "Drying agent"
+	name = "drying agent"
 	description = "A desiccant. Can be used to dry things."
 	reagent_state = LIQUID
 	color = "#A70FFF"
@@ -1395,7 +1395,7 @@
 //Misc reagents
 
 /datum/reagent/growthserum
-	name = "Growth Serum"
+	name = "growth serum"
 	description = "A commercial chemical designed to help older men in the bedroom."//not really it just makes you a giant
 	color = "#ff0000"//strong red. rgb 255, 0, 0
 	var/current_size = 1
@@ -1485,7 +1485,7 @@
 	can_synth = FALSE
 
 /datum/reagent/peaceborg/confuse
-	name = "Dizzying Solution"
+	name = "dizzying solution"
 	description = "Makes the target off balance and dizzy"
 	metabolization_rate = 1.5 * REAGENTS_METABOLISM
 	taste_description = "dizziness"
@@ -1501,7 +1501,7 @@
 	..()
 
 /datum/reagent/peaceborg/tire
-	name = "Tiring Solution"
+	name = "tiring solution"
 	description = "An extremely weak stamina-toxin that tires out the target. Completely harmless."
 	metabolization_rate = 1.5 * REAGENTS_METABOLISM
 	taste_description = "tiredness"
@@ -1516,7 +1516,7 @@
 	..()
 
 /datum/reagent/spider_extract
-	name = "Spider Extract"
+	name = "spider extract"
 	description = "A highly specialized extract coming from the Australicus sector, used to create broodmother spiders."
 	color = "#ED2939"
 	taste_description = "upside down"
@@ -1524,7 +1524,7 @@
 
 /// Improvised reagent that induces vomiting. Created by dipping a dead mouse in welder fluid.
 /datum/reagent/yuck
-	name = "Organic Slurry"
+	name = "organic slurry"
 	description = "A mixture of various colors of fluid. Induces vomiting."
 	glass_name = "glass of ...yuck!"
 	glass_desc = ""
@@ -1575,7 +1575,7 @@
 	return ..()
 
 /datum/reagent/cellulose
-	name = "Cellulose Fibers"
+	name = "cellulose fibers"
 	description = "A crystaline polydextrose polymer, plants swear by this stuff."
 	reagent_state = SOLID
 	color = "#E6E6DA"

--- a/code/modules/reagents/chemistry/reagents/rt_alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/rt_alcohol_reagents.dm
@@ -2,7 +2,7 @@
 /datum/reagent/consumable/ethanol/beer
 	cuisine = CUISINE_NORTH_IMPERIAL
 	drink_type = DRINKTYPE_ALE
-	name = "Beer"
+	name = "beer"
 	description = "Civilization in a cup. Could you truly ask for anything more?"
 	color = "#a17c10" // rgb: 102, 67, 0
 	nutriment_factor = 0.1
@@ -14,7 +14,7 @@
 /datum/reagent/consumable/ethanol/rum
 	cuisine = CUISINE_RANESHENI
 	drink_type = DRINKTYPE_SPIRIT
-	name = "Rum"
+	name = "rum"
 	description = "Where has the rum gone?"
 	color = "#5f3b23" // rgb: 102, 67, 0
 	boozepwr = 40
@@ -24,7 +24,7 @@
 /datum/reagent/consumable/ethanol/cider
 	cuisine = CUISINE_OTAVAIS|CUISINE_ETRUSCAN
 	drink_type = DRINKTYPE_CIDER
-	name = "Apple Cider"
+	name = "apple cider"
 	boozepwr = 40
 	taste_description = "crisp freshness of apple"
 	glass_name = "glass of cider"
@@ -32,15 +32,15 @@
 	quality = DRINK_NICE
 
 /datum/reagent/consumable/ethanol/cider/pear
-	name = "Pear Cider"
+	name = "pear cider"
 	boozepwr = 40
 	taste_description = "sweet subtle delights of pear"
-	glass_name = "Glass of Pear Cider"
+	glass_name = "glass of pear cider"
 	color = "fffc6c"
 	quality = DRINK_NICE
 
 /datum/reagent/consumable/ethanol/cider/strawberry
-	name = "Strawberry Cider"
+	name = "strawberry cider"
 	boozepwr = 40
 	taste_description = "a subtle hint of strawberry sweetness"
 	color = "#da4d4d"
@@ -50,7 +50,7 @@
 /datum/reagent/consumable/ethanol/aqua_vitae
 	cuisine = CUISINE_NORTH_IMPERIAL
 	drink_type = DRINKTYPE_SPIRIT
-	name = "Aqua Vitae"
+	name = "aqua vitae"
 	boozepwr = 150
 	taste_description = "death"
 	color = "#6e6e6e"
@@ -59,7 +59,7 @@
 /datum/reagent/consumable/ethanol/brandy
 	cuisine = CUISINE_NORTH_IMPERIAL
 	drink_type = DRINKTYPE_SPIRIT
-	name = "Apple Brandy"
+	name = "apple brandy"
 	boozepwr = 60
 	taste_description = "caramel oak brandy"
 	glass_name = "glass of brandy"
@@ -67,28 +67,28 @@
 	quality = DRINK_VERYGOOD
 
 /datum/reagent/consumable/ethanol/brandy/pear
-	name = "Pear Brandy"
+	name = "pear brandy"
 	boozepwr = 60
 	taste_description = "ripe pear with a hint of spice"
 	color = "b9b607"
 	quality = DRINK_VERYGOOD
 
 /datum/reagent/consumable/ethanol/brandy/strawberry
-	name = "Strawberry Brandy"
+	name = "strawberry brandy"
 	boozepwr = 60
 	taste_description = "overwhelming sweetness with a smooth finish"
 	color = "#bb1a1a"
 	quality = DRINK_VERYGOOD
 
 /datum/reagent/consumable/ethanol/brandy/tangerine
-	name = "Tangerine Brandy"
+	name = "tangerine brandy"
 	boozepwr = 60
 	taste_description = "spice and a twist of citrus"
 	color = "#bb751a"
 	quality = DRINK_VERYGOOD
 
 /datum/reagent/consumable/ethanol/brandy/plum
-	name = "Plum Brandy"
+	name = "plum brandy"
 	boozepwr = 60
 	taste_description = "purple sweetness and vanila"
 	color = "#5c0449"
@@ -97,7 +97,7 @@
 /datum/reagent/consumable/ethanol/wine
 	cuisine = CUISINE_ETRUSCAN
 	drink_type = DRINKTYPE_WINE
-	name = "Wine"
+	name = "wine"
 	boozepwr = 30
 	taste_description = "aromatic bitterness with notes of sweetly-fermented jackberries"
 	glass_name = "glass of wine"
@@ -106,7 +106,7 @@
 
 /datum/reagent/consumable/ethanol/light
 	cuisine = CUISINE_NORTH_IMPERIAL
-	name = "Light Beer"
+	name = "light beer"
 	description = "An alcoholic beverage brewed since ancient times on Old Earth. This variety has reduced calorie and alcohol content."
 	boozepwr = 5 //Space Europeans hate it
 	taste_description = "dish water"
@@ -115,7 +115,7 @@
 
 /datum/reagent/consumable/ethanol/green
 	cuisine = CUISINE_NORTH_IMPERIAL
-	name = "Green Beer"
+	name = "green beer"
 	description = "An alcoholic beverage brewed since ancient times on Old Earth. This variety is dyed a festive green."
 	color = "#A8E61D"
 	taste_description = "green piss water"
@@ -134,7 +134,7 @@
 /datum/reagent/consumable/ethanol/ale
 	cuisine = CUISINE_NORTH_IMPERIAL
 	drink_type = DRINKTYPE_ALE
-	name = "Ale"
+	name = "ale"
 	description = "A dark alcoholic beverage made with malted barley and yeast."
 	color = "#664300" // rgb: 102, 67, 0
 	boozepwr = 25
@@ -158,7 +158,7 @@
 /datum/reagent/consumable/ethanol/gin
 	cuisine = CUISINE_NORTH_IMPERIAL
 	drink_type = DRINKTYPE_SPIRIT
-	name = "Gin"
+	name = "gin"
 	boozepwr = 65
 	taste_description = "strong, piney flavor"
 	color = "#809978"
@@ -192,7 +192,7 @@
 /datum/reagent/consumable/ethanol/onion
 	cuisine = CUISINE_NORTH_IMPERIAL
 	drink_type = DRINKTYPE_SPIRIT
-	name = "Onion Cognac"
+	name = "onion cognac"
 	boozepwr = 10
 	taste_description = "spicy sweet malty overtones"
 	color = "#683e00"
@@ -269,7 +269,7 @@
 /datum/reagent/consumable/ethanol/ricewine
 	cuisine = CUISINE_SOUTHEASTERN
 	drink_type = DRINKTYPE_RICEWINE
-	name = "Rice Wine"
+	name = "rice wine"
 	taste_description = "floral sweetness with a subtle umami taste."
 	color = "#F5E6C4" // rgb: 210, 218, 99
 	boozepwr = 30
@@ -278,7 +278,7 @@
 /datum/reagent/consumable/ethanol/ricespirit
 	cuisine = CUISINE_SOUTHEASTERN
 	drink_type = DRINKTYPE_RICEWINE
-	name = "Rice Spirit"
+	name = "rice spirit"
 	taste_description = "clean heat and dry finish."
 	color = "#F8FDFC" // rgb: 210, 218, 99
 	boozepwr = 55
@@ -290,7 +290,7 @@
 
 /datum/reagent/consumable/ethanol/sourwine // Peasant grade shit.
 	cuisine = CUISINE_NORTH_IMPERIAL
-	name = "Sour Wine"
+	name = "sour wine"
 	boozepwr = 20
 	taste_description = "sour wine"
 	color = "#552b4b"
@@ -298,7 +298,7 @@
 /datum/reagent/consumable/ethanol/whitewine
 	cuisine = CUISINE_OTAVAIS
 	drink_type = DRINKTYPE_WINE
-	name = "White Wine"
+	name = "white wine"
 	boozepwr = 30
 	taste_description = "sweet white wine"
 	color = "#F3ED91"
@@ -307,7 +307,7 @@
 /datum/reagent/consumable/ethanol/redwine
 	cuisine = CUISINE_OTAVAIS
 	drink_type = DRINKTYPE_WINE
-	name = "Red Wine"
+	name = "red wine"
 	boozepwr = 30
 	taste_description = "tannin-stricken wine"
 	color = "#571111"
@@ -316,21 +316,21 @@
 /datum/reagent/consumable/ethanol/jackberrywine
 	cuisine = CUISINE_OTAVAIS
 	drink_type = DRINKTYPE_WINE
-	name = "Jackberry Wine"
+	name = "jacksberried wine"
 	boozepwr = 15
 	taste_description = "sickly sweet young wine"
 	color = "#3b2342"
 	quality = DRINK_NICE
 
 /datum/reagent/consumable/ethanol/jackberrywine/aged
-	name = "Aged Jackberry Wine"
+	name = "aged jacksberried wine"
 	boozepwr = 30
 	taste_description = "sweet aged wine"
 	color = "#402249"
 	quality = DRINK_GOOD
 
 /datum/reagent/consumable/ethanol/jackberrywine/delectable
-	name = "Delectable Jackberry Wine"
+	name = "delectable jacksberried wine"
 	boozepwr = 30
 	taste_description = "sweet delectably aged wine"
 	color = "#652679"
@@ -339,21 +339,21 @@
 /datum/reagent/consumable/ethanol/plum_wine
 	cuisine = CUISINE_OTAVAIS|CUISINE_ETRUSCAN
 	drink_type = DRINKTYPE_WINE
-	name = "Umeshu"
+	name = "umeshu"
 	boozepwr = 15
 	taste_description = "sickly sour young wine"
 	color = "#c997d8"
 	quality = DRINK_NICE
 
 /datum/reagent/consumable/ethanol/plum_wine/aged
-	name = "Aged Umeshu"
+	name = "aged umeshu"
 	boozepwr = 30
 	taste_description = "sweet slightly sour aged wine"
 	color = "#c27cd8"
 	quality = DRINK_GOOD
 
 /datum/reagent/consumable/ethanol/plum_wine/delectable
-	name = "Delectable Umeshu"
+	name = "delectable umeshu"
 	boozepwr = 30
 	taste_description = "delectably aged sour sweet wine"
 	color = "#a854c2"
@@ -362,21 +362,21 @@
 /datum/reagent/consumable/ethanol/tangerine
 	cuisine = CUISINE_OTAVAIS|CUISINE_ETRUSCAN
 	drink_type = DRINKTYPE_WINE
-	name = "Tangerine Wine"
+	name = "tangerine wine"
 	boozepwr = 15
 	taste_description = "bittersweet, citrusy young wine"
 	color = "#e7aa59"
 	quality = DRINK_NICE
 
 /datum/reagent/consumable/ethanol/tangerine/aged
-	name = "Aged Tangerine Wine"
+	name = "aged tangerine wine"
 	boozepwr = 30
 	taste_description = "bittersweet, citrusy aged wine"
 	color = "#d68d2d"
 	quality = DRINK_GOOD
 
 /datum/reagent/consumable/ethanol/tangerine/delectable
-	name = "Delectable Tangerine Wine"
+	name = "delectable tangerine wine"
 	boozepwr = 30
 	taste_description = "bittersweet, citrusy delectably aged wine"
 	color = "#eb9321"
@@ -385,21 +385,21 @@
 /datum/reagent/consumable/ethanol/raspberry
 	cuisine = CUISINE_OTAVAIS
 	drink_type = DRINKTYPE_WINE
-	name = "Raspberry Wine"
+	name = "raspberry wine"
 	boozepwr = 15
 	taste_description = "tart sweet young wine"
 	color = "#ee5ea6"
 	quality = DRINK_NICE
 
 /datum/reagent/consumable/ethanol/raspberry/aged
-	name = "Aged Raspberry Wine"
+	name = "aged raspberry wine"
 	boozepwr = 30
 	taste_description = "tart sweet aged wine"
 	color = "#d83788"
 	quality = DRINK_GOOD
 
 /datum/reagent/consumable/ethanol/raspberry/delectable
-	name = "Delectable Raspberry Wine"
+	name = "delectable raspberry wine"
 	boozepwr = 30
 	taste_description = "tart sweet delectably aged wine"
 	color = "#db0d74"
@@ -408,21 +408,21 @@
 /datum/reagent/consumable/ethanol/blackberry
 	cuisine = CUISINE_OTAVAIS
 	drink_type = DRINKTYPE_WINE
-	name = "Blackberry Wine"
+	name = "blackberry wine"
 	boozepwr = 15
 	taste_description = "bitter tart young wine"
 	color = "#861491"
 	quality = DRINK_NICE
 
 /datum/reagent/consumable/ethanol/blackberry/aged
-	name = "Aged Blackberry Wine"
+	name = "aged blackberry wine"
 	boozepwr = 30
 	taste_description = "bitter tart aged wine"
 	color = "#58065f"
 	quality = DRINK_GOOD
 
 /datum/reagent/consumable/ethanol/blackberry/delectable
-	name = "Delectable Blackberry Wine"
+	name = "delectable blackberry wine"
 	boozepwr = 30
 	taste_description = "bitter tart delectably aged wine"
 	color = "#330038"
@@ -433,7 +433,7 @@
 /datum/reagent/consumable/ethanol/spicedwine
 	cuisine = CUISINE_RANESHENI
 	drink_type = DRINKTYPE_WINE
-	name = "Spiced Wine"
+	name = "spiced wine"
 	boozepwr = 10
 	taste_description = "overpoweringly aromatic, sweetening the tongue and numbing the lips"
 	color = "#a11a00"
@@ -446,7 +446,7 @@
 	..()
 
 /datum/reagent/consumable/ethanol/spicedwine/aged
-	name = "Aged Spiced Wine"
+	name = "aged spiced wine"
 	boozepwr = 20
 	taste_description = "richly aromatic spiciness, evoking the memory of a holidae's snow-speckled nite"
 	color = "#961800"
@@ -459,7 +459,7 @@
 	..()
 
 /datum/reagent/consumable/ethanol/spicedwine/delectable
-	name = "Delectable Spiced Wine"
+	name = "delectable spiced wine"
 	boozepwr = 40
 	taste_description = "heavenly aromatic sweetness, followed by an ever-familiar warmness in the heart"
 	color = "#821500"
@@ -667,7 +667,7 @@
 /datum/reagent/consumable/ethanol/mead
 	cuisine = CUISINE_SOUTH_IMPERIAL
 	drink_type = DRINKTYPE_MEAD
-	name = "Mead"
+	name = "mead"
 	description = "A warriors drink, though a cheap one."
 	color = "#664300" // rgb: 102, 67, 0
 	nutriment_factor = 1 * REAGENTS_METABOLISM

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -2,7 +2,7 @@
 //////////////////////////Poison stuff (Toxins & Acids)///////////////////////
 
 /datum/reagent/toxin
-	name = "Toxin"
+	name = "toxin"
 	description = "A toxic chemical."
 	color = "#CF3600" // rgb: 207, 54, 0
 	taste_description = "bitterness"
@@ -17,14 +17,14 @@
 	return ..()
 
 /datum/reagent/toxin/amatoxin
-	name = "Amatoxin"
+	name = "amatoxin"
 	description = "A powerful poison derived from certain species of mushroom."
 	color = "#792300" // rgb: 121, 35, 0
 	toxpwr = 2.5
 	taste_description = "mushroom"
 
 /datum/reagent/toxin/mutagen
-	name = "Unstable mutagen"
+	name = "unstable mutagen"
 	description = "Might cause unpredictable mutations. Keep away from children."
 	color = "#00FF00"
 	toxpwr = 0
@@ -49,7 +49,7 @@
 #define	LIQUID_PLASMA_BP (50+T0C)
 
 /datum/reagent/toxin/plasma
-	name = "Plasma"
+	name = "plasma"
 	description = "Plasma in its liquid form."
 	taste_description = "bitterness"
 	specific_heat = SPECIFIC_HEAT_PLASMA
@@ -64,7 +64,7 @@
 	..()
 
 /datum/reagent/toxin/lexorin
-	name = "Lexorin"
+	name = "lexorin"
 	description = "A powerful poison used to stop respiration."
 	color = "#7DC3A0"
 	toxpwr = 0
@@ -84,7 +84,7 @@
 	..()
 
 /datum/reagent/toxin/slimejelly
-	name = "Slime Jelly"
+	name = "slime jelly"
 	description = "A gooey semi-liquid produced from one of the deadliest lifeforms in existence. SO REAL."
 	color = "#801E28" // rgb: 128, 30, 40
 	toxpwr = 0
@@ -102,7 +102,7 @@
 	..()
 
 /datum/reagent/toxin/minttoxin
-	name = "Mint Toxin"
+	name = "mint toxin"
 	description = "Useful for dealing with undesirable customers."
 	color = "#CF3600" // rgb: 207, 54, 0
 	toxpwr = 0
@@ -114,7 +114,7 @@
 	return ..()
 
 /datum/reagent/toxin/carpotoxin
-	name = "Carpotoxin"
+	name = "carpotoxin"
 	description = "A deadly neurotoxin produced by the dreaded spess carp."
 	silent_toxin = TRUE
 	color = "#003333" // rgb: 0, 51, 51
@@ -122,7 +122,7 @@
 	taste_description = "fish"
 
 /datum/reagent/toxin/zombiepowder
-	name = "Zombie Powder"
+	name = "zombie powder"
 	description = "A strong neurotoxin that puts the subject into a death-like state."
 	silent_toxin = TRUE
 	reagent_state = SOLID
@@ -161,7 +161,7 @@
 			M.fakedeath(type)
 
 /datum/reagent/toxin/ghoulpowder
-	name = "Ghoul Powder"
+	name = "ghoul powder"
 	description = "A strong neurotoxin that slows metabolism to a death-like state, while keeping the patient fully active. Causes toxin buildup if used too long."
 	reagent_state = SOLID
 	color = "#664700" // rgb: 102, 71, 0
@@ -182,7 +182,7 @@
 	. = 1
 
 /datum/reagent/toxin/mindbreaker
-	name = "Mindbreaker Toxin"
+	name = "mindbreaker toxin"
 	description = "A powerful hallucinogen. Not a thing to be messed with. For some mental patients. it counteracts their symptoms and anchors them to reality."
 	color = "#B31008" // rgb: 139, 166, 233
 	toxpwr = 0
@@ -215,12 +215,12 @@
 				C.adjustToxLoss(damage)
 
 /datum/reagent/toxin/plantbgone/weedkiller
-	name = "Weed Killer"
+	name = "weed killer"
 	description = "A harmful toxic mixture to kill weeds. Do not ingest!"
 	color = "#4B004B" // rgb: 75, 0, 75
 
 /datum/reagent/toxin/pestkiller
-	name = "Pest Killer"
+	name = "pest killer"
 	description = "A harmful toxic mixture to kill pests. Do not ingest!"
 	color = "#4B004B" // rgb: 75, 0, 75
 	toxpwr = 1
@@ -232,7 +232,7 @@
 		M.adjustToxLoss(damage)
 
 /datum/reagent/toxin/spore
-	name = "Spore Toxin"
+	name = "spore toxin"
 	description = "A natural toxin produced by blob spores that inhibits vision when ingested."
 	color = "#9ACD32"
 	toxpwr = 1
@@ -244,7 +244,7 @@
 	return ..()
 
 /datum/reagent/toxin/spore_burning
-	name = "Burning Spore Toxin"
+	name = "burning spore toxin"
 	description = "A natural toxin produced by blob spores that induces combustion in its victim."
 	color = "#9ACD32"
 	toxpwr = 0.5
@@ -256,7 +256,7 @@
 	return ..()
 
 /datum/reagent/toxin/chloralhydrate
-	name = "Chloral Hydrate"
+	name = "chloral hydrate"
 	description = "A powerful sedative that induces confusion and drowsiness before putting its target to sleep."
 	silent_toxin = TRUE
 	reagent_state = SOLID
@@ -279,7 +279,7 @@
 	..()
 
 /datum/reagent/toxin/fakebeer	//disguised as normal beer for use by emagged brobots
-	name = "Beer"
+	name = "beer"
 	description = "A specially-engineered sedative disguised as beer. It induces instant sleep in its target."
 	color = "#664300" // rgb: 102, 67, 0
 	metabolization_rate = 1.5 * REAGENTS_METABOLISM
@@ -298,14 +298,14 @@
 	return ..()
 
 /datum/reagent/toxin/coffeepowder
-	name = "Coffee Grounds"
+	name = "coffee grounds"
 	description = "Finely ground coffee beans, used to make coffee."
 	reagent_state = SOLID
 	color = "#5B2E0D" // rgb: 91, 46, 13
 	toxpwr = 0.5
 
 /datum/reagent/toxin/teapowder
-	name = "Ground Tea Leaves"
+	name = "ground tea leaves"
 	description = "Finely shredded tea leaves, used for making tea."
 	reagent_state = SOLID
 	color = "#7F8400" // rgb: 127, 132, 0
@@ -313,7 +313,7 @@
 	taste_description = "green tea"
 
 /datum/reagent/toxin/mutetoxin //the new zombie powder.
-	name = "Mute Toxin"
+	name = "mute toxin"
 	description = "A nonlethal poison that inhibits speech in its victim."
 	silent_toxin = TRUE
 	color = "#F0F8FF" // rgb: 240, 248, 255
@@ -325,7 +325,7 @@
 	..()
 
 /datum/reagent/toxin/histamine
-	name = "Histamine"
+	name = "histamine"
 	description = "Histamine's effects become more dangerous depending on the dosage amount. They range from mildly annoying to incredibly lethal."
 	silent_toxin = TRUE
 	reagent_state = LIQUID
@@ -359,7 +359,7 @@
 	. = 1
 
 /datum/reagent/toxin/formaldehyde
-	name = "Formaldehyde"
+	name = "formaldehyde"
 	description = "Formaldehyde, on its own, is a fairly weak toxin. It contains trace amounts of Histamine, very rarely making it decay into Histamine."
 	silent_toxin = TRUE
 	reagent_state = LIQUID
@@ -375,7 +375,7 @@
 		return ..()
 
 /datum/reagent/toxin/venom
-	name = "Venom"
+	name = "venom"
 	description = "An exotic poison extracted from highly toxic fauna. Causes scaling amounts of toxin damage and bruising depending and dosage. Often decays into Histamine."
 	reagent_state = LIQUID
 	color = "#F0FFF0"
@@ -394,7 +394,7 @@
 	..()
 
 /datum/reagent/toxin/fentanyl
-	name = "Fentanyl"
+	name = "fentanyl"
 	description = "Fentanyl will inhibit brain function and cause toxin damage before eventually knocking out its victim."
 	reagent_state = LIQUID
 	color = "#64916E"
@@ -411,7 +411,7 @@
 	return TRUE
 
 /datum/reagent/toxin/cyanide
-	name = "Cyanide"
+	name = "cyanide"
 	description = "An infamous poison known for its use in assassination. Causes small amounts of toxin damage with a small chance of oxygen damage or a stun."
 	reagent_state = LIQUID
 	color = "#FFFFFF"
@@ -425,7 +425,7 @@
 	return ..()
 
 /datum/reagent/toxin/bad_food
-	name = "Bad Food"
+	name = "bad food"
 	description = "The result of some abomination of cookery, food so bad it's toxic."
 	reagent_state = LIQUID
 	color = "#d6d6d8"
@@ -434,7 +434,7 @@
 	taste_description = "bad cooking"
 
 /datum/reagent/toxin/itching_powder
-	name = "Itching Powder"
+	name = "itching powder"
 	description = "A powder that induces itching upon contact with the skin. Causes the victim to scratch at their itches and has a very low chance to decay into Histamine."
 	silent_toxin = TRUE
 	reagent_state = LIQUID
@@ -466,7 +466,7 @@
 	..()
 
 /datum/reagent/toxin/initropidril
-	name = "Initropidril"
+	name = "initropidril"
 	description = "A powerful poison with insidious effects. It can cause stuns, lethal breathing failure, and cardiac arrest."
 	silent_toxin = TRUE
 	reagent_state = LIQUID
@@ -497,7 +497,7 @@
 	return ..() || .
 
 /datum/reagent/toxin/pancuronium
-	name = "Pancuronium"
+	name = "pancuronium"
 	description = "An undetectable toxin that swiftly incapacitates its victim. May also cause breathing failure."
 	silent_toxin = TRUE
 	reagent_state = LIQUID
@@ -515,7 +515,7 @@
 	..()
 
 /datum/reagent/toxin/sodium_thiopental
-	name = "Sodium Thiopental"
+	name = "sodium thiopental"
 	description = "Sodium Thiopental induces heavy weakness in its target as well as unconsciousness."
 	silent_toxin = TRUE
 	reagent_state = LIQUID
@@ -531,7 +531,7 @@
 	return TRUE
 
 /datum/reagent/toxin/sulfonal
-	name = "Sulfonal"
+	name = "sulfonal"
 	description = "A stealthy poison that deals minor toxin damage and eventually puts the target to sleep."
 	silent_toxin = TRUE
 	reagent_state = LIQUID
@@ -545,7 +545,7 @@
 	return ..()
 
 /datum/reagent/toxin/amanitin
-	name = "Amanitin"
+	name = "amanitin"
 	description = "A very powerful delayed toxin. Upon full metabolization, a massive amount of toxin damage will be dealt depending on how long it has been in the victim's bloodstream."
 	silent_toxin = TRUE
 	reagent_state = LIQUID
@@ -560,7 +560,7 @@
 	..()
 
 /datum/reagent/toxin/lipolicide
-	name = "Lipolicide"
+	name = "lipolicide"
 	description = "A powerful toxin that will destroy fat cells, massively reducing body weight in a short time. Deadly to those without nutriment in their body."
 	silent_toxin = TRUE
 	taste_description = "mothballs"
@@ -577,7 +577,7 @@
 	return ..()
 
 /datum/reagent/toxin/coniine
-	name = "Coniine"
+	name = "coniine"
 	description = "Coniine metabolizes extremely slowly, but deals high amounts of toxin damage and stops breathing."
 	reagent_state = LIQUID
 	color = "#7DC3A0"
@@ -589,7 +589,7 @@
 	return ..()
 
 /datum/reagent/toxin/spewium
-	name = "Spewium"
+	name = "spewium"
 	description = "A powerful emetic, causes uncontrollable vomiting.	May result in vomiting organs at high doses."
 	reagent_state = LIQUID
 	color = "#2f6617" //A sickly green color
@@ -614,7 +614,7 @@
 		to_chat(C, span_danger("I feel something lumpy come up..."))
 
 /datum/reagent/toxin/curare
-	name = "Curare"
+	name = "curare"
 	description = "Causes slight toxin damage followed by chain-stunning and oxygen damage."
 	reagent_state = LIQUID
 	color = "#191919"
@@ -629,7 +629,7 @@
 	..()
 
 /datum/reagent/toxin/heparin //Based on a real-life anticoagulant. I'm not a doctor, so this won't be realistic.
-	name = "Heparin"
+	name = "heparin"
 	description = "A powerful anticoagulant. Victims will bleed uncontrollably and suffer scaling bruising."
 	silent_toxin = TRUE
 	reagent_state = LIQUID
@@ -647,7 +647,7 @@
 
 
 /datum/reagent/toxin/rotatium //Rotatium. Fucks up my rotation and is hilarious
-	name = "Rotatium"
+	name = "rotatium"
 	description = "A constantly swirling, oddly colourful fluid. Causes the consumer's sense of direction and hand-eye coordination to become wild."
 	silent_toxin = TRUE
 	reagent_state = LIQUID
@@ -674,7 +674,7 @@
 	..()
 
 /datum/reagent/toxin/anacea
-	name = "Anacea"
+	name = "anacea"
 	description = "A toxin that quickly purges medicines and metabolizes very slowly."
 	reagent_state = LIQUID
 	color = "#3C5133"
@@ -688,7 +688,7 @@
 	return ..()
 
 /datum/reagent/toxin/drow
-	name = "Drow Toxin"
+	name = "drow toxin"
 	description = "How are you even reading this?"
 	reagent_state = LIQUID
 	color = "#410233"
@@ -696,7 +696,7 @@
 
 //ACID
 /datum/reagent/toxin/acid
-	name = "Sulphuric acid"
+	name = "sulphuric acid"
 	description = "A strong mineral acid with the molecular formula H2SO4."
 	color = "#00FF32"
 	toxpwr = 1
@@ -729,7 +729,7 @@
 	T.acid_act(acidpwr, reac_volume)
 
 /datum/reagent/toxin/acid/fluacid
-	name = "Fluorosulfuric acid"
+	name = "fluorosulfuric acid"
 	description = "Fluorosulfuric acid is an extremely corrosive chemical substance."
 	color = "#5050FF"
 	toxpwr = 2
@@ -741,7 +741,7 @@
 	..()
 
 /datum/reagent/toxin/acid/nitracid
-	name = "Nitric acid"
+	name = "nitric acid"
 	description = "Nitric acid is an extremely corrosive chemical substance that violently reacts with living organic tissue."
 	color = "#5050FF"
 	toxpwr = 6
@@ -753,7 +753,7 @@
 	..()
 
 /datum/reagent/toxin/delayed
-	name = "Toxin Microcapsules"
+	name = "toxin microcapsules"
 	description = "Causes heavy toxin damage after a brief time of inactivity."
 	reagent_state = LIQUID
 	metabolization_rate = 0 //stays in the system until active.
@@ -772,7 +772,7 @@
 	..()
 
 /datum/reagent/toxin/mimesbane
-	name = "Mime's Bane"
+	name = "mime's bane"
 	description = "A nonlethal neurotoxin that interferes with the victim's ability to gesture."
 	silent_toxin = TRUE
 	color = "#F0F8FF" // rgb: 240, 248, 255
@@ -786,7 +786,7 @@
 	REMOVE_TRAIT(L, TRAIT_EMOTEMUTE, type)
 
 /datum/reagent/toxin/bonehurtingjuice //oof ouch
-	name = "Bone Hurting Juice"
+	name = "bone hurting juice"
 	description = "A strange substance that looks a lot like water. Drinking it is oddly tempting. Oof ouch."
 	silent_toxin = TRUE //no point spamming them even more.
 	color = "#AAAAAA77" //RGBA: 170, 170, 170, 77
@@ -824,7 +824,7 @@
 	return ..()
 
 /datum/reagent/toxin/bungotoxin
-	name = "Bungotoxin"
+	name = "bungotoxin"
 	description = "A horrible cardiotoxin that protects the humble bungo pit."
 	silent_toxin = TRUE
 	color = "#EBFF8E"

--- a/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
@@ -1,6 +1,6 @@
 //Potions
 /datum/reagent/medicine/healthpot
-	name = "Health Potion"
+	name = "health potion"
 	description = "Gradually regenerates all types of damage."
 	reagent_state = LIQUID
 	color = "#ff0000"
@@ -29,21 +29,21 @@
 	..()
 
 /datum/reagent/medicine/healthpot/zarum/blood
-	name = "Blackened Sludge"
+	name = "blackened sludge"
 	description = "A fairly disgusting, bubbling mess of an unknown origin that seems to be constantly fermenting onto itself, exhuding a foul smell."
 	color = "#241a1a"
 	taste_description = "sins of Otava"
 	scent_description = "dark darker yet darker"
 
 /datum/reagent/medicine/healthpot/zarum/bog // no changes, it's just more palatable :>
-	name = "Honeyed Zarum"
+	name = "honeyed zarum"
 	description = "A fermented sauce of fish innards, vinegar and honey, which gradually regenerates all types of damage while remaining surprisingly pleasant to the tastebuds."
 	color = "#dd9700"
 	taste_description = "sweet-sour fish-glazed honey"
 	scent_description = "sweet fermented pungence"
 
 /datum/reagent/medicine/healthpot/zarum
-	name = "Zarum"
+	name = "zarum"
 	description = "A fermented sauce of fish innards and vinegar, which gradually regenerates all types of damage."
 	reagent_state = LIQUID
 	color = "#891305"
@@ -76,7 +76,7 @@
 	..()
 
 /datum/reagent/medicine/stronghealth
-	name = "Strong Health Potion"
+	name = "strong health potion"
 	description = "Quickly regenerates all types of damage."
 	color = "#820000"
 	taste_description = "rich lifeblood"
@@ -103,7 +103,7 @@
 	. = 1
 
 /datum/reagent/medicine/manapot
-	name = "Mana Potion"
+	name = "mana potion"
 	description = "Gradually regenerates energy."
 	reagent_state = LIQUID
 	color = "#000042"
@@ -120,7 +120,7 @@
 	..()
 
 /datum/reagent/medicine/strongmana
-	name = "Strong Mana Potion"
+	name = "strong mana potion"
 	description = "Rapidly regenerates energy."
 	color = "#0000ff"
 	taste_description = "raw power"
@@ -134,7 +134,7 @@
 	..()
 
 /datum/reagent/medicine/restoration
-	name = "Restoration Potion"
+	name = "restoration potion"
 	description = "Simultaneously regenerates health and energy. Inherits a higher potency than common lifeblood and manna, but remains inferior to stronger brews."
 	color = "#ff8da1"
 	taste_description = "reinvigorative creaminess"
@@ -164,7 +164,7 @@
 
 // Stamina potion no longer grant green bar directly which led to it being far too powerful when abused
 /datum/reagent/medicine/stampot
-	name = "Fortitude Potion"
+	name = "fortitude potion"
 	description = "Hardens the humors against fatigue, granting Fortitude for a short while."
 	reagent_state = LIQUID
 	color = "#129c00"
@@ -182,7 +182,7 @@
 	return TRUE
 
 /datum/reagent/medicine/strongstam
-	name = "Strong Fortitude Potion"
+	name = "strong fortitude potion"
 	description = "Rapidly hardens the humors against fatigue, granting Fortitude for a short while."
 	color = "#13df00"
 	taste_description = "sparkly static"
@@ -203,7 +203,7 @@
 	Previously, antidote did not have a dylovene-like effect and just purged toxin damage while poison will outlast them.
 **/
 /datum/reagent/medicine/antidote
-	name = "Antidote"
+	name = "antidote"
 	description = "Gradually purges any imbalanced humors and poisons within the bloodstream."
 	reagent_state = LIQUID
 	color = "#00ff00"
@@ -227,7 +227,7 @@
 
 // About 3 time as potent as antidote
 /datum/reagent/medicine/strong_antidote
-	name = "Strong Antidote"
+	name = "strong antidote"
 	description = "Rapidly purges any imbalanced humors and poisons within the bloodstream."
 	reagent_state = LIQUID
 	color = "#004200"
@@ -305,6 +305,7 @@
 	name = STATKEY_WIL
 	color = "#ffff00"
 	taste_description = "oversweetened milk"
+	scent_description = "sugar"
 	buff_type = /datum/status_effect/buff/alch/statbuff/endurancepot
 
 /datum/reagent/buff/speed
@@ -326,7 +327,7 @@
 	they neutralize each other into this useless sludge.
 */
 /datum/reagent/ruined_potion
-	name = "Odd water"
+	name = "odd water"
 	description = "A foul mess of conflicting alchemical essences that tried to push nature too far. Utterly useless."
 	reagent_state = LIQUID
 	color = "#6b5d4f" // muddy brownish-green
@@ -350,8 +351,8 @@ A dose of ingested potion is defined as 5u, projectile deliver at most 2u, you a
 If you want to expand on poisons theres tons of fun effects TG chemistry has that could be added, randomzied damage values for more unpredictable poison, add trait based resists instead of the clunky race check etc.*/
 
 /datum/reagent/berrypoison	// Weaker poison, balanced to make you wish for death and incapacitate but not kill
-	name = "Berry Poison"
-	description = ""
+	name = "berry poison"
+	description = "Gradually debilitates the body's humors, inducing nausea and poisoning-of-blood."
 	reagent_state = LIQUID
 	color = "#47b2e0"
 	taste_description = "bitterness"
@@ -371,8 +372,8 @@ If you want to expand on poisons theres tons of fun effects TG chemistry has tha
 
 
 /datum/reagent/strongpoison		// Strong poison, meant to be somewhat difficult to produce using alchemy or spawned with select antags. Designed to kill in one full dose (5u) better drink antidote fast
-	name = "Strong Poison"
-	description = ""
+	name = "strong poison"
+	description = "Rapidly debilitates the body's humors, inducing severe nausea and poisoning-of-blood."
 	reagent_state = LIQUID
 	color = "#1a1616"
 	taste_description = "burning"
@@ -392,8 +393,8 @@ If you want to expand on poisons theres tons of fun effects TG chemistry has tha
 	return ..()
 
 /datum/reagent/bloodacid // Quietus Poison for Vampires
-	name = "Vitae Acid"
-	description = ""
+	name = "vitae acid"
+	description = "Burns away the body's humors, inducing lethal nausea and the curdling of blood-in-circulation."
 	reagent_state = LIQUID
 	color = "#ff3300"
 	taste_description = "burning"
@@ -416,15 +417,14 @@ If you want to expand on poisons theres tons of fun effects TG chemistry has tha
 	return ..()
 
 /datum/reagent/organpoison
-	name = "Organ Poison"
-	description = ""
+	name = "organ poison"
+	description = "Induces severe nausea and light poisoning-of blood. Lightly regenerates energy to those with more humanitarian diets."
 	reagent_state = LIQUID
 	color = "#2c1818"
 	taste_description = "sour meat"
 	scent_description = "rancid meat"
 	metabolization_rate = 0.1 * REAGENTS_METABOLISM
 	harmful = TRUE
-
 
 /datum/reagent/organpoison/on_mob_life(mob/living/carbon/M)
 	if(HAS_TRAIT(M, TRAIT_ORGAN_EATER))
@@ -435,8 +435,8 @@ If you want to expand on poisons theres tons of fun effects TG chemistry has tha
 	return ..()
 
 /datum/reagent/sleep_powder
-	name = "Sleep Poison"
-	description = ""
+	name = "sleep poison"
+	description = "Rapidly induces unconsciousness."
 	color = "#ddd3df" // rgb: 96, 165, 132
 	metabolization_rate = 1
 	taste_description = "numbing mintiness"
@@ -446,8 +446,8 @@ If you want to expand on poisons theres tons of fun effects TG chemistry has tha
 	..()
 
 /datum/reagent/stampoison
-	name = "Stamina Poison"
-	description = ""
+	name = "stamina poison"
+	description = "Gradually drains energy."
 	reagent_state = LIQUID
 	color = "#083b1c"
 	taste_description = "breathlessness"
@@ -462,8 +462,8 @@ If you want to expand on poisons theres tons of fun effects TG chemistry has tha
 	return ..()
 
 /datum/reagent/strongstampoison
-	name = "Strong Stamina Poison"
-	description = ""
+	name = "strong stamina poison"
+	description = "Rapidly drains energy."
 	reagent_state = LIQUID
 	color = "#041d0e"
 	taste_description = "frozen air"
@@ -478,8 +478,8 @@ If you want to expand on poisons theres tons of fun effects TG chemistry has tha
 	return ..()
 
 /datum/reagent/toxin/killersice
-	name = "Killer's Ice"
-	description = "c8c9e9"
+	name = "killer's ice"
+	description = "A notoriously lethal poison that freezes the body's humors from the inside-out. Just a single drop is all it takes."
 	reagent_state = LIQUID
 	color = "#FFFFFF"
 	taste_description = "cold needles"
@@ -493,7 +493,7 @@ If you want to expand on poisons theres tons of fun effects TG chemistry has tha
 	return ..()
 
 /datum/chemical_reaction/alch/vitae_essence
-	name = "Vitae Decoction"
+	name = "vitae cecoction"
 	id = /datum/reagent/medicine/vitae_essence
 	results = list(/datum/reagent/medicine/vitae_essence = 1)
 	required_reagents = list(/datum/reagent/vitae = 1, /datum/reagent/toxin/fyritiusnectar = 5)
@@ -503,8 +503,8 @@ If you want to expand on poisons theres tons of fun effects TG chemistry has tha
 |Ingredients|
 \----------*/
 /datum/reagent/undeadash
-	name = "Spectral Powder"
-	description = ""
+	name = "spectral powder"
+	description = "Remains of what one was."
 	reagent_state = SOLID
 	color = "#330066"
 	taste_description = "tombstones"
@@ -512,7 +512,7 @@ If you want to expand on poisons theres tons of fun effects TG chemistry has tha
 
 /datum/reagent/toxin/fyritiusnectar
 	name = "fyritius nectar"
-	description = "oh no"
+	description = "A powdery-flecked pseudoliquid with incendiary properties, especially when applied to bare skin."
 	reagent_state = LIQUID
 	color = "#ffc400"
 	metabolization_rate = 0.5
@@ -571,7 +571,7 @@ If you want to expand on poisons theres tons of fun effects TG chemistry has tha
 
 
 /datum/reagent/medicine/vitae_essence
-	name = "Vitae Decoction"
+	name = "vitae decoction"
 	description = "Decoction of essence of lyfe, used to restore one's lux humours."
 	color = "#67c7ff" // rgb: 96, 165, 132
 	overdose_threshold = 10
@@ -584,21 +584,21 @@ If you want to expand on poisons theres tons of fun effects TG chemistry has tha
 	return ..()
 
 /datum/reagent/fire_resist
-	name = "Fire Resistance"
+	name = "elixir of fire resistance"
 	color = "#ff7300"
-	taste_description = "burning coal"
+	taste_description = "burning coals"
 
 /datum/reagent/fire_resist/on_mob_life(mob/living/carbon/M)
 	M.apply_status_effect(/datum/status_effect/buff/alch/fire_resist)
 	return ..()
 
 /datum/reagent/fermented_crab
-	name = "Fermented Crab"
-	description = ""
+	name = "fermented crab"
+	description = "A pungent 'remedy' to failings by the bedside."
 	color = "#abaa7c"
 	overdose_threshold = 15
 	metabolization_rate = 0.2
-	taste_description = "randcid, putrid crab"
+	taste_description = "rancid, putrid crab"
 
 /datum/reagent/fermented_crab/overdose_process(mob/living/M)
 	M.adjustToxLoss(1, FALSE)

--- a/modular/Neu_teas_and_brews/code/drink_mix_recipes.dm
+++ b/modular/Neu_teas_and_brews/code/drink_mix_recipes.dm
@@ -1,6 +1,6 @@
 
 /datum/crafting_recipe/roguetown/cooking/mix_taraxamint
-	name = "Taraxacum-Mentha tea mix"
+	name = "taraxacum-mentha tea mix"
 	display_category = ITEM_CAT_FOODSTUFF_PRESERVED
 	reqs = list(
 		/obj/item/alch/taraxacum = 1,
@@ -11,7 +11,7 @@
 	req_table = TRUE
 
 /datum/crafting_recipe/roguetown/cooking/mix_utricasalvia
-	name = "Utrica-Salvia tea mix"
+	name = "utrica-salvia tea mix"
 	display_category = ITEM_CAT_FOODSTUFF_PRESERVED
 	reqs = list(
 		/obj/item/alch/urtica = 1,
@@ -22,7 +22,7 @@
 	req_table = TRUE
 
 /datum/crafting_recipe/roguetown/cooking/mix_sbiten
-	name = "Sbiten Brick"
+	name = "sbiten Brick"
 	display_category = ITEM_CAT_FOODSTUFF_PRESERVED
 	reqs = list(
 		/obj/item/reagent_containers/food/snacks/rogue/honey = 1,
@@ -34,7 +34,7 @@
 
 
 /datum/crafting_recipe/roguetown/cooking/tar_brick
-	name = "Westleach tar brick"
+	name = "westleach tar brick"
 	display_category = ITEM_CAT_FOODSTUFF_PRESERVED
 	reqs = list(
 		/datum/reagent/consumable/tea/badidea = 120,

--- a/modular/Neu_teas_and_brews/code/drink_mixes.dm
+++ b/modular/Neu_teas_and_brews/code/drink_mixes.dm
@@ -1,6 +1,6 @@
 //defines for tea mix items, a workaround pots using only one input
 /obj/item/reagent_containers/food/snacks/mix_taraxamint
-	name = "Taraxacum-Mentha tea mix"
+	name = "taraxacum-mentha tea mix"
 	desc = "A tea mix consisting of smothered herbs of Taraxacum and Mentha"
 	icon = 'modular/Neu_teas_and_brews/icons/obj/tea_mixes.dmi'
 	icon_state = "mix_taraxamint"
@@ -13,7 +13,7 @@
 	foodtype = GROSS
 
 /obj/item/reagent_containers/food/snacks/mix_utricasalvia
-	name = "Urtica-Salvia tea mix"
+	name = "urtica-salvia tea mix"
 	desc = "A tea mix consisting of smothered herbs of Urtica and Salvia"
 	icon = 'modular/Neu_teas_and_brews/icons/obj/tea_mixes.dmi'
 	icon_state = "mix_utricasalvia"
@@ -27,7 +27,7 @@
 
 /obj/item/reagent_containers/food/snacks/mix_sbiten
 	cuisine = CUISINE_NORTHERN
-	name = "Sbiten honey mix"
+	name = "sbiten honey mix"
 	desc = "a brick of crystallized honey, infused with spices for extra comfort"
 	icon = 'modular/Neu_teas_and_brews/icons/obj/tea_mixes.dmi'
 	icon_state = "sbiten_brick"
@@ -42,7 +42,7 @@
 //NOT REALLY A TEA, but it kinda expands on smoking options and is a derivative of, so I think its kinda coolish
 // also maybe in future someone will make tea bricks to use in the teapots and etc
 /obj/item/reagent_containers/food/snacks/grown/tar_brick
-	name = "Westleach Tar Brick"
+	name = "westleach tar brick"
 	desc = "A brick of dark-brown tar made by separating boiled leaf residue from water, used by the travellers and the poor as a substitute for a quality leaf smokes. Use a knife to slice a piece off to smoke, you may try to smoke whole thing too however..."
 	icon = 'modular/Neu_teas_and_brews/icons/obj/tar_brick.dmi'
 	icon_state = "Tar_Brick4"
@@ -77,7 +77,7 @@
 			changefood(slice_path, eater)
 
 /obj/item/reagent_containers/food/snacks/grown/tar_slice //the thing you are ACTUALLY supposed to smoke
-	name = "Westleach Tar slice"
+	name = "westleach tar slice"
 	icon = 'modular/Neu_teas_and_brews/icons/obj/tar_brick.dmi'
 	icon_state = "tar_slice"
 	bitesize = 1

--- a/modular/Neu_teas_and_brews/code/drink_reagents_tea.dm
+++ b/modular/Neu_teas_and_brews/code/drink_reagents_tea.dm
@@ -3,7 +3,7 @@
 // PORT TO AZURE COMMENT: When I originally added this to vanderlin, I had to axe existing teas, In good conciousness I refuse to touch it here because it doest conflict and I refuse to refactor entire thing. Goodluck to whoever does tho.
 /datum/reagent/consumable/tea/
 	drink_type = DRINKTYPE_CAFFEINE
-	name = "Generic tea"
+	name = "generic tea"
 	description = "A common concept of a generic tea made from whatever, by whoever."
 	reagent_state = LIQUID
 	color = "#c38553"
@@ -23,7 +23,7 @@
 
 /datum/reagent/consumable/tea/taraxamint
 	cuisine = CUISINE_SOUTHEASTERN
-	name = "Taraxacum-Mentha tea"
+	name = "taraxacum-mentha tea"
 	description = "Soothing herbal green tea, rumored to help ease burns, liver issues and help with head traumas"
 	color = "#acaf01"
 	nutriment_factor = 2
@@ -46,7 +46,7 @@
 
 /datum/reagent/consumable/tea/utricasalvia
 	cuisine = CUISINE_SOUTHEASTERN
-	name = "Urtica-Salvia tea"
+	name = "urtica-salvia tea"
 	description = "Deep, velvet tea. Taste of tingling sour fruits. Used by a traditional remedy by common folk to recover from bruises and burns. Some even say it can heal wounds."
 	color = "#451853"
 	nutriment_factor = 2
@@ -108,7 +108,7 @@
 	return ..()
 
 /datum/reagent/consumable/tea/manabloom
-	name = "Manabloom tea"
+	name = "manabloom tea"
 	description = "Manabloom flower is tossed into hot, boiling water. A crude, inefficient but cheap method to extract its properties."
 	color = "#5986b1"
 	nutriment_factor = 2
@@ -133,7 +133,7 @@
 /datum/reagent/consumable/tea/compot
 	cuisine = CUISINE_NORTHERN
 	drink_type = DRINKTYPE_JUICE
-	name = "Compot"
+	name = "compot"
 	description = "Drink of Gronnic origin, dried fruit is made into nutritious sweet delicacy they partake regardless of status."
 	color = "#cca358"
 	nutriment_factor = 2
@@ -150,7 +150,7 @@
 
 /datum/reagent/consumable/tea/sbiten
 	cuisine = CUISINE_NORTHERN
-	name = "Sbiten" //not a typo
+	name = "sbiten" //not a typo
 	description = "Marvel of Gronnic cuisine, rivals even well aged liquors in how enjoyable it is. Honey is infused with spices and then diluted in hot water. Highly luxurious item in the North."
 	reagent_state = LIQUID
 	color = "#f0dba3"


### PR DESCRIPTION
## About The Pull Request

ya

## Testing Evidence

<img width="578" height="223" alt="ac6330d6006ffda600fd515bc65abd2c" src="https://github.com/user-attachments/assets/16d7c131-c4ec-4fef-b3d4-0a8e4a1cae39" />


## Why It's Good For The Game

cocnmnnnsitancny + sty l e

## Changelog

:cl:
fix: Most non-unique reagents now have their capitalization standardized (like Water -> water, Blackberry -> extract of blackberry, etc.) for a neater presentation. Note that uniquely-named reagents - chiefly imported liqours - remain capitalized, as they're proper names.
fix: Certain reagents have been given a more historically appropriate name. Most notably, the series of fruity reagents extractable from flavored zigarettes are now named "extract of [FRUITNAME]", and fire resistance juices are now named "elixir of fire resistance."
add: Minor descriptions to most remaining reagents that lacked one. I don't actually know if these're visible in-game, but it's good to have just in case.
/:cl: