### PR TITLE
Reclaiming Real Estate: Toggle Action Buttons

### DIFF
--- a/code/_onclick/hud/action_button.dm
+++ b/code/_onclick/hud/action_button.dm
@@ -2,6 +2,30 @@
 #define AB_REARRANGE_TINT "#96ff96"
 #define AB_DROP_TINT "#40ff40"
 
+/atom/movable/screen/action_button_toggle
+	var/datum/hud/our_hud
+
+	icon = 'icons/mob/actions.dmi'
+	icon_state = "hide"
+	screen_loc = "WEST:4,SOUTH:3"
+	layer = ABOVE_HUD_LAYER
+	mouse_opacity = MOUSE_OPACITY_OPAQUE
+
+	New(loc, datum/hud/hud)
+		our_hud = hud
+		..()
+
+	Click(location, control, params)
+		if(!our_hud || !our_hud.mymob)
+			return
+
+		our_hud.mymob.toggle_action_buttons()
+		return TRUE
+
+	Destroy()
+		our_hud = null
+		return ..()
+
 /atom/movable/screen/movable/action_button
 	var/datum/action/linked_action
 	var/datum/hud/our_hud
@@ -156,7 +180,8 @@
 /mob/proc/update_action_buttons(reload_screen)
 	if(!hud_used || !client)
 		return
-
+	if(hud_used.action_button_toggle)
+		hud_used.action_button_toggle.icon_state = hud_used.action_buttons_hidden ? "show" : "hide"
 	if(hud_used.hud_shown != HUD_STYLE_STANDARD)
 		return
 
@@ -187,6 +212,18 @@
 			B.set_hotkey_label(button_number <= 9 ? button_number : null)
 			if(reload_screen)
 				client.screen += B
+
+/mob/proc/toggle_action_buttons()
+	if(!hud_used)
+		return
+	hud_used.action_buttons_hidden = !hud_used.action_buttons_hidden
+	if(hud_used.action_button_toggle)
+		hud_used.action_button_toggle.icon_state = hud_used.action_buttons_hidden ? "show" : "hide"
+	update_action_buttons()
+	if(hud_used.action_buttons_hidden)
+		to_chat(src, "Action buttons hidden.")
+	else
+		to_chat(src, "Action buttons shown.")
 
 /datum/hud/proc/toggle_rearrange_mode()
 	rearrange_mode = !rearrange_mode

--- a/code/_onclick/hud/action_button.dm
+++ b/code/_onclick/hud/action_button.dm
@@ -11,20 +11,20 @@
 	layer = ABOVE_HUD_LAYER
 	mouse_opacity = MOUSE_OPACITY_OPAQUE
 
-	New(loc, datum/hud/hud)
-		our_hud = hud
-		..()
+/atom/movable/screen/action_button_toggle/New(loc, datum/hud/hud)
+	our_hud = hud
+	..()
 
-	Click(location, control, params)
-		if(!our_hud || !our_hud.mymob)
-			return
+/atom/movable/screen/action_button_toggle/Click(location, control, params)
+	if(!our_hud || !our_hud.mymob)
+		return
 
-		our_hud.mymob.toggle_action_buttons()
-		return TRUE
+	our_hud.mymob.toggle_action_buttons()
+	return TRUE
 
-	Destroy()
-		our_hud = null
-		return ..()
+/atom/movable/screen/action_button_toggle/Destroy()
+	our_hud = null
+	return ..()
 
 /atom/movable/screen/movable/action_button
 	var/datum/action/linked_action

--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -39,6 +39,7 @@
 	var/atom/movable/screen/stress/stressies
 	var/atom/movable/screen/cmode_button
 	var/atom/movable/screen/rmbintent/rmb_intent
+	var/atom/movable/screen/action_button_toggle
 
 	var/list/static_inventory = list() //the screen objects which are static
 	var/list/toggleable_inventory = list() //the screen objects which can be hidden
@@ -75,6 +76,9 @@
 
 /datum/hud/New(mob/owner)
 	mymob = owner
+//	Below adds a button to the HUD that toggles the action buttons on and off.
+//	Inactive until I can find a fitting icon for it.
+//	action_button_toggle = new /atom/movable/screen/action_button_toggle(null, src)
 
 	if (!ui_style)
 		// will fall back to the default if any of these are null
@@ -115,6 +119,7 @@
 	QDEL_NULL(bloodpool)
 	QDEL_NULL(vis_holder)
 	QDEL_NULL(module_store_icon)
+	QDEL_NULL(action_button_toggle)
 	QDEL_LIST(static_inventory)
 
 	inv_slots.Cut()
@@ -178,6 +183,10 @@
 				screenmob.client.screen += hotkeybuttons
 			if(infodisplay.len)
 				screenmob.client.screen += infodisplay
+//	Adds a button to the HUD that toggles the action buttons on and off.
+//	Inactive until I can find a fitting icon for it.
+//			if(action_button_toggle)
+//				screenmob.client.screen += action_button_toggle
 
 
 			if(action_intent)

--- a/code/datums/keybinding/mob.dm
+++ b/code/datums/keybinding/mob.dm
@@ -2,6 +2,18 @@
 	category = CATEGORY_HUMAN
 	weight = WEIGHT_MOB
 
+/datum/keybinding/mob/toggle_action_buttons
+	hotkey_keys = list("Alt`")
+	name = "toggle_action_buttons"
+	full_name = "Toggle Action Buttons"
+	description = "Show or hide the action button bar."
+
+/datum/keybinding/mob/toggle_action_buttons/down(client/user)
+	var/mob/M = user.mob
+	if(!M)
+		return FALSE
+	M.toggle_action_buttons()
+	return TRUE
 
 /datum/keybinding/mob/face_north
 	hotkey_keys = list("CtrlW", "CtrlNorth")

--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -40,6 +40,13 @@
 		else
 			to_chat(src, "Screen shake disabled.")
 
+/client/verb/toggle_action_buttons()
+	set category = "Preferences.Options"
+	set name = "Toggle Action Buttons"
+	set desc = "Show or hide the action button bar."
+	if(mob)
+		mob.toggle_action_buttons()
+
 /client/verb/masked_examine()
 	set category = "Preferences.Options"
 	set name = "Toggle Masked Examine"


### PR DESCRIPTION
## About The Pull Request

There are some classes with a lot of abilities, miracles, and spells—a few with an **obscene** amount like the Bishop, Court Magos, and especially the Lich—taking up _sooo_ much real estate on their screens that their southbound vision gets handicapped by their own curse of knowledge.

Thinking about MMOs, I thought "maybe something to hide _just_ the action bar could work here", and thankfully, I saw that a lot of groundwork was already done for it, so I finished off the rest of it and added a button ~~(currently inactive until I can find a Roguetown-fitting show/hide icon pair for it)~~, keybind, and verb for toggling the action buttons.

_As requested, I unparked the toggle button and reused/modified an icon (`fortify` from `genericmiracles.dmi`) as its temporary icon pair until an artist doesn't mind making a more fitting replacement. It won't appear unless there are action buttons that can have their visibility toggled._

## Testing Evidence

https://github.com/user-attachments/assets/426b3eae-d45c-46f7-9cd1-b5c5c7653709

<p align="center"><img width="880" height="163" alt="dreamseeker_sQ1ZOV4Kj1" src="https://github.com/user-attachments/assets/944115ba-d5c1-446a-a417-593e6744e018" /></p>

<p align="center"><img width="461" height="353" alt="Hmk4uFnp6A" src="https://github.com/user-attachments/assets/88a6bac6-078e-4ea9-855b-175590e98d15" /></p>

## Why It's Good For The Game

As mentioned earlier in this body, some classes have an obscene amount of abilities/miracles/spells that makes seeing the bottom of their screen a minigame within a game.

The ability to hide and show them with ease would give all of us much needed control over our screen real estate.

## Changelog

:cl:Fi
add: Added a button (located left of the action buttons on the Castlevania pillar), keybind, and verb for toggling the action buttons' visibility.
/:cl: