### PR TITLE
Removes Black Oak's unique armor define.

### DIFF
--- a/code/__DEFINES/armor_defines.dm
+++ b/code/__DEFINES/armor_defines.dm
@@ -204,7 +204,6 @@
 #define ARMOR_GNOLL_WEAK list("blunt" = DR_ULTRA, "slash" = DBLOCK_HEAVY, "stab" = DBLOCK_HEAVY, "piercing" = DBLOCK_MEDIUM, "fire" = DR_MEDIUM)
 #define ARMOR_GNOLL_STANDARD list("blunt" = DR_SUPER, "slash" = DBLOCK_HEAVY, "stab" = DBLOCK_HEAVY, "piercing" = DBLOCK_HEAVY, "fire" = DR_MEDIUM)
 #define ARMOR_GNOLL_STRONG list("blunt" = DR_MEDIUM, "slash" = DBLOCK_BSTEEL, "stab" = DBLOCK_BSTEEL, "piercing" = DBLOCK_HEAVY, "fire" = DR_MEDIUM)
-#define ARMOR_BLACKOAK list("blunt" = DR_ULTRA, "slash" = DBLOCK_LIGHT, "stab" = DBLOCK_BSTEEL, "piercing" = DBLOCK_MEDIUM, "fire" = DR_NONE) // Wood: great vs blunt/stab, bad vs slash
 
 // Indestructible / Meme
 #define ARMOR_INDESTRUCTIBLE list("blunt" = DR_ULTRA, "slash" = DBLOCK_BSTEEL, "stab" = DBLOCK_BSTEEL, "piercing" = DBLOCK_BSTEEL, "fire" = DR_ULTRA) // Magical / indestructible items

--- a/code/modules/clothing/rogueclothes/armor/unique.dm
+++ b/code/modules/clothing/rogueclothes/armor/unique.dm
@@ -111,7 +111,7 @@
 	name = "woad elven plate"
 	desc = "An assembly of thickly woven trunk, bound together by ancient song and tool of the oldest elven druids. It still creaks and weeps with forlorn reminiscence of a bygone era. It looks like only Elves can fit in it."
 	allowed_race = list(/datum/species/elf/wood, /datum/species/human/halfelf, /datum/species/elf/dark)
-	armor = ARMOR_BLACKOAK
+	armor = ARMOR_BRIGANDINE
 	armor_class = ARMOR_CLASS_MEDIUM
 	body_parts_covered = COVERAGE_ALL_BUT_HANDFEET
 	icon = 'icons/roguetown/clothing/special/race_armor.dmi'

--- a/code/modules/clothing/rogueclothes/feet.dm
+++ b/code/modules/clothing/rogueclothes/feet.dm
@@ -369,7 +369,7 @@
 	name = "woad elven boots"
 	desc = "'Tread lightly, for the ground remembers every footfall.'"
 	allowed_race = list(/datum/species/elf/wood, /datum/species/human/halfelf, /datum/species/elf/dark)
-	armor = ARMOR_BRIGANDINE //Resistant to blunt and stab, but very weak to slash.
+	armor = ARMOR_BRIGANDINE
 	max_integrity = ARMOR_INT_SIDE_IRON
 	resistance_flags = FIRE_PROOF
 	blocksound = SOFTHIT

--- a/code/modules/clothing/rogueclothes/feet.dm
+++ b/code/modules/clothing/rogueclothes/feet.dm
@@ -369,7 +369,7 @@
 	name = "woad elven boots"
 	desc = "'Tread lightly, for the ground remembers every footfall.'"
 	allowed_race = list(/datum/species/elf/wood, /datum/species/human/halfelf, /datum/species/elf/dark)
-	armor = ARMOR_BLACKOAK //Resistant to blunt and stab, but very weak to slash.
+	armor = ARMOR_BRIGANDINE //Resistant to blunt and stab, but very weak to slash.
 	max_integrity = ARMOR_INT_SIDE_IRON
 	resistance_flags = FIRE_PROOF
 	blocksound = SOFTHIT

--- a/code/modules/clothing/rogueclothes/gloves/unique.dm
+++ b/code/modules/clothing/rogueclothes/gloves/unique.dm
@@ -15,7 +15,7 @@
 	mob_overlay_icon = 'icons/roguetown/clothing/special/onmob/race_armor.dmi'
 	icon_state = "welfhand"
 	item_state = "welfhand"
-	armor = ARMOR_BRIGANDINE //Resistant to blunt and stab, super weak to slash.
+	armor = ARMOR_BRIGANDINE
 	resistance_flags = FIRE_PROOF
 	blocksound = SOFTHIT
 	max_integrity = ARMOR_INT_SIDE_IRON

--- a/code/modules/clothing/rogueclothes/gloves/unique.dm
+++ b/code/modules/clothing/rogueclothes/gloves/unique.dm
@@ -15,7 +15,7 @@
 	mob_overlay_icon = 'icons/roguetown/clothing/special/onmob/race_armor.dmi'
 	icon_state = "welfhand"
 	item_state = "welfhand"
-	armor = ARMOR_BLACKOAK //Resistant to blunt and stab, super weak to slash.
+	armor = ARMOR_BRIGANDINE //Resistant to blunt and stab, super weak to slash.
 	resistance_flags = FIRE_PROOF
 	blocksound = SOFTHIT
 	max_integrity = ARMOR_INT_SIDE_IRON

--- a/code/modules/clothing/rogueclothes/headwear/helmet/heavy_helmet.dm
+++ b/code/modules/clothing/rogueclothes/headwear/helmet/heavy_helmet.dm
@@ -1253,7 +1253,7 @@
 	merely worn - it watches alongside its bearer."
 	allowed_race = list(/datum/species/elf/wood, /datum/species/human/halfelf, /datum/species/elf/dark)
 	body_parts_covered = FULL_HEAD|NECK
-	armor = ARMOR_BRIGANDINE //Resistant to blunt & stab, but very weak to slash.
+	armor = ARMOR_BRIGANDINE
 	icon = 'icons/roguetown/clothing/special/race_armor.dmi'
 	mob_overlay_icon = 'icons/roguetown/clothing/special/onmob/race_armor.dmi'
 	icon_state = "welfhead"

--- a/code/modules/clothing/rogueclothes/headwear/helmet/heavy_helmet.dm
+++ b/code/modules/clothing/rogueclothes/headwear/helmet/heavy_helmet.dm
@@ -1253,7 +1253,7 @@
 	merely worn - it watches alongside its bearer."
 	allowed_race = list(/datum/species/elf/wood, /datum/species/human/halfelf, /datum/species/elf/dark)
 	body_parts_covered = FULL_HEAD|NECK
-	armor = ARMOR_BLACKOAK //Resistant to blunt & stab, but very weak to slash.
+	armor = ARMOR_BRIGANDINE //Resistant to blunt & stab, but very weak to slash.
 	icon = 'icons/roguetown/clothing/special/race_armor.dmi'
 	mob_overlay_icon = 'icons/roguetown/clothing/special/onmob/race_armor.dmi'
 	icon_state = "welfhead"


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->
Black Oak's unique armor define was removed and replaced with Brigandine's define.

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->
<img width="585" height="378" alt="dreamseeker_HzGXPgTFdK" src="https://github.com/user-attachments/assets/546ef976-387e-424b-a33c-672da968ecd7" />

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

The armor define existed in a world where PIERCING and STAB was scary, but those times have changed. The current values means that Black Oak's unique items gets them slaughtered by everything that has AP1 slash which is everything. They either accept it or ditch it for something that will protect them. Swapping it to Brigandine's define makes them more practical without being oppressive. 

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
del: Deleted Black Oak's unique armor define.
balance: Swapped Black Oak's armor define to Brigandine.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
