### PR TITLE
[Rewrite-ish] Silver Anti-Heal

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -82,9 +82,9 @@
 #define TRAIT_SHATTER_KILL "Shatterable Form" //Lesser ver of critical weakness that only instantly kills on chest fractures/paralysis. ALSO prevents rolling voicepacks, used for skeletons.
 #define TRAIT_DNR "Bane of Existence"
 
-#define TRAIT_NOHEAL "Laden Soul" // Only affects magic healing, such as miracle or supernatural heals.
-#define TRAIT_NOREGEN "Laden Body" // Only affects natural healing, such as resting, campfires, potions, etc.
-#define TRAIT_HALFHEAL "Laden Lux" // -50% Magic Heal.
+#define TRAIT_NOHEAL "Soul Decay" // Only affects magic healing, such as miracle or supernatural heals.
+#define TRAIT_NOREGEN "Foul Humors" // Only affects natural healing, such as resting, campfires, potions, etc.
+#define TRAIT_HALFHEAL "Lux Decay" // -50% Magic Heal.
 
 #define TRAIT_EASYDISMEMBER	"Easy Dismemberment"
 #define TRAIT_HARDDISMEMBER	"Hard Dismemberment"
@@ -737,9 +737,9 @@ GLOBAL_LIST_INIT(roguetraits, list(
 	TRAIT_INK_AFFINITY = span_info("I can thread sacred abyssorite paint splotches safely, and benefit from them."),
 	TRAIT_REGROW_LIMBS = span_info("I can regrow my limbs in my sleep, but doing so will make me hungry."),
 	TRAIT_MUSES_GRACE = span_info("I feel a sudden and powerful urge to break out into song."),
-	TRAIT_NOHEAL = span_artery("I cannot be healed by supernatural means. Healing magic has no effect."),
-	TRAIT_NOREGEN = span_artery("I cannot be healed by natural means. Rest and potions have no effect."),
-	TRAIT_HALFHEAL = span_artery("I have some spiritual oddity to my Lux. Healing magic effectiveness is halved."),
+	TRAIT_NOHEAL = span_artery("I cannot be healed by supernatural means. Healing magic has no effect!"),
+	TRAIT_NOREGEN = span_artery("I cannot be healed by natural means. Resting and potions have no effect on me!"),
+	TRAIT_HALFHEAL = span_artery("I have some spiritual oddity to my Lux. Healing magic effectiveness is halved!"),
 	TRAIT_SUNLIGHT_SENSITIVE = span_danger("Put on those shades and wave to yesterday, 'cause the sunlight hurts my eyes!"),
 ))
 

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -688,7 +688,7 @@
 				victim.adjust_fire_stacks(thrown ? 1 : 3, /datum/status_effect/fire_handler/fire_stacks/sunder/blessed)
 			else
 				if(!victim.has_status_effect(/datum/status_effect/fire_handler/fire_stacks/sunder/blessed))
-					to_chat(victim, span_silver("The divinity of blessed silver rebukes my presence!!"))
+					to_chat(victim, span_silver("The divinity of blessed silver rebukes my very soul!!"))
 				victim.adjust_fire_stacks(thrown ? 1 : 3, /datum/status_effect/fire_handler/fire_stacks/sunder)
 			victim.ignite_mob()
 

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -684,11 +684,11 @@
 			var/datum/component/silverbless/blesscomp = GetComponent(/datum/component/silverbless)
 			if(blesscomp?.is_blessed)
 				if(!victim.has_status_effect(/datum/status_effect/fire_handler/fire_stacks/sunder))
-					to_chat(victim, span_silver("Silver rebukes my presence! My vitae smolders, and my powers wane!"))
+					to_chat(victim, span_silver("The purity of silver rebukes my presence!"))
 				victim.adjust_fire_stacks(thrown ? 1 : 3, /datum/status_effect/fire_handler/fire_stacks/sunder/blessed)
 			else
 				if(!victim.has_status_effect(/datum/status_effect/fire_handler/fire_stacks/sunder/blessed))
-					to_chat(victim, span_silver("Blessed silver rebukes my presence! These fires are lashing at my very soul!"))
+					to_chat(victim, span_silver("The divinity of blessed silver rebukes my presence!!"))
 				victim.adjust_fire_stacks(thrown ? 1 : 3, /datum/status_effect/fire_handler/fire_stacks/sunder)
 			victim.ignite_mob()
 

--- a/code/datums/magic_items/mundane_items/silver.dm
+++ b/code/datums/magic_items/mundane_items/silver.dm
@@ -12,7 +12,7 @@
 		var/mob/living/H = target
 		if(HAS_TRAIT(H, TRAIT_SILVER_WEAK) && !H.has_status_effect(STATUS_EFFECT_ANTIMAGIC))
 			H.visible_message(span_silver("The silver sunders [target]!"))
-			to_chat(H, span_silver("Silver rebukes my presence! My vitae smolders, and my powers wane!"))
+			to_chat(H, span_silver("The purity of silver rebukes my presence!"))
 			H.adjust_fire_stacks(2, /datum/status_effect/fire_handler/fire_stacks/sunder)
 
 /datum/magic_item/mundane/silver/on_equip(obj/item/i, mob/living/user)

--- a/code/datums/status_effects/rogue/debuff.dm
+++ b/code/datums/status_effects/rogue/debuff.dm
@@ -146,6 +146,74 @@
 
 /////////
 
+/datum/status_effect/debuff/silver_lingering_damage
+	id = "silver_lingering_damage"
+	alert_type = /atom/movable/screen/alert/status_effect/debuff/silver_lingering_damage
+	effectedstats = list(STATKEY_SPD = -2, STATKEY_WIL = -2, STATKEY_LCK = -2)
+	duration = 10 SECONDS
+	status_type = STATUS_EFFECT_REFRESH
+	tick_interval = 1 SECONDS
+	var/list/nopain_sources
+	var/list/nopainstun_sources
+
+/datum/status_effect/debuff/silver_lingering_damage/on_apply()
+	. = ..()
+
+	to_chat(owner, span_warning("SILVER DEBUG: Lingering damage applied."))
+
+	ADD_TRAIT(owner, TRAIT_NOHEAL, "silver_lingering_damage")
+	to_chat(owner, span_warning("SILVER DEBUG: NOHEAL applied."))
+
+	if(HAS_TRAIT(owner, TRAIT_NOPAIN))
+		nopain_sources = list()
+		for(var/source in owner.status_traits[TRAIT_NOPAIN])
+			nopain_sources += source
+		to_chat(owner, span_warning("SILVER DEBUG: NOPAIN sources found: [jointext(nopain_sources, ", ")]"))
+		REMOVE_TRAIT(owner, TRAIT_NOPAIN, nopain_sources)
+		to_chat(owner, span_warning("SILVER DEBUG: NOPAIN removed."))
+
+	if(HAS_TRAIT(owner, TRAIT_NOPAINSTUN))
+		nopainstun_sources = list()
+		for(var/source in owner.status_traits[TRAIT_NOPAINSTUN])
+			nopainstun_sources += source
+		to_chat(owner, span_warning("SILVER DEBUG: NOPAINSTUN sources found: [jointext(nopainstun_sources, ", ")]"))
+		REMOVE_TRAIT(owner, TRAIT_NOPAINSTUN, nopainstun_sources)
+		to_chat(owner, span_warning("SILVER DEBUG: NOPAINSTUN removed."))
+
+	return TRUE
+
+/datum/status_effect/debuff/silver_lingering_damage/tick()
+	. = ..()
+	to_chat(owner, span_warning("SILVER DEBUG: Lingering damage tick."))
+	owner.adjustFireLoss(7)
+
+/datum/status_effect/debuff/silver_lingering_damage/on_remove()
+	to_chat(owner, span_warning("SILVER DEBUG: Lingering damage removed."))
+
+	REMOVE_TRAIT(owner, TRAIT_NOHEAL, "silver_lingering_damage")
+	to_chat(owner, span_warning("SILVER DEBUG: NOHEAL removed."))
+
+	if(nopain_sources)
+		to_chat(owner, span_warning("SILVER DEBUG: Restoring NOPAIN sources: [jointext(nopain_sources, ", ")]"))
+		for(var/source in nopain_sources)
+			ADD_TRAIT(owner, TRAIT_NOPAIN, source)
+
+	if(nopainstun_sources)
+		to_chat(owner, span_warning("SILVER DEBUG: Restoring NOPAINSTUN sources: [jointext(nopainstun_sources, ", ")]"))
+		for(var/source in nopainstun_sources)
+			ADD_TRAIT(owner, TRAIT_NOPAINSTUN, source)
+
+	to_chat(owner, span_warning("SILVER DEBUG: Trait restoration complete."))
+
+	return ..()
+
+/atom/movable/screen/alert/status_effect/debuff/silver_lingering_damage
+	name = "Aftershock: Silver"
+	desc = "<font color='#c4ecff'><b>MY BODY IS BEING UNDONE BY THIS PURITY!</b></font>"
+	icon_state = "vblood3"
+
+/////////
+
 /datum/status_effect/debuff/uncookedfood
 	id = "uncookedfood"
 	effectedstats = null

--- a/code/datums/status_effects/rogue/debuff.dm
+++ b/code/datums/status_effects/rogue/debuff.dm
@@ -158,53 +158,33 @@
 
 /datum/status_effect/debuff/silver_lingering_damage/on_apply()
 	. = ..()
-
-	to_chat(owner, span_warning("SILVER DEBUG: Lingering damage applied."))
-
 	ADD_TRAIT(owner, TRAIT_NOHEAL, "silver_lingering_damage")
-	to_chat(owner, span_warning("SILVER DEBUG: NOHEAL applied."))
-
+	ADD_TRAIT(owner, TRAIT_NOREGEN, "silver_lingering_damage")
 	if(HAS_TRAIT(owner, TRAIT_NOPAIN))
 		nopain_sources = list()
 		for(var/source in owner.status_traits[TRAIT_NOPAIN])
 			nopain_sources += source
-		to_chat(owner, span_warning("SILVER DEBUG: NOPAIN sources found: [jointext(nopain_sources, ", ")]"))
 		REMOVE_TRAIT(owner, TRAIT_NOPAIN, nopain_sources)
-		to_chat(owner, span_warning("SILVER DEBUG: NOPAIN removed."))
-
 	if(HAS_TRAIT(owner, TRAIT_NOPAINSTUN))
 		nopainstun_sources = list()
 		for(var/source in owner.status_traits[TRAIT_NOPAINSTUN])
 			nopainstun_sources += source
-		to_chat(owner, span_warning("SILVER DEBUG: NOPAINSTUN sources found: [jointext(nopainstun_sources, ", ")]"))
 		REMOVE_TRAIT(owner, TRAIT_NOPAINSTUN, nopainstun_sources)
-		to_chat(owner, span_warning("SILVER DEBUG: NOPAINSTUN removed."))
-
 	return TRUE
 
 /datum/status_effect/debuff/silver_lingering_damage/tick()
 	. = ..()
-	to_chat(owner, span_warning("SILVER DEBUG: Lingering damage tick."))
 	owner.adjustFireLoss(7)
 
 /datum/status_effect/debuff/silver_lingering_damage/on_remove()
-	to_chat(owner, span_warning("SILVER DEBUG: Lingering damage removed."))
-
 	REMOVE_TRAIT(owner, TRAIT_NOHEAL, "silver_lingering_damage")
-	to_chat(owner, span_warning("SILVER DEBUG: NOHEAL removed."))
-
+	REMOVE_TRAIT(owner, TRAIT_NOREGEN, "silver_lingering_damage")
 	if(nopain_sources)
-		to_chat(owner, span_warning("SILVER DEBUG: Restoring NOPAIN sources: [jointext(nopain_sources, ", ")]"))
 		for(var/source in nopain_sources)
 			ADD_TRAIT(owner, TRAIT_NOPAIN, source)
-
 	if(nopainstun_sources)
-		to_chat(owner, span_warning("SILVER DEBUG: Restoring NOPAINSTUN sources: [jointext(nopainstun_sources, ", ")]"))
 		for(var/source in nopainstun_sources)
 			ADD_TRAIT(owner, TRAIT_NOPAINSTUN, source)
-
-	to_chat(owner, span_warning("SILVER DEBUG: Trait restoration complete."))
-
 	return ..()
 
 /atom/movable/screen/alert/status_effect/debuff/silver_lingering_damage

--- a/code/game/objects/items/rogueweapons/ranged/_ammo.dm
+++ b/code/game/objects/items/rogueweapons/ranged/_ammo.dm
@@ -58,6 +58,6 @@
 
 	if(is_silver_proj && HAS_TRAIT(victim, TRAIT_SILVER_WEAK))
 		SEND_SIGNAL(victim, COMSIG_FORCE_UNDISGUISE)
-		to_chat(victim, span_silver("Silver rebukes my presence! My vitae smolders, and my powers wane!"))
+		to_chat(victim, span_silver("The purity of silver rebukes my presence!"))
 		victim.adjust_fire_stacks(1, /datum/status_effect/fire_handler/fire_stacks/sunder) // Ammunition can't be blessed.
 		victim.ignite_mob()

--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -272,17 +272,16 @@ All foods are distributed among various categories. Use common sense.
 	// check to see if what we're eating is appropriate fare for our "social class" (aka nobles shouldn't be eating sticks of butter you troglodytes)
 	if (ishuman(eater))
 		var/mob/living/carbon/human/human_eater = eater
-		if(!HAS_TRAIT(human_eater, TRAIT_NOREGEN) || !(human_eater.has_status_effect(/datum/status_effect/fire_handler/fire_stacks/sunder) || human_eater.has_status_effect(/datum/status_effect/fire_handler/fire_stacks/sunder/blessed)))
-			if(HAS_TRAIT(human_eater, TRAIT_BLACKBLOOD))
-				var/datum/status_effect/buff/foodhealing/H = eater.has_status_effect(/datum/status_effect/buff/foodhealing)
-				if(H)
-					if(faretype > H.fare_power)
-						eater.remove_status_effect(/datum/status_effect/buff/foodhealing)
-						eater.apply_status_effect(/datum/status_effect/buff/foodhealing, faretype, faretype)
-					else if(faretype == H.fare_power)
-						H.duration += 2 SECONDS
-				else
+		if(HAS_TRAIT(human_eater, TRAIT_BLACKBLOOD) && !(HAS_TRAIT(human_eater, TRAIT_NOHEAL) || HAS_TRAIT(human_eater, TRAIT_NOHEAL)))
+			var/datum/status_effect/buff/foodhealing/H = eater.has_status_effect(/datum/status_effect/buff/foodhealing)
+			if(H)
+				if(faretype > H.fare_power)
+					eater.remove_status_effect(/datum/status_effect/buff/foodhealing)
 					eater.apply_status_effect(/datum/status_effect/buff/foodhealing, faretype, faretype)
+				else if(faretype == H.fare_power)
+					H.duration += 2 SECONDS
+			else
+				eater.apply_status_effect(/datum/status_effect/buff/foodhealing, faretype, faretype)
 
 		if(faretype >= FAVORITE_FOOD_MINFARE && ((cuisine & human_eater.favorite_cuisine) || (dish_type & human_eater.favorite_dish)))
 			if(human_eater.add_stress(/datum/stressevent/favourite_food))

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1879,6 +1879,9 @@
 		stacks = max(-fire_stacks, stacks)
 	apply_status_effect(fire_type, stacks)
 
+	if(ispath(fire_type, /datum/status_effect/fire_handler/fire_stacks/sunder))
+		apply_status_effect(/datum/status_effect/debuff/silver_lingering_damage)
+
 /**
  * Set the fire stacks on a mob
  *

--- a/code/modules/surgery/bodyparts/bodypart_wounds.dm
+++ b/code/modules/surgery/bodyparts/bodypart_wounds.dm
@@ -50,7 +50,7 @@
 /obj/item/bodypart/proc/heal_wounds(heal_amount)
 	if(!length(wounds))
 		return FALSE
-	if(HAS_TRAIT(owner, TRAIT_SILVER_WEAK) && owner.has_status_effect(/datum/status_effect/fire_handler/fire_stacks/sunder) || owner.has_status_effect(/datum/status_effect/fire_handler/fire_stacks/sunder/blessed))
+	if(HAS_TRAIT(owner, TRAIT_NOHEAL) || HAS_TRAIT(owner, TRAIT_NOREGEN))
 		return
 	var/healed_any = FALSE
 	for(var/datum/wound/wound as anything in wounds)


### PR DESCRIPTION
## About The Pull Request

- Made it so being silver-sundered will inflict a debuff that properly removes your pain immunity and blocks your heal/regen for the duration, while dealing minor fire aftershock damage.

- **Aftershock: Silver** >> Reduces SPD, LUC and WIL by 2. Deals 7 fire damage every second, for 10 seconds. Status is refreshed every time we are to receive silver sunder stacks. You cannot heal by any means while this lasts.

- Refluffed Silver sunder text to be more 'global' now that this isn't a vampire-only thing anymore. 

## Testing Evidence

It works! Slapped a few to_chat debugs and it did work as in 10 did.

## Why It's Good For The Game

The effectiveness of silver has been ebb-and-flowing considerably thanks to the previous adjustments to fire stacks, leading to people complaining about how worthless it is since all it takes to stop it is press X once. This now inflicts a lingering effect that lasts 10 seconds.

If this gets merged, please revisit sunder crits and adjust it in a way that it won't be leading to insta-kills. The Aftershock debuff is considerably strong by itself now.

## Changelog
balance: Added Aftershock: Silver, more details on the PR, but basically, igniting someone who is Silver Weak with silver will give them a 10 second debuff that prevents them from healing, and removes any pain immunity they would have.
/:cl: