### PR TITLE
Update on donator ckey

### DIFF
--- a/code/datums/loadout/loadout_donators.dm
+++ b/code/datums/loadout/loadout_donators.dm
@@ -1160,7 +1160,7 @@
 /datum/loadout_item/donator/lief_friend
 	name = "Donator Item - Aurum's Amulets"
 	path = /obj/item/clothing/neck/roguetown/psicross/liefdonator
-	ckeywhitelist = list("linxsysart", "Pessime959")
+	ckeywhitelist = list("linxsysart", "pessime959")
 
 
 /datum/loadout_item/donator/rezathedwarf


### PR DESCRIPTION

## About The Pull Request

adds a minus to the ckey since isn't showing up for the donator

## Testing Evidence

compiled

## Why It's Good For The Game

apparently donators can't have mayus on their loadout ckey and all has to be on minus 

## Changelog

:cl:
fix: fixed a donator ckey
:cl: